### PR TITLE
Added links to exercises in Chapter 1

### DIFF
--- a/chapters/01-computer-basics/index.adoc
+++ b/chapters/01-computer-basics/index.adoc
@@ -710,6 +710,11 @@ determine its contribution, and so on. In this case, the leftmost 1
 contributes 1 × 2^4^ = 16 to the value.
 ====
 
+****
+<<exercise1.4, Exercise 4>> +
+<<exercise1.5, Exercise 5>>
+****
+
 Another useful number system is _base 16_, also known as _hexadecimal_.
 Hexadecimal is surprising because it requires more than the familiar 10
 digits. Numerals in this system are written with 16 hexadecimal digits
@@ -816,6 +821,10 @@ every place we skipped, we get 23 = 10111~2~. While this is a
 straightforward procedure for decimal to binary conversion, it can be
 cumbersome for larger numbers.
 
+****
+<<exercise1.6, Exercise 6>>
+****
+
 An alternate way to convert a decimal numeral to an equivalent binary
 numeral is to divide the given number by 2 until the quotient is 0
 (keeping only the integer part of the quotient). At each step, record
@@ -859,6 +868,10 @@ decimal number as a sum of powers of 2, one writes it as a sum of powers
 of 16. Similarly, when using the division method, instead of dividing by
 2, one divides by 16. Octal conversion is similar.
 
+****
+<<exercise1.9, Exercise 9>>
+****
+
 We use hexadecimal because it is straightforward to convert from it to
 binary or back. The following table lists binary equivalents for the 16
 hexadecimal digits.
@@ -887,6 +900,11 @@ With the help of the table above, let's convert
 Note that we have grouped the binary digits into clusters of
 4 bits each. Of course, the leftmost zeroes in the binary equivalent are
 useless as they do not contribute to the value of the number.
+
+****
+<<exercise1.10, Exercise 10>> +
+<<exercise1.11, Exercise 11>>
+****
 
 ===== Integer representation in a computer
 
@@ -975,6 +993,10 @@ Again, we'll use 60 and 6 and their binary equivalents given above.
 |=====================
 ====
 
+****
+<<exercise1.17, Exercise 17>>
+****
+
 ===== Negative integers in a computer
 
 Negative integers are also represented in computer memory as binary
@@ -999,6 +1021,11 @@ Thus, the 8-bit, two's complement binary equivalent of -12 is
 `1111 0100`. Note that the leftmost bit is a 1, indicating that this is
 a negative number.
 
+****
+<<exercise1.7, Exercise 7>> +
+<<exercise1.8, Exercise 8>>
+****
+
 .Decimal to two's complement
 ====
 Let's convert -29 to its binary equivalent assuming that the number is
@@ -1010,6 +1037,10 @@ flipping 0s to 1s and 1s to 0s. This gives us `1110 0010`. Finally, we
 add 1 to the one's complement representation to get `1110 0010` + `1` =
 `1110 0011`, which is the desired binary equivalent of -29.
 ====
+
+****
+<<exercise1.14, Exercise 14>>
+****
 
 .Two's complement to decimal
 ====
@@ -1023,6 +1054,10 @@ one's complement form, yielding `0111 0100`.
 Now we convert this binary representation to its decimal equivalent,
 yielding 116. Thus, the decimal equivalent of `1000 1100` is -116.
 ====
+
+****
+<<exercise1.15, Exercise 15>>
+****
 
 Why do we use two's complement? First of all, we needed a system that
 could represent both positive and negative numbers. We could have simply
@@ -1068,6 +1103,10 @@ complement representations are `1000 0010` and `1111 1110`.
 The result is -128, which is the smallest negative integer that can be
 represented in 8-bit two's complement.
 ====
+
+****
+<<exercise1.16, Exercise 16>>
+****
 
 ===== Overflow and underflow
 
@@ -1327,6 +1366,7 @@ of 0. In such cases we can only find an approximate representation of
 the given fraction as demonstrated in the next example.
 
 .Non-terminating fraction
+[[Non-terminating_fraction]]
 ====
 Let's convert 0.3 to binary assuming that we have only five bits in
 which to represent the fraction. The following table shows the five
@@ -1359,6 +1399,11 @@ an error of 0.3 - 0.28125 = 0.01875. Most computers use many
 more bits to represent fractions and obtain much better accuracy in
 their representation.
 ====
+
+****
+<<exercise1.18, Exercise 18>> +
+<<exercise1.19, Exercise 19>>
+****
 
 Now that we understand how integers as well as fractions can be
 converted from one number base to another, we can convert any rational
@@ -1439,6 +1484,10 @@ representation of 10.5 is shown in <<numberRepresentationFigure>> (c).
 Note in the figure how the sign bit, the exponent, and the mantissa are
 packed into 32 bits.
 ====
+
+****
+<<exercise1.20, Exercise 20>>
+****
 
 [[numberRepresentationFigure]]
 .Layouts for floating point representation (a) in single precision, (b) in double precision, and (c) of 10.5~10~ in single precision.
@@ -1763,6 +1812,10 @@ are not general purpose or completely independent. Instead, they're
 specialized to do certain kinds of matrix transformations and floating
 point computations.
 
+****
+<<exercise1.23, Exercise 23>>
+****
+
 ===== The Bad
 
 Although chip-makers have spent a lot of money marketing multicore
@@ -1861,19 +1914,21 @@ The next chapter extends the idea of data representation into the
 specific types of data that Java uses and introduces representation
 systems for individual characters and text.
 
-=== Problems
+=== Excercises
+*Conceptual Problems*
 
-. Name a few programming languages other than Java.
+1. Name a few programming languages other than Java.
 
-. What is the difference between machine code and bytecode?
+2. What is the difference between machine code and bytecode?
 
-. What are some advantages of JIT compilation over traditional,
+3. What are some advantages of JIT compilation over traditional,
 ahead-of-time compilation?
 
-. Without converting to decimal, how can one find out whether a given
+4. [[exercise1.4]] Without converting to decimal, how can one find out whether a given
 binary number is odd or even?
 
-. Convert the following positive binary numbers into decimal.
+
+5. [[exercise1.5]] Convert the following positive binary numbers into decimal.
 [loweralpha]
 .. 100~2~
 .. 111~2~
@@ -1881,7 +1936,8 @@ binary number is odd or even?
 .. 111101~2~
 .. 10101~2~
 
-. Convert the following positive decimal numbers into binary.
+
+6. [[exercise1.6]] Convert the following positive decimal numbers into binary.
 [loweralpha]
 ..  1
 ..  15
@@ -1889,13 +1945,13 @@ binary number is odd or even?
 ..  1,025
 ..  567,899
 
-. What is the process for converting the representation of a binary
+7. [[exercise1.7]] What is the process for converting the representation of a binary
 integer given in one's complement into two's complement?
 
-. Perform the conversion from one's complement to two's complement on the
+8. [[exercise1.8]] Perform the conversion from one's complement to two's complement on the
 representation `1011 0111`, which uses 8 bits for storage.
 
-. Convert the following decimal numbers to their hexadecimal and octal
+9. [[exercise1.9]] Convert the following decimal numbers to their hexadecimal and octal
 equivalents.
 [loweralpha]
 ..  29
@@ -1904,40 +1960,38 @@ equivalents.
 ..  382
 ..  4,096
 
-. Create a table similar to the one on page  that lists the binary
-equivalents of octal digits. Hint: Each octal digit can be represented
-as a sequence of three binary digits.
+10. [[exercise1.10]] Create a table that lists the binary equivalents of octal digits, similar to the one in the subsection on <<Other conversions>> . Hint: Each octal digit can be represented as a sequence of three binary digits.
 
-. Use this table to convert the following octal numbers to binary.
+11. [[exercise1.11]] Use this table to convert the following octal numbers to binary.
 [loweralpha]
 ..  337~8~
 ..  24~8~
 ..  777~8~
 
-. The ternary number system has a base of 3 and uses symbols 0, 1, and 2
+12. The ternary number system has a base of 3 and uses symbols 0, 1, and 2
 to construct numbers.
 
-. Convert the following decimal numbers to their ternary equivalents.
+13. Convert the following decimal numbers to their ternary equivalents.
 [loweralpha]
 ..  23
 ..  333
 ..  729
 
-. Convert the following decimal numbers to 8-bit, two's complement binary
+14. [[exercise1.14]] Convert the following decimal numbers to 8-bit, two's complement binary
 representations.
 [loweralpha]
 ..  -15
 ..  -101
 ..  -120
 
-. Given the following 8-bit binary representations in two's complement,
+15. [[exercise1.15]] Given the following 8-bit binary representations in two's complement,
 find their decimal equivalents.
 [loweralpha]
 ..  `1100 0000`
 ..  `1111 1111`
 ..  `1000 0001`
 
-. Perform the following arithmetic operation on the following 8-bit, two's
+16. [[exercise1.16]] Perform the following arithmetic operation on the following 8-bit, two's
 complement binary representations of integers. Check your answers by
 performing arithmetic on equivalent decimal numbers.
 [loweralpha]
@@ -1947,7 +2001,7 @@ performing arithmetic on equivalent decimal numbers.
 ..  `0000 1111` - `0001 1110` =
 ..  `1000 0001` - `1111 1100` =
 
-. Extrapolate the rules for decimal and binary addition to rules for the
+17. [[exercise1.17]] Extrapolate the rules for decimal and binary addition to rules for the
 hexadecimal system. Then, use these rules to perform the following
 additions in hexadecimal. Check your answers by converting the values
 and their sums to decimal.
@@ -1955,14 +2009,14 @@ and their sums to decimal.
 ..  A2F~16~ + BB~16~ =
 ..  32C~16~ + D11F~16~ =
 
-. Expand Example  assuming that you have ten bits to represent the
+18. [[exercise1.18]] Expand <<Non-terminating_fraction>> assuming that you have ten bits to represent the
 fraction. Convert the representation back to base 10. How far off is
 this value from 0.3?
 
-. Will the process in Example  ever terminate assuming that we can use as
+19. [[exercise1.19]] Will the process in <<Non-terminating fraction>> ever terminate assuming that we can use as
 many bits as needed to represent 0.3 in binary?
 
-. Derive the binary representation of the following decimal numbers
+20. [[exercise1.20]] Derive the binary representation of the following decimal numbers
 assuming 32-bit (single) precision representation using the IEEE
 floating point format.
 [loweralpha]
@@ -1970,14 +2024,14 @@ floating point format.
 ..  7.7
 ..  -10.3
 
-. The IEEE 754 standard also defines a 16-bit (half) precision format. In
+21. The IEEE 754 standard also defines a 16-bit (half) precision format. In
 this format, there is one sign bit, five bits for the exponent, and ten
 bits for the mantissa. This format is the same as single and double
 precision in that it assumes that a bit with a value of 1 precedes the
 ten bits in the mantissa. It also uses a bias of 15 for the exponent.
 What is the largest decimal number that can be stored in this format?
 
-. Let stem:[a], stem:[b], and stem:[c] denote three real numbers.
+22. Let stem:[a], stem:[b], and stem:[c] denote three real numbers.
 With real numbers, each of the equations below is true. Now suppose that
 all arithmetic operations are performed using floating point
 representations of these numbers. Indicate which of the following
@@ -1990,7 +2044,7 @@ expressions are still always true and which are sometimes false.
 ..  stem:[(a\times b)\times c=a\times (b\times c)]
 ..  stem:[a\times (b+c)=(a\times b)+(a\times c)]
 
-. What is a multicore microprocessor? Why do you think a multicore chip
+23. [[exercise1.23]] What is a multicore microprocessor? Why do you think a multicore chip
 might be better than a single core chip? Search on the Internet to find
 the names of a few common multicore chips. Which chip does your computer
 use?

--- a/chapters/02-intro/index.adoc
+++ b/chapters/02-intro/index.adoc
@@ -1654,6 +1654,7 @@ solutions to problems and clarified the subtle difference between
 parallelism and concurrency.
 
 === Exercises
+*Conceptual Problems*
 
 1.  <<exercise:problemSolvingExericise>> When solving a problem using a
 computer, what problem is solved by the programmer and what problem is

--- a/chapters/03-strings-primitive-types/index.adoc
+++ b/chapters/03-strings-primitive-types/index.adoc
@@ -2618,6 +2618,7 @@ the evaluation of mathematical computations on multicore processors, but
 only if the computations are long, complex, and not too interdependent.
 
 === Exercises
+*Conceptual Problems*
 
 1.  <<exercise:mathematicsAndIntExercise>> What is the difference
 between the set of integers from mathematics and the sets defined by

--- a/chapters/04-selection/index.adoc
+++ b/chapters/04-selection/index.adoc
@@ -1365,6 +1365,7 @@ in mind the assumptions your code makes and the way different parts of
 your program interact with each other.
 
 === Exercises
+*Conceptual Problems*
 
 1.  Given that latexmath:[x], latexmath:[y], and latexmath:[z] are
 propositions in Boolean logic, make a truth table for the expression

--- a/chapters/05-repetition/index.adoc
+++ b/chapters/05-repetition/index.adoc
@@ -1271,6 +1271,7 @@ execution at a time without the need to run multiple programs by hand.
 ====
 
 === Exercises
+*Conceptual Problems*
 
 1.  If you have a `String` containing a long text and you want to count
 the number of words in the text that begin with the letter `'m'`, which

--- a/chapters/06-arrays/index.adoc
+++ b/chapters/06-arrays/index.adoc
@@ -1971,6 +1971,7 @@ include::programs/AssigningWork.java[]
 ====
 
 === Exercises
+*Conceptual Problems*
 
 1.  Why can't an array be used to hold an arbitrarily long list of
 numbers entered by a user? What are strategies that can be used to

--- a/chapters/07-gui-basics/index.adoc
+++ b/chapters/07-gui-basics/index.adoc
@@ -592,6 +592,7 @@ Construction of more complex GUIs is the subject of
 Chapter <<chapter:Constructing_Graphical_User_Interfaces>>.
 
 === Exercises
+*Conceptual Problems*
 
 1.  In which situations would it be better to use a command-line
 interface instead of a GUI? When is it better to use a GUI over a

--- a/chapters/08-methods/index.adoc
+++ b/chapters/08-methods/index.adoc
@@ -983,6 +983,7 @@ be changed by one right before the other executes the `if` statements.
 ====
 
 === Exercises
+*Conceptual Problems*
 
 1.  Describe three advantages of dividing long segments of code into
 static methods.

--- a/chapters/09-classes/index.adoc
+++ b/chapters/09-classes/index.adoc
@@ -1099,6 +1099,7 @@ how it enforces that keyword, but the computational expense is not zero.
 Learn the libraries well, and use the right tools for the right job.
 
 === Exercises
+*Conceptual Problems*
 
 1.  Explain the relationship between a class and an object.
 2.  What is the difference between a static method and an instance

--- a/chapters/10-interfaces/index.adoc
+++ b/chapters/10-interfaces/index.adoc
@@ -697,6 +697,7 @@ to force programmers to use the `synchronized` keyword, the
 documentation may be the only guide.
 
 === Exercises
+*Conceptual Problems*
 
 1.  What is the purpose of an interface?
 2.  Why implement an interface when it puts additional requirements on a

--- a/chapters/11-inheritance/index.adoc
+++ b/chapters/11-inheritance/index.adoc
@@ -902,6 +902,7 @@ with a synchronized method, it is safest to mark your method
 synchronized as well.
 
 === Exercises
+*Conceptual Problems*
 
 1.  Give three advantages of using inheritance instead of copying and
 pasting code from a parent class. Are there any disadvantages to using

--- a/chapters/12-exceptions/index.adoc
+++ b/chapters/12-exceptions/index.adoc
@@ -798,6 +798,7 @@ causing such an exception. Although we will generally leave the
 for production code should always handle interruptions gracefully.
 
 === Exercises
+*Conceptual Problems*
 
 1.  <<exercise:exceptions_vs._error_codes>> What are the advantages of
 using exceptions instead of returning error codes?

--- a/chapters/13-concurrency/index.adoc
+++ b/chapters/13-concurrency/index.adoc
@@ -1324,6 +1324,7 @@ chapter. Subsequent chapters give additional tools to code more complex
 concurrent programs.
 
 === Exercises
+*Conceptual Problems*
 
 1.  <<exercise:thread_methods>> The `start()`, `run()`, and `join()`
 methods are essential parts of the process of using threads in Java.

--- a/chapters/14-synchronization/index.adoc
+++ b/chapters/14-synchronization/index.adoc
@@ -875,6 +875,7 @@ synchronization problems. Such problems have been studied for many
 years, and research continues to find better solutions.
 
 === Exercises
+*Conceptual Problems*
 
 1.  <<exercise:synchronized_keyword>> What is the purpose of the
 `synchronized` keyword? How does it work?

--- a/chapters/15-gui/index.adoc
+++ b/chapters/15-gui/index.adoc
@@ -1759,6 +1759,7 @@ http://download.oracle.com/javase/tutorial/uiswing/components/ or other
 reference sources.
 
 === Exercises
+*Conceptual Problems*
 
 1.  <<exercise:finalButtonExercise>> In
 Program <<program:FrameWithPanelAndActions>>, why have we declared the

--- a/chapters/16-testing-and-debugging/index.adoc
+++ b/chapters/16-testing-and-debugging/index.adoc
@@ -1994,6 +1994,7 @@ include::programs/TestPointCharge.java[]
 ----
 
 === Exercises
+*Conceptual Problems*
 
 1.  What is the purpose of the `assert` keyword in Java? What steps must
 be taken for it to be active?

--- a/chapters/17-polymorphism/index.adoc
+++ b/chapters/17-polymorphism/index.adoc
@@ -814,6 +814,7 @@ Many high performance concurrent applications depends on CAS
 implementations.
 
 === Exercises
+*Conceptual Problems*
 
 1.  Consider the following two classes:
 +

--- a/chapters/18-dynamic-data-structures/index.adoc
+++ b/chapters/18-dynamic-data-structures/index.adoc
@@ -1474,6 +1474,7 @@ Thread-0: 9
 ====
 
 === Exercises
+*Conceptual Problems*
 
 1.  Explain the difference between static data structures and dynamic
 data structures.

--- a/chapters/19-recursion/index.adoc
+++ b/chapters/19-recursion/index.adoc
@@ -1326,6 +1326,7 @@ print out the result.
 ====
 
 === Exercises
+*Conceptual Problems*
 
 1.  <<exercise:recursive_addition>> Example <<example:Multiplication_defined_recursively>> gave a mathematical recursive definition for
 latexmath:[x \times y]. Give a similar recursive definition for

--- a/chapters/20-file-io/index.adoc
+++ b/chapters/20-file-io/index.adoc
@@ -769,6 +769,7 @@ with everything file-related, `FileLock` is dependent on the underlying
 OS and may behave differently on different systems.
 
 === Exercises
+*Conceptual Problems*
 
 1.  What is the difference between volatile and non-volatile memory?
 Which is often associated with files and why?

--- a/chapters/21-network-communication/index.adoc
+++ b/chapters/21-network-communication/index.adoc
@@ -604,6 +604,7 @@ details. In other cases, your program must explicitly use multiple
 threads to solve the networking problem effectively.
 
 === Exercises
+*Conceptual Problems*
 
 1.  Why are there so many similarities between the network I/O and the
 file I/O APIs in Java?

--- a/index.html
+++ b/index.html
@@ -519,7 +519,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_syntax_data_representation">Syntax: Data Representation</a></li>
 <li><a href="#_solution_buying_a_computer">Solution: Buying a computer</a></li>
 <li><a href="#_summary">Summary</a></li>
-<li><a href="#_problems">Problems</a></li>
+<li><a href="#_excercises">Excercises</a></li>
 </ul>
 </li>
 <li><a href="#chapter:Problem_Solving_and_Programming">Problem Solving and Programming</a>
@@ -1697,6 +1697,14 @@ contributes 1 × 2<sup>4</sup> = 16 to the value.</p>
 </div>
 </div>
 </div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.4">Exercise 4</a><br>
+<a href="#exercise1.5">Exercise 5</a></p>
+</div>
+</div>
+</div>
 <div class="paragraph">
 <p>Another useful number system is <em>base 16</em>, also known as <em>hexadecimal</em>.
 Hexadecimal is surprising because it requires more than the familiar 10
@@ -1857,6 +1865,13 @@ every place we skipped, we get 23 = 10111<sub>2</sub>. While this is a
 straightforward procedure for decimal to binary conversion, it can be
 cumbersome for larger numbers.</p>
 </div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.6">Exercise 6</a></p>
+</div>
+</div>
+</div>
 <div class="paragraph">
 <p>An alternate way to convert a decimal numeral to an equivalent binary
 numeral is to divide the given number by 2 until the quotient is 0
@@ -1945,6 +1960,13 @@ decimal number as a sum of powers of 2, one writes it as a sum of powers
 of 16. Similarly, when using the division method, instead of dividing by
 2, one divides by 16. Octal conversion is similar.</p>
 </div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.9">Exercise 9</a></p>
+</div>
+</div>
+</div>
 <div class="paragraph">
 <p>We use hexadecimal because it is straightforward to convert from it to
 binary or back. The following table lists binary equivalents for the 16
@@ -2025,6 +2047,14 @@ digit</th>
 Note that we have grouped the binary digits into clusters of
 4 bits each. Of course, the leftmost zeroes in the binary equivalent are
 useless as they do not contribute to the value of the number.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.10">Exercise 10</a><br>
+<a href="#exercise1.11">Exercise 11</a></p>
+</div>
+</div>
 </div>
 </div>
 <div class="sect4">
@@ -2208,6 +2238,13 @@ position. The next example illustrates binary subtraction.</p>
 </table>
 </div>
 </div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.17">Exercise 17</a></p>
+</div>
+</div>
+</div>
 </div>
 <div class="sect4">
 <h5 id="_negative_integers_in_a_computer">Negative integers in a computer</h5>
@@ -2236,6 +2273,14 @@ complement. The result is <code>1111 0011</code> + <code>1</code> = <code>1111 0
 <code>1111 0100</code>. Note that the leftmost bit is a 1, indicating that this is
 a negative number.</p>
 </div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.7">Exercise 7</a><br>
+<a href="#exercise1.8">Exercise 8</a></p>
+</div>
+</div>
+</div>
 <div class="exampleblock">
 <div class="title">Example 11. Decimal to two&#8217;s complement</div>
 <div class="content">
@@ -2249,6 +2294,13 @@ to be stored in 8-bit, two&#8217;s complement form. First we convert positive
 flipping 0s to 1s and 1s to 0s. This gives us <code>1110 0010</code>. Finally, we
 add 1 to the one&#8217;s complement representation to get <code>1110 0010</code> + <code>1</code> =
 <code>1110 0011</code>, which is the desired binary equivalent of -29.</p>
+</div>
+</div>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.14">Exercise 14</a></p>
 </div>
 </div>
 </div>
@@ -2266,6 +2318,13 @@ one&#8217;s complement form, yielding <code>0111 0100</code>.</p>
 <div class="paragraph">
 <p>Now we convert this binary representation to its decimal equivalent,
 yielding 116. Thus, the decimal equivalent of <code>1000 1100</code> is -116.</p>
+</div>
+</div>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.15">Exercise 15</a></p>
 </div>
 </div>
 </div>
@@ -2365,6 +2424,13 @@ complement representations are <code>1000 0010</code> and <code>1111 1110</code>
 <div class="paragraph">
 <p>The result is -128, which is the smallest negative integer that can be
 represented in 8-bit two&#8217;s complement.</p>
+</div>
+</div>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.16">Exercise 16</a></p>
 </div>
 </div>
 </div>
@@ -2821,7 +2887,7 @@ decimal to verify that it is correct.</p>
 of 0. In such cases we can only find an approximate representation of
 the given fraction as demonstrated in the next example.</p>
 </div>
-<div class="exampleblock">
+<div id="Non-terminating_fraction" class="exampleblock">
 <div class="title">Example 17. Non-terminating fraction</div>
 <div class="content">
 <div class="paragraph">
@@ -2899,6 +2965,14 @@ of 0.3. Let&#8217;s convert this back to decimal to see how accurate it is.</p>
 an error of 0.3 - 0.28125 = 0.01875. Most computers use many
 more bits to represent fractions and obtain much better accuracy in
 their representation.</p>
+</div>
+</div>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.18">Exercise 18</a><br>
+<a href="#exercise1.19">Exercise 19</a></p>
 </div>
 </div>
 </div>
@@ -3008,6 +3082,13 @@ Since 10.5 is positive, we set the sign bit to 0.</p>
 representation of 10.5 is shown in <a href="#numberRepresentationFigure">Figure 5</a> (c).
 Note in the figure how the sign bit, the exponent, and the mantissa are
 packed into 32 bits.</p>
+</div>
+</div>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.20">Exercise 20</a></p>
 </div>
 </div>
 </div>
@@ -3507,6 +3588,13 @@ are not general purpose or completely independent. Instead, they&#8217;re
 specialized to do certain kinds of matrix transformations and floating
 point computations.</p>
 </div>
+<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p><a href="#exercise1.23">Exercise 23</a></p>
+</div>
+</div>
+</div>
 </div>
 <div class="sect4">
 <h5 id="_the_bad">The Bad</h5>
@@ -3624,7 +3712,10 @@ systems for individual characters and text.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_problems">Problems</h3>
+<h3 id="_excercises">Excercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -3638,11 +3729,11 @@ systems for individual characters and text.</p>
 ahead-of-time compilation?</p>
 </li>
 <li>
-<p>Without converting to decimal, how can one find out whether a given
+<p><a id="exercise1.4"></a> Without converting to decimal, how can one find out whether a given
 binary number is odd or even?</p>
 </li>
 <li>
-<p>Convert the following positive binary numbers into decimal.</p>
+<p><a id="exercise1.5"></a> Convert the following positive binary numbers into decimal.</p>
 <div class="olist loweralpha">
 <ol class="loweralpha" type="a">
 <li>
@@ -3664,7 +3755,7 @@ binary number is odd or even?</p>
 </div>
 </li>
 <li>
-<p>Convert the following positive decimal numbers into binary.</p>
+<p><a id="exercise1.6"></a> Convert the following positive decimal numbers into binary.</p>
 <div class="olist loweralpha">
 <ol class="loweralpha" type="a">
 <li>
@@ -3686,15 +3777,15 @@ binary number is odd or even?</p>
 </div>
 </li>
 <li>
-<p>What is the process for converting the representation of a binary
+<p><a id="exercise1.7"></a> What is the process for converting the representation of a binary
 integer given in one&#8217;s complement into two&#8217;s complement?</p>
 </li>
 <li>
-<p>Perform the conversion from one&#8217;s complement to two&#8217;s complement on the
+<p><a id="exercise1.8"></a> Perform the conversion from one&#8217;s complement to two&#8217;s complement on the
 representation <code>1011 0111</code>, which uses 8 bits for storage.</p>
 </li>
 <li>
-<p>Convert the following decimal numbers to their hexadecimal and octal
+<p><a id="exercise1.9"></a> Convert the following decimal numbers to their hexadecimal and octal
 equivalents.</p>
 <div class="olist loweralpha">
 <ol class="loweralpha" type="a">
@@ -3717,12 +3808,10 @@ equivalents.</p>
 </div>
 </li>
 <li>
-<p>Create a table similar to the one on page  that lists the binary
-equivalents of octal digits. Hint: Each octal digit can be represented
-as a sequence of three binary digits.</p>
+<p><a id="exercise1.10"></a> Create a table that lists the binary equivalents of octal digits, similar to the one in the subsection on <a href="#_other_conversions">Other conversions</a> . Hint: Each octal digit can be represented as a sequence of three binary digits.</p>
 </li>
 <li>
-<p>Use this table to convert the following octal numbers to binary.</p>
+<p><a id="exercise1.11"></a> Use this table to convert the following octal numbers to binary.</p>
 <div class="olist loweralpha">
 <ol class="loweralpha" type="a">
 <li>
@@ -3758,7 +3847,7 @@ to construct numbers.</p>
 </div>
 </li>
 <li>
-<p>Convert the following decimal numbers to 8-bit, two&#8217;s complement binary
+<p><a id="exercise1.14"></a> Convert the following decimal numbers to 8-bit, two&#8217;s complement binary
 representations.</p>
 <div class="olist loweralpha">
 <ol class="loweralpha" type="a">
@@ -3775,7 +3864,7 @@ representations.</p>
 </div>
 </li>
 <li>
-<p>Given the following 8-bit binary representations in two&#8217;s complement,
+<p><a id="exercise1.15"></a> Given the following 8-bit binary representations in two&#8217;s complement,
 find their decimal equivalents.</p>
 <div class="olist loweralpha">
 <ol class="loweralpha" type="a">
@@ -3792,7 +3881,7 @@ find their decimal equivalents.</p>
 </div>
 </li>
 <li>
-<p>Perform the following arithmetic operation on the following 8-bit, two&#8217;s
+<p><a id="exercise1.16"></a> Perform the following arithmetic operation on the following 8-bit, two&#8217;s
 complement binary representations of integers. Check your answers by
 performing arithmetic on equivalent decimal numbers.</p>
 <div class="olist loweralpha">
@@ -3816,7 +3905,7 @@ performing arithmetic on equivalent decimal numbers.</p>
 </div>
 </li>
 <li>
-<p>Extrapolate the rules for decimal and binary addition to rules for the
+<p><a id="exercise1.17"></a> Extrapolate the rules for decimal and binary addition to rules for the
 hexadecimal system. Then, use these rules to perform the following
 additions in hexadecimal. Check your answers by converting the values
 and their sums to decimal.</p>
@@ -3832,16 +3921,16 @@ and their sums to decimal.</p>
 </div>
 </li>
 <li>
-<p>Expand Example  assuming that you have ten bits to represent the
+<p><a id="exercise1.18"></a> Expand <a href="#Non-terminating_fraction">Example 17</a> assuming that you have ten bits to represent the
 fraction. Convert the representation back to base 10. How far off is
 this value from 0.3?</p>
 </li>
 <li>
-<p>Will the process in Example  ever terminate assuming that we can use as
+<p><a id="exercise1.19"></a> Will the process in <a href="#Non-terminating_fraction">Example 17</a> ever terminate assuming that we can use as
 many bits as needed to represent 0.3 in binary?</p>
 </li>
 <li>
-<p>Derive the binary representation of the following decimal numbers
+<p><a id="exercise1.20"></a> Derive the binary representation of the following decimal numbers
 assuming 32-bit (single) precision representation using the IEEE
 floating point format.</p>
 <div class="olist loweralpha">
@@ -3896,7 +3985,7 @@ expressions are still always true and which are sometimes false.</p>
 </div>
 </li>
 <li>
-<p>What is a multicore microprocessor? Why do you think a multicore chip
+<p><a id="exercise1.23"></a> What is a multicore microprocessor? Why do you think a multicore chip
 might be better than a single core chip? Search on the Internet to find
 the names of a few common multicore chips. Which chip does your computer
 use?</p>
@@ -6013,6 +6102,9 @@ parallelism and concurrency.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -9675,6 +9767,9 @@ only if the computations are long, complex, and not too interdependent.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_2">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -12162,6 +12257,9 @@ your program interact with each other.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_3">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -14082,6 +14180,9 @@ execution at a time without the need to run multiple programs by hand.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_4">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -17052,6 +17153,9 @@ balancing</em>, a broad term for dividing work across computing resources.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_5">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -18126,6 +18230,9 @@ Chapter <a href="#chapter:Constructing_Graphical_User_Interfaces"><em>Construct
 </div>
 <div class="sect2">
 <h3 id="_exercises_6">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -19490,6 +19597,9 @@ be changed by one right before the other executes the <code>if</code> statements
 </div>
 <div class="sect2">
 <h3 id="_exercises_7">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -21197,6 +21307,9 @@ Learn the libraries well, and use the right tools for the right job.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_8">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -22286,6 +22399,9 @@ documentation may be the only guide.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_9">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -23781,6 +23897,9 @@ synchronized as well.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_10">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -25042,6 +25161,9 @@ for production code should always handle interruptions gracefully.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_11">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -27035,6 +27157,9 @@ concurrent programs.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_12">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -28624,6 +28749,9 @@ years, and research continues to find better solutions.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_13">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -31543,6 +31671,9 @@ reference sources.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_14">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -34181,6 +34312,9 @@ class.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_15">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -35464,6 +35598,9 @@ implementations.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_16">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -38120,6 +38257,9 @@ alternate in strict lock-step.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_17">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -40146,6 +40286,9 @@ print out the result.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_18">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -41426,6 +41569,9 @@ OS and may behave differently on different systems.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_19">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -42431,6 +42577,9 @@ threads to solve the networking problem effectively.</p>
 </div>
 <div class="sect2">
 <h3 id="_exercises_20">Exercises</h3>
+<div class="paragraph">
+<p><strong>Conceptual Problems</strong></p>
+</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -42516,7 +42665,7 @@ multi-threaded versions?</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-06-05 13:25:34 Eastern Daylight Time
+Last updated 2018-06-19 11:44:41 Eastern Daylight Time
 </div>
 </div>
 <script type="text/x-mathjax-config">


### PR DESCRIPTION
I used the sidebar syntax to give exercise links:

```
****
Sidebar text
****
```

Unfortunately, referring to exercises by number seems to make the most sense, although doing so requires the authors to keep all the numbers straight.

I also added the text "Conceptual Problems" at the beginning of each Exercises section.