### PR TITLE
Removed remaining links to sections and subsections

### DIFF
--- a/chapters/05-repetition/index.adoc
+++ b/chapters/05-repetition/index.adoc
@@ -837,7 +837,6 @@ By removing the inner `for` loop, the total amount of work needed is
 greatly reduced.
 ====
 
-[[subsection:common_pitfalls]]
 ==== Common pitfalls
 
 With great power comes great responsibility. The power to repeat things

--- a/chapters/06-arrays/index.adoc
+++ b/chapters/06-arrays/index.adoc
@@ -1696,7 +1696,7 @@ There are often special syntactical tools or libraries designed to make
 them easier to use. In this section, we explore two advanced tools, the
 for-each loop and the `Arrays` utility class.
 
-[[subsection:The_for-each_loop]]
+
 ==== The for-each loop
 
 In <<Repetition>> we describe three loops: `while`

--- a/chapters/07-gui-basics/index.adoc
+++ b/chapters/07-gui-basics/index.adoc
@@ -98,7 +98,6 @@ be handled automatically by the tools we will introduce in this chapter.
 creation of more complex GUIs that require the programmer to program
 event handling explicitly.
 
-[[syntax:Dialogs_and_the_JOptionPane_class]]
 === Syntax: Dialogs and the `JOptionPane` class
 
 `JOptionPane` is a utility class for creating GUIs consisting most often

--- a/chapters/08-methods/index.adoc
+++ b/chapters/08-methods/index.adoc
@@ -330,7 +330,6 @@ If Java finds a way that execution could reach the end of a value
 returning method without reaching a `return` statement, it causes a
 compiler error.
 
-[[subsubsection:Overloaded_methods]]
 ===== Overloaded methods
 
 Since this declaration is in another class, it is OK to create a `max()`

--- a/chapters/09-classes/index.adoc
+++ b/chapters/09-classes/index.adoc
@@ -491,7 +491,6 @@ don't make sense for dimensions of a rectangle. For more complicated
 objects, it becomes even more important to protect the values of the
 fields from malicious or mistaken users.
 
-[[subsection:Access_modifiers]]
 ==== Access modifiers
 
 Hiding data is at the heart of the Java OOP model. There are four

--- a/chapters/15-gui/index.adoc
+++ b/chapters/15-gui/index.adoc
@@ -1318,7 +1318,7 @@ created.
 <9> The `main()` method creates an instance of `MathTutor`, initiating GUI construction.
 ====
 
-[[subsection:Applets]]
+
 ==== Applets
 
 An applet is a Java program that is written to run inside a web browser.

--- a/chapters/17-polymorphism/index.adoc
+++ b/chapters/17-polymorphism/index.adoc
@@ -521,7 +521,7 @@ This version of the code will only call `blastOff()` for objects of
 class `RocketShip` and not for objects of a subclass like
 `FusionPoweredRocketShip`.
 
-[[subsection:Inheritance_and_exceptions]]
+
 ==== Inheritance and exceptions
 
 Beyond `ClassCastException`s, there are a few other issues that come up

--- a/chapters/19-recursion/index.adoc
+++ b/chapters/19-recursion/index.adoc
@@ -59,7 +59,6 @@ problem solving in Java? How does the computer keep track of these
 self-references? The following subsections address precisely these
 questions.
 
-[[subsection:What_is_recursion]]
 ==== What is recursion?
 
 In the context of computer science and mathematics, recursion means

--- a/chapters/21-network-communication/index.adoc
+++ b/chapters/21-network-communication/index.adoc
@@ -243,7 +243,6 @@ The first parameter is a `String` specifying the address of the server,
 either as an IP address as shown or as domain like `"google.com"`. The
 second parameter is, of course, the port you want to connect on.
 
-[[subsection:receiving_and_sending_data]]
 ==== Receiving and sending data
 
 From here on out, we no longer have to worry about the differences

--- a/index.html
+++ b/index.html
@@ -585,7 +585,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_problem_codon_extractor">7.1. Problem: Codon extractor</a></li>
 <li><a href="#GUIBasicsIntroductionSection">7.2. Concepts: User interaction</a></li>
-<li><a href="#syntax:Dialogs_and_the_JOptionPane_class">7.3. Syntax: Dialogs and the <code>JOptionPane</code> class</a></li>
+<li><a href="#_syntax_dialogs_and_the_code_joptionpane_code_class">7.3. Syntax: Dialogs and the <code>JOptionPane</code> class</a></li>
 <li><a href="#_solution_codon_extractor">7.4. Solution: Codon extractor</a></li>
 <li><a href="#_concurrency_simple_guis">7.5. Concurrency: Simple GUIs</a></li>
 <li><a href="#_summary_4">7.6. Summary</a></li>
@@ -13758,7 +13758,7 @@ greatly reduced.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="subsection:common_pitfalls">5.3.5. Common pitfalls</h4>
+<h4 id="_common_pitfalls">5.3.5. Common pitfalls</h4>
 <div class="paragraph">
 <p>With great power comes great responsibility. The power to repeat things
 a large number of times means that we can also repeat our mistakes a
@@ -14495,7 +14495,7 @@ time. However, if you increase the values of all three loops too much,
 you may have to wait longer than you want.</p>
 </li>
 <li>
-<p><a id="exercise5.13"></a> In <a href="#subsection:common_pitfalls">Section 5.3.5</a>, one of the common loop
+<p><a id="exercise5.13"></a> In <a href="#_common_pitfalls">Section 5.3.5</a>, one of the common loop
 mistakes we discuss is an almost infinite loop. Create your own almost
 infinite loop that runs from <code>10</code> to <code>0</code>, incrementing instead of
 decrementing. Time the execution of your program. Unlike our example, do
@@ -15071,7 +15071,7 @@ Note that the <code>length</code> field is read-only. If you try to set
 with a loop. Let&#8217;s assume that an array of type <code>double</code> named <code>data</code>
 has been declared, instantiated, and filled with user input. We could
 sum all its elements using the following code. A more elegant way to do
-the same summation is discussed in <a href="#subsection:The_for-each_loop">Section 6.9.1</a>.</p>
+the same summation is discussed in <a href="#_the_for_each_loop">Section 6.9.1</a>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -16449,7 +16449,7 @@ the original two-dimensional array.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_common_pitfalls">6.7.4. Common pitfalls</h4>
+<h4 id="_common_pitfalls_2">6.7.4. Common pitfalls</h4>
 <div class="paragraph">
 <p>Even one-dimensional arrays make many new errors possible. Below we list
 two of the most common mistakes made with both one-dimensional and
@@ -16938,7 +16938,7 @@ them easier to use. In this section, we explore two advanced tools, the
 for-each loop and the <code>Arrays</code> utility class.</p>
 </div>
 <div class="sect3">
-<h4 id="subsection:The_for-each_loop">6.9.1. The for-each loop</h4>
+<h4 id="_the_for_each_loop">6.9.1. The for-each loop</h4>
 <div class="paragraph">
 <p>In <a href="#_repetition">Chapter 5</a> we describe three loops: <code>while</code>
 loops, <code>for</code> loops, and <code>do-while</code> loops. Although these are the only
@@ -17698,7 +17698,7 @@ event handling explicitly.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="syntax:Dialogs_and_the_JOptionPane_class">7.3. Syntax: Dialogs and the <code>JOptionPane</code> class</h3>
+<h3 id="_syntax_dialogs_and_the_code_joptionpane_code_class">7.3. Syntax: Dialogs and the <code>JOptionPane</code> class</h3>
 <div class="paragraph">
 <p><code>JOptionPane</code> is a utility class for creating GUIs consisting most often
 of a single dialog. It offers a variety of ways to create useful dialogs
@@ -19038,7 +19038,7 @@ compiler error.</p>
 </div>
 </div>
 <div class="sect4">
-<h5 id="subsubsection:Overloaded_methods">Overloaded methods</h5>
+<h5 id="_overloaded_methods">Overloaded methods</h5>
 <div class="paragraph">
 <p>Since this declaration is in another class, it is OK to create a <code>max()</code>
 method even though there is already one in the <code>Math</code> class. However, it
@@ -20580,7 +20580,7 @@ constructor does not have a return type. A constructors is the only kind
 of method that does not have a return type. It is possible to have more
 than one constructor as well, just as other methods can be overloaded.
 For more information about overloaded methods, refer back to
-<a href="#subsubsection:Overloaded_methods">Section 8.3.1.2</a>.</p>
+<a href="#_overloaded_methods">Section 8.3.1.2</a>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -20781,7 +20781,7 @@ fields from malicious or mistaken users.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="subsection:Access_modifiers">9.3.4. Access modifiers</h4>
+<h4 id="_access_modifiers">9.3.4. Access modifiers</h4>
 <div class="paragraph">
 <p>Hiding data is at the heart of the Java OOP model. There are four
 different levels of access that can be applied to fields and methods,
@@ -23331,7 +23331,7 @@ so it might be good design to prevent outside code from changing the
 making these kinds of decisions.</p>
 </div>
 <div class="paragraph">
-<p>We introduced access modifiers in <a href="#subsection:Access_modifiers">Section 9.3.4</a>, but inheritance gives them new meaning. Recall that the
+<p>We introduced access modifiers in <a href="#_access_modifiers">Section 9.3.4</a>, but inheritance gives them new meaning. Recall that the
 access modifier for the <code>color</code> field of <code>Fish</code> was <code>protected</code>. A field
 or method with the <code>protected</code> modifier can be accessed by all child
 classes (as well as classes in the same package). If the modifier for
@@ -24178,7 +24178,7 @@ synchronized method with a non-synchronized method or vice versa.</p>
 child class is usable anywhere that an object of the parent class is
 usable. Thus, you cannot override a public method with a private one,
 reducing the visibility of a method. We discuss a similar restriction
-with exceptions in <a href="#subsection:Inheritance_and_exceptions">Section 17.3.4</a>.</p>
+with exceptions in <a href="#_inheritance_and_exceptions">Section 17.3.4</a>.</p>
 </div>
 <div class="paragraph">
 <p>If it has these restrictions, why doesn&#8217;t Java prevent a synchronized
@@ -29914,7 +29914,7 @@ could click a button labeled &#8220;Chirp,&#8221; causing the program to play a
 bird chirp sound. Clicking a button generates an <em>event</em>. In Java, an
 event is processed by one or more <em>listeners</em>. Java provides various
 types of listeners, some of which are introduced here and a few others
-in <a href="#subsection:Applets">Section 15.3.7</a>. Next we show you how to handle action
+in <a href="#_applets">Section 15.3.7</a>. Next we show you how to handle action
 events generated by a few different kinds of widgets.</p>
 </div>
 <div class="sect4">
@@ -30471,7 +30471,7 @@ handle mouse movement with or without the button pressed.</p>
 <div class="paragraph">
 <p>An <code>ItemListener</code> can be attached to a widget such as a check box or a
 radio button to listen for a check box to be selected. This listener is
-illustrated in <a href="#subsection:Applets">Section 15.3.7</a>.</p>
+illustrated in <a href="#_applets">Section 15.3.7</a>.</p>
 </div>
 <div class="paragraph">
 <p>Java provides several other listeners to handle a variety of events. For
@@ -31479,7 +31479,7 @@ that fired the <code>ItemEvent</code> is now selected or deselected.</p>
 <p>Here we give the code to generate the GUI shown in
 <a href="#MathTutorFigure">Figure 66</a> which displays basic (addition and
 subtraction) as well as advanced (multiplication and division) problems.
-In <a href="#subsection:Applets">Section 15.3.7</a> we transform this GUI into an applet
+In <a href="#_applets">Section 15.3.7</a> we transform this GUI into an applet
 like the one described in <a href="#_problem_math_applet">Section 15.1</a>.</p>
 </div>
 <div id="MathTutorFigure" class="imageblock">
@@ -31689,7 +31689,7 @@ created.</td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="subsection:Applets">15.3.7. Applets</h4>
+<h4 id="_applets">15.3.7. Applets</h4>
 <div class="paragraph">
 <p>An applet is a Java program that is written to run inside a web browser.
 A normal Java application is stored on disk and runs on the command line
@@ -35804,7 +35804,7 @@ class <code>RocketShip</code> and not for objects of a subclass like
 </div>
 </div>
 <div class="sect3">
-<h4 id="subsection:Inheritance_and_exceptions">17.3.4. Inheritance and exceptions</h4>
+<h4 id="_inheritance_and_exceptions">17.3.4. Inheritance and exceptions</h4>
 <div class="paragraph">
 <p>Beyond `ClassCastException`s, there are a few other issues that come up
 when combining exceptions with inheritance. As you already know, an
@@ -38252,7 +38252,7 @@ different underlying types. We illustrate three examples here: <code>Vector</cod
 class, which is a great deal more powerful than the <code>LinkedList</code> class
 defined in this chapter. Any class that implements the <code>Iterable</code>
 interface can be used in the for-each loops described in
-<a href="#subsection:The_for-each_loop">Section 6.9.1</a>. The <code>ArrayDeque</code>, <code>ArrayList</code>,
+<a href="#_the_for_each_loop">Section 6.9.1</a>. The <code>ArrayDeque</code>, <code>ArrayList</code>,
 <code>HashSet</code>, <code>TreeSet</code>, and <code>Vector</code>, classes all implement <code>Iterable</code>. In
 our examples, a <code>Vector</code> object and a <code>Set</code> (returned by the
 <code>entrySet()</code> method of a <code>HashMap</code>) are used as targest of for-each
@@ -39237,7 +39237,7 @@ self-references? The following subsections address precisely these
 questions.</p>
 </div>
 <div class="sect3">
-<h4 id="subsection:What_is_recursion">19.2.1. What is recursion?</h4>
+<h4 id="_what_is_recursion">19.2.1. What is recursion?</h4>
 <div class="paragraph">
 <p>In the context of computer science and mathematics, recursion means
 describing some repetitive process in terms of itself. Many complex
@@ -41089,7 +41089,7 @@ print out the result.</p>
 <p><a id="exercise19.1"></a> <a href="#multiplicationDefinedRecursivelyExample">Example 149</a> gave a mathematical recursive definition for
 \(x \times y\). Give a similar recursive definition for
 \(x + y\). The structure is similar to the recursion to
-determine your current age given in <a href="#subsection:What_is_recursion">Section 19.2.1</a>.</p>
+determine your current age given in <a href="#_what_is_recursion">Section 19.2.1</a>.</p>
 </li>
 <li>
 <p><a id="exercise19.2"></a> In principle, every problem that can be solved with an iterative
@@ -42806,7 +42806,7 @@ second parameter is, of course, the port you want to connect on.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="subsection:receiving_and_sending_data">21.3.3. Receiving and sending data</h4>
+<h4 id="_receiving_and_sending_data">21.3.3. Receiving and sending data</h4>
 <div class="paragraph">
 <p>From here on out, we no longer have to worry about the differences
 between the client and server. Both programs have a <code>Socket</code> object that
@@ -43420,7 +43420,7 @@ hexadecimal digits. How many possible IP addresses are there in IPv6?</p>
 </div>
 </li>
 <li>
-<p><a id="exercise21.8"></a> Recall the client and server from <a href="#subsection:receiving_and_sending_data">Section 21.3.3</a> that, respectively, send 100 <code>int</code> values and sum them.
+<p><a id="exercise21.8"></a> Recall the client and server from <a href="#_receiving_and_sending_data">Section 21.3.3</a> that, respectively, send 100 <code>int</code> values and sum them.
 Rewrite these fragments to send and receive the <code>int</code> values in text
 rather than binary format.</p>
 </li>

--- a/index.xml
+++ b/index.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc maxdepth="2"?>
-<?asciidoc-numbered?>
+<?asciidoc-numbered maxdepth="3"?>
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Start Concurrent</title>
 <subtitle>A Gentle Introduction to Concurrent Programming</subtitle>
-<date>2018-06-05</date>
+<date>2018-07-20</date>
 <authorgroup>
 <author>
 <personname>
@@ -39,7 +39,7 @@ Pablo Picasso
 <simpara>Computers are useless. They can only give you answers.</simpara>
 </blockquote>
 <section xml:id="_problem_buying_a_computer">
-<title>Problem: Buying a Computer</title>
+<title>Problem: Buying a computer</title>
 <simpara>We begin almost every chapter of this book with a motivating problem.
 Why? Sometimes it helps to see how tools can be applied in order to see
 why they&#8217;re useful. As we move through each chapter, we cover background
@@ -47,11 +47,10 @@ concepts needed to solve the problem in the <emphasis role="strong">Concepts</em
 specific technical details (usually in the form of Java syntax) required
 in the <emphasis role="strong">Syntax and Semantics</emphasis> section, and eventually the solution to
 the problem in the <emphasis role="strong">Solution</emphasis> sections. If you&#8217;re not interested in the
-problem, that&#8217;s fine! Feel free to skip ahead to the <xref linkend="_concepts_hardware_and_software"/> section
-or directly to the <xref linkend="_syntax_data_representation"/> section, especially if you
+problem, that&#8217;s fine! Feel free to skip ahead to <xref linkend="_concepts_hardware_and_software"/> on hardware and software
+or to <xref linkend="_syntax_data_representation"/> on data representation, especially if you
 already have some programming experience. Then, if you&#8217;d like to see
-another detailed example, the <xref linkend="_solution_buying_a_computer"/> is
-available as a reference.</simpara>
+another detailed example, the solution to this problem is available in <xref linkend="_solution_buying_a_computer"/> as a reference.</simpara>
 <simpara>We&#8217;ll start with a problem that is not about programming and may be
 familiar to you. Imagine you are just about to start college and need a
 computer. Should you buy a Mac or PC? What kind of computer is going to
@@ -68,7 +67,7 @@ Nevertheless, both the hardware that makes up your computer and the
 other software running on it affect the way the programs you write work.</simpara>
 </section>
 <section xml:id="_concepts_hardware_and_software">
-<title>Concepts: Hardware and Software</title>
+<title>Concepts: Hardware and software</title>
 <simpara>Computers are ubiquitous. We see them nearly everywhere. They are found
 in most homes, shops, cars, aircraft, phones, and inside many other
 devices. Sometimes they are obvious, like a laptop sitting on a desk.
@@ -213,7 +212,7 @@ they can all communicate with the same memory.</simpara>
 <simpara>In theory, having six cores could allow your computer to run six times
 as fast. In practice, this speedup is rarely the case. Learning how to
 get more performance out of multicore systems is one of the major
-themes of this book. Chapters <xref linkend="chapter:Concurrent_Programming"/> and <xref linkend="chapter:Synchronization"/> as well as
+themes of this book. <xref linkend="_concurrent_programming"/> and <xref linkend="_synchronization"/> as well as
 sections marked <emphasis role="strong">Concurrency</emphasis> in other chapters are specifically
 tailored for students interested in programming these multicore
 systems to work effectively. If you aren&#8217;t interested in concurrent
@@ -255,7 +254,7 @@ computers, all data is stored as a sequence of 0s and 1s. In memory, the
 space that can hold either a single 0 or a single 1 is called a <emphasis>bit</emphasis>,
 which is short for &#8220;binary digit.&#8221;</simpara>
 <figure>
-<title>Computer memory contains bits organized as bytes and words. One bit contains either a 0 or a 1.  A byte contains eight bits. A word may contain two or more bytes. Shown here is a word containing four bytes, or 32 bits. Computer scientists often number items starting at zero, as we discuss in <xref linkend="chapter:Arrays"/>.</title>
+<title>Computer memory contains bits organized as bytes and words. One bit contains either a 0 or a 1.  A byte contains eight bits. A word may contain two or more bytes. Shown here is a word containing four bytes, or 32 bits. Computer scientists often number items starting at zero, as we discuss in <xref linkend="_arrays"/>.</title>
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/01-computer-basics/images/bitsBytesFigure.svg" width="100%"/>
@@ -271,12 +270,12 @@ it is inconvenient to describe them in bytes. Computer scientists have
 borrowed prefixes from physical scientists to create suitable units.</simpara>
 <simpara>Common units for measuring memory are bytes, kilobytes, megabytes,
 gigabytes, and terabytes. Each unit is 1,024 times the size of the
-previous unit. Notice that <inlineequation><alt><![CDATA[2^{10}]]></alt><mathphrase><![CDATA[2^{10}]]></mathphrase></inlineequation> (1,024) is almost the
-same as <inlineequation><alt><![CDATA[10^3]]></alt><mathphrase><![CDATA[10^3]]></mathphrase></inlineequation> (1,000). Sometimes it is not clear which
+previous unit. Notice that 2<superscript>10</superscript> (1,024) is almost the
+same as 10<superscript>3</superscript> (1,000). Sometimes it is not clear which
 value is meant. Disk drive manufacturers always use powers of 10 when
 they quote the size of their disks. Thus, a 1 TB hard disk can hold
-<inlineequation><alt><![CDATA[10^{12}]]></alt><mathphrase><![CDATA[10^{12}]]></mathphrase></inlineequation> (1,000,000,000,000) bytes, not
-<inlineequation><alt><![CDATA[2^{40}]]></alt><mathphrase><![CDATA[2^{40}]]></mathphrase></inlineequation> (1,099,511,627,776) bytes. Standards organizations
+10<superscript>12</superscript> (1,000,000,000,000) bytes, not
+2<superscript>40</superscript> (1,099,511,627,776) bytes. Standards organizations
 have advocated that the terms kibibyte (KiB), mebibyte (MiB), gibibyte
 (GiB), and tebibyte (TiB) be used to refer to the units based on powers
 of 2, while the traditional names be used to refer only to the units
@@ -566,13 +565,15 @@ telephones.</simpara>
 <title>Examples</title>
 <simpara>Here are a few examples of modern computers with a brief description of
 their hardware and some of the software that runs on them.</simpara>
+<example>
+<title>Desktop computer</title>
 <simpara>The Inspiron 560 Desktop is a modestly priced computer manufactured and
 sold by Dell, Inc. It can be configured with different hardware options,
 but one choice uses a 64-bit Intel Pentium E6700 CPU that runs at a
 clock rate of 3.2 GHz with a 2 MB cache and two cores. In terms of
 memory, you can choose between 4 and 6 GB worth of RAM. You can also
 choose to have a 500 GB or 1 TB hard drive. The computer comes with a
-DVD<inlineequation><alt><![CDATA[\pm]]></alt><mathphrase><![CDATA[\pm]]></mathphrase></inlineequation>RW optical drive.</simpara>
+DVD-RW optical drive.</simpara>
 <simpara>For I/O, the computer has various ports for connecting USB devices,
 monitors, speakers, microphones, and network cables. By default, it
 includes a keyboard, a mouse, a network card, a graphics card, and an
@@ -586,7 +587,8 @@ Windows 7 is <emphasis role="strong">not</emphasis> the seventh version of the W
 is the successor to Windows 7. ) Depending on the price, different
 configurations of Microsoft Office 2010 with more or fewer features can
 be included.
-<xref linkend="computerPictures"/> (a) shows a picture of the Dell Inspiron 560.</simpara>
+<xref linkend="computerPictures"/>(a) shows a picture of the Dell Inspiron 560.</simpara>
+</example>
 <figure xml:id="computerPictures">
 <title>(a) Dell Inspiron 560. (b) Apple iPhone 4. (c) Motorola Xoom.</title>
 <mediaobject>
@@ -596,6 +598,8 @@ be included.
 <textobject><phrase>computerPictures</phrase></textobject>
 </mediaobject>
 </figure>
+<example>
+<title>Smartphone</title>
 <simpara>All mobile phones contain a computer, but a phone that has features like
 a media player, calendar, GPS, or camera is often called a <emphasis>smartphone</emphasis>.
 Such phones often have sophisticated software that is comparable to a
@@ -612,7 +616,10 @@ on several kinds of wireless networks.</simpara>
 <simpara>In addition to the Apple iOS 4 operating system, the iPhone runs a
 variety of applications just like a desktop computer. These applications
 are available from the iTunes App Store.
-<xref linkend="computerPictures"/> (b) shows a picture of the iPhone 4.</simpara>
+<xref linkend="computerPictures"/>(b) shows a picture of the iPhone 4.</simpara>
+</example>
+<example>
+<title>Tablet</title>
 <simpara>The Motorola Xoom is a <emphasis>tablet computer</emphasis>. A tablet computer has a touch
 screen and is generally lighter than a laptop. Some tablets have
 keyboards, but many newer models use the touch screen instead.</simpara>
@@ -625,11 +632,12 @@ accelerometers, a barometer, and the capability to communicate on
 several kinds of wireless networks.</simpara>
 <simpara>It uses the Google Android 3 operating system, which can run
 applications available from the Android Market.
-<xref linkend="computerPictures"/> (c) shows a picture of the Motorola Xoom.</simpara>
+<xref linkend="computerPictures"/>(c) shows a picture of the Motorola Xoom.</simpara>
+</example>
 </section>
 </section>
 <section xml:id="_syntax_data_representation">
-<title>Syntax: Data Representation</title>
+<title>Syntax: Data representation</title>
 <simpara>After each <emphasis role="strong">Concepts</emphasis> section, this book usually has a <emphasis role="strong">Syntax</emphasis> section.
 Syntax is the rules for a language. These <emphasis role="strong">Syntax</emphasis> sections generally
 focus on concrete Java language features and technical specifics that
@@ -684,9 +692,8 @@ from?</simpara>
 <textobject><phrase>compilerFigure</phrase></textobject>
 </mediaobject>
 </figure>
-</section>
-<section xml:id="_example_java_compilation">
-<title>Example: Java compilation</title>
+<example>
+<title>Java compilation</title>
 <simpara>Java is the popular high-level programming language we will focus on in
 this book. The standard way to run a Java program has an extra step that
 most compiled languages do not. Most compilers for Java, though not all,
@@ -713,6 +720,7 @@ combination of OS and hardware that it runs on.</simpara>
 Inc., which was bought by Oracle Corporation in 2009. Oracle continues
 to produce HotSpot, the standard JVM, but many other JVMs exist,
 including Apache Harmony and Dalvik, the Google Android JVM.</simpara>
+</example>
 </section>
 <section xml:id="_numbers">
 <title>Numbers</title>
@@ -747,16 +755,15 @@ combined. Every base has the property that the number it is named after
 takes two digits to write, namely &#8220;1&#8221; and &#8220;0.&#8221; (An exception is base
 1, which does not behave like the other bases and is not a normal
 positional number system.)</simpara>
-</section>
-<section xml:id="_example_decimal_numbers">
-<title>Example: Decimal numbers</title>
-<simpara>The number <inlineequation><alt><![CDATA[723]]></alt><mathphrase><![CDATA[723]]></mathphrase></inlineequation> can be written as
-<inlineequation><alt><![CDATA[723=7 \times 10^2+2 \times 10^1+3 \times 10^0]]></alt><mathphrase><![CDATA[723=7 \times 10^2+2 \times 10^1+3 \times 10^0]]></mathphrase></inlineequation>.</simpara>
+<example>
+<title>Decimal numbers</title>
+<simpara>The number 723 can be written as
+723=7 × 10<superscript>2</superscript> + 2 × 10<superscript>1</superscript> + 3 × 10<superscript>0</superscript>.</simpara>
 <simpara>Note that the rightmost digit is the ones place, which is equivalent to
-<inlineequation><alt><![CDATA[10^0]]></alt><mathphrase><![CDATA[10^0]]></mathphrase></inlineequation>. Be sure to start with <inlineequation><alt><![CDATA[b^0]]></alt><mathphrase><![CDATA[b^0]]></mathphrase></inlineequation> and not
+10<superscript>0</superscript>. Be sure to start with <inlineequation><alt><![CDATA[b^0]]></alt><mathphrase><![CDATA[b^0]]></mathphrase></inlineequation> and not
 <inlineequation><alt><![CDATA[b^1]]></alt><mathphrase><![CDATA[b^1]]></mathphrase></inlineequation> when considering the value of a number written in base
 <inlineequation><alt><![CDATA[b]]></alt><mathphrase><![CDATA[b]]></mathphrase></inlineequation>, no matter what <inlineequation><alt><![CDATA[b]]></alt><mathphrase><![CDATA[b]]></mathphrase></inlineequation> is. The second digit
-from the right is multiplied by <inlineequation><alt><![CDATA[10^1]]></alt><mathphrase><![CDATA[10^1]]></mathphrase></inlineequation>, and so on. The
+from the right is multiplied by 10<superscript>1</superscript>, and so on. The
 product of a digit and the corresponding power of 10 tells us how much a
 digit contributes to the number. In the above expansion, digit 7
 contributes 700 to the number 723. Similarly, digits 2 and 3 contribute,
@@ -764,11 +771,10 @@ respectively, 20 and 3 to 723.</simpara>
 <simpara>As we move to the right, the power of 10 goes down by one, and this
 pattern works even for negative powers of 10. If we expand the
 fractional value 0.324, we get
-<inlineequation><alt><![CDATA[0.324=3\times10^{-1}+2\times10^{-2}+4\times10^{-3}]]></alt><mathphrase><![CDATA[0.324=3\times10^{-1}+2\times10^{-2}+4\times10^{-3}]]></mathphrase></inlineequation>.</simpara>
+0.324 = 3 × 10<superscript>-1</superscript> + 2 × 10<superscript>-2</superscript> + 4 × 10<superscript>-3</superscript>.</simpara>
 <simpara>We can combine the above two numbers to get
-<inlineequation><alt><![CDATA[723.324=7 \times 10^2+2 \times 10^1+ 3\times 10^0+
-3\times10^{-1}+2\times10^{-2}+4\times10^{-3}]]></alt><mathphrase><![CDATA[723.324=7 \times 10^2+2 \times 10^1+ 3\times 10^0+
-3\times10^{-1}+2\times10^{-2}+4\times10^{-3}]]></mathphrase></inlineequation>.</simpara>
+723.324 = 7 × 10<superscript>2</superscript> + 2 × 10<superscript>1</superscript> + 3 × 10<superscript>0</superscript> + 3 × 10<superscript>-1</superscript> + 2 × 10<superscript>-2</superscript> + 4 × 10<superscript>-3</superscript>.</simpara>
+</example>
 <simpara>We can expand these ideas to any base, checking our logic against the
 familiar base 10. Suppose that a numeral consists of <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>
 symbols <inlineequation><alt><![CDATA[s_{n-1},
@@ -804,25 +810,32 @@ used to express numbers inside of a computer. Base 2 is also called
 <simpara>In the binary numeral 100110, the leftmost 1 is the highest order bit
 and the rightmost 0 is the lowest order bit. By the rules of positional
 number systems, the highest order bit represents
-<inlineequation><alt><![CDATA[1 \times 2^5 = 32]]></alt><mathphrase><![CDATA[1 \times 2^5 = 32]]></mathphrase></inlineequation>.</simpara>
-<simpara>Examples of numbers written in binary are 100, 111, 0111, and 10101.
+1 × 2<superscript>5</superscript> = 32.</simpara>
+<example>
+<title>Binary numbers</title>
+<simpara>Examples of numbers written in binary are 100<subscript>2</subscript>, 111<subscript>2</subscript>, 0111<subscript>2</subscript>, and 10101<subscript>2</subscript>.
 Recall that the base of the binary number system is 2. Thus, we can
 write a number in binary as the sum of products of powers of 2. For
-example, the numeral 10011 can be expanded to:</simpara>
+example, the numeral 10011<subscript>2</subscript> can be expanded to:</simpara>
 <informalequation>
-<alt><![CDATA[10011 = 1 \times 2^4+0 \times 2^3+0 \times 2^2+1 \times 2^1+1 \times
+<alt><![CDATA[10011_2 = 1 \times 2^4+0 \times 2^3+0 \times 2^2+1 \times 2^1+1 \times
 2^0=16+0+0+2+1 = 19]]></alt>
-<mathphrase><![CDATA[10011 = 1 \times 2^4+0 \times 2^3+0 \times 2^2+1 \times 2^1+1 \times
+<mathphrase><![CDATA[10011_2 = 1 \times 2^4+0 \times 2^3+0 \times 2^2+1 \times 2^1+1 \times
 2^0=16+0+0+2+1 = 19]]></mathphrase>
 </informalequation>
 <simpara>By expanding the number, we have also shown how to convert a binary
 numeral into a decimal numeral. Remember that both 10011 and 19
 represent the same value, namely nineteen. The conversion between bases
 changes only the way the number is written. As before, the rightmost bit
-is multiplied by <inlineequation><alt><![CDATA[2^0]]></alt><mathphrase><![CDATA[2^0]]></mathphrase></inlineequation> to determine its contribution to the
-binary number. The bit to its left is multiplied by <inlineequation><alt><![CDATA[2^1]]></alt><mathphrase><![CDATA[2^1]]></mathphrase></inlineequation> to
+is multiplied by 2<superscript>0</superscript> to determine its contribution to the
+binary number. The bit to its left is multiplied by 2<superscript>1</superscript> to
 determine its contribution, and so on. In this case, the leftmost 1
-contributes <inlineequation><alt><![CDATA[1 \times 2^4 = 16]]></alt><mathphrase><![CDATA[1 \times 2^4 = 16]]></mathphrase></inlineequation> to the value.</simpara>
+contributes 1 × 2<superscript>4</superscript> = 16 to the value.</simpara>
+</example>
+<sidebar>
+<simpara><link linkend="exercise1.4">Exercise 1.4</link><?asciidoc-br?>
+<link linkend="exercise1.5">Exercise 1.5</link></simpara>
+</sidebar>
 <simpara>Another useful number system is <emphasis>base 16</emphasis>, also known as <emphasis>hexadecimal</emphasis>.
 Hexadecimal is surprising because it requires more than the familiar 10
 digits. Numerals in this system are written with 16 hexadecimal digits
@@ -832,9 +845,11 @@ E, and F. The six letters, starting from A, correspond to the values 10,
 <simpara>Hexadecimal is used as a compact representation of binary. Binary
 numbers can get very long, but four binary digits can be represented
 with a single hexadecimal digit.</simpara>
-<simpara>39A, 32, and AFBC12 are examples of numbers written in hexadecimal. A
+<example>
+<title>Hexadecimal numbers</title>
+<simpara>39A<subscript>16</subscript>, 32<subscript>16</subscript>, and AFBC12<subscript>16</subscript> are examples of numbers written in hexadecimal. A
 hexadecimal numeral can be expressed as the sum of products of powers of
-16. For example, the hexadecimal numeral A0BF can be expanded to:</simpara>
+16. For example, the hexadecimal numeral A0BF<subscript>16</subscript> can be expanded to:</simpara>
 <informalequation>
 <alt><![CDATA[\mathrm{A} \times 16^3+0 \times 16^2+ \mathrm{B} \times 16^1+ \mathrm{F} \times
 16^0]]></alt>
@@ -848,7 +863,8 @@ sum of products from above as:</simpara>
 <alt><![CDATA[10 \times 16^3+0 \times 16^2+11 \times 16^1+15 \times 16^0=40960+0+176+15=41151]]></alt>
 <mathphrase><![CDATA[10 \times 16^3+0 \times 16^2+11 \times 16^1+15 \times 16^0=40960+0+176+15=41151]]></mathphrase>
 </informalequation>
-<simpara>Thus, we get <inlineequation><alt><![CDATA[\mathrm{A}0\mathrm{BF}_{16} = 41151_{10}]]></alt><mathphrase><![CDATA[\mathrm{A}0\mathrm{BF}_{16} = 41151_{10}]]></mathphrase></inlineequation>.</simpara>
+<simpara>Thus, we get A0BF<subscript>16</subscript> = 41151<subscript>10</subscript>.</simpara>
+</example>
 <simpara>The base 8 number system is also called <emphasis>octal</emphasis>. Like hexadecimal, octal
 is used as a shorthand for binary. A numeral in octal uses the octal
 digits 0, 1, 2, 3, 4, 5, 6, and 7. Otherwise the same rules apply. For
@@ -862,15 +878,15 @@ written in. The digit sequence 337 is a legal numeral in octal, decimal,
 and hexadecimal, but it represents different numbers in each system.
 Mathematicians use a subscript to denote the base in which a numeral is
 written.</simpara>
-<simpara>Thus, <inlineequation><alt><![CDATA[337_8 = 255_{10}]]></alt><mathphrase><![CDATA[337_8 = 255_{10}]]></mathphrase></inlineequation>, <inlineequation><alt><![CDATA[377_{10} = 377_{10}]]></alt><mathphrase><![CDATA[377_{10} = 377_{10}]]></mathphrase></inlineequation>,
-and <inlineequation><alt><![CDATA[377_{16} = 887_{10}]]></alt><mathphrase><![CDATA[377_{16} = 887_{10}]]></mathphrase></inlineequation>. Base numbers are always written
+<simpara>Thus, 337<subscript>8</subscript> = 255<subscript>10</subscript>, 377<subscript>10</subscript> = 377<subscript>10</subscript>,
+and 377<subscript>16</subscript> = 887<subscript>10</subscript>. Base numbers are always written
 in base 10. A number without a subscript is assumed to be in base 10. In
-Java, there is no way to mark subscripts and so prefixes are used. A
-prefix of is used for octal, no prefix is used for decimal, and a prefix
-of is used for hexadecimal. A numeral cannot be marked as binary in
-Java. The corresponding numerals in Java code would thus be written , ,
-and . Be careful not to pad numbers with zeroes in Java. Remember that
-the value is <emphasis role="strong">not</emphasis> the same as the value in Java.</simpara>
+Java, there is no way to mark subscripts, and so prefixes are used. A
+prefix of <literal>0</literal> is used for octal, no prefix is used for decimal, and a prefix
+of <literal>0x</literal> is used for hexadecimal. A numeral cannot be marked as binary in
+Java. The corresponding numerals in Java code would thus be written <literal>0377</literal>, <literal>377</literal>,
+and <literal>0x377</literal>. Be careful not to pad numbers with zeroes in Java since they might be interpreted as base 8! Remember that
+the value <literal>056</literal> is <emphasis role="strong">not</emphasis> the same as the value <literal>56</literal> in Java.</simpara>
 <simpara>The following table lists a few characteristics of the four number
 systems we have discussed with representations of the numbers 7 and
 29.</simpara>
@@ -948,9 +964,12 @@ Subtract that value from the number, leaving 7 in this case. Then repeat
 the process. The last step is to collect the coefficients of the powers
 of two into a sequence to get the binary equivalent. We used 16, 4, 2,
 and 1 but skipped 8. If we write a 1 for every place we used and a 0 for
-every place we skipped, we get <inlineequation><alt><![CDATA[23=10111_2]]></alt><mathphrase><![CDATA[23=10111_2]]></mathphrase></inlineequation>. While this is a
+every place we skipped, we get 23 = 10111<subscript>2</subscript>. While this is a
 straightforward procedure for decimal to binary conversion, it can be
 cumbersome for larger numbers.</simpara>
+<sidebar>
+<simpara><link linkend="exercise1.6">Exercise 1.6</link></simpara>
+</sidebar>
 <simpara>An alternate way to convert a decimal numeral to an equivalent binary
 numeral is to divide the given number by 2 until the quotient is 0
 (keeping only the integer part of the quotient). At each step, record
@@ -958,7 +977,9 @@ the remainder found when dividing by 2. Collect these remainders (which
 will always be either 0 or 1) to form the binary equivalent. The least
 significant bit is the remainder obtained after the first division, and
 the most significant bit is the remainder obtained after the last
-division.</simpara>
+division.  In other words, this approach finds the digits of the binary number in the opposite order.</simpara>
+<example>
+<title>Decimal to binary with remainders</title>
 <simpara>Let&#8217;s use this method to convert 23 to its binary equivalent. The
 following table shows the steps need for the conversion. The leftmost
 column lists the step number. The second column contains the number to
@@ -1015,9 +1036,10 @@ each step, and the last column contains the current remainder.</simpara>
 <simpara>We begin by dividing 23 by 2, yielding 11 as the quotient and 1 as the
 remainder. The quotient 11 is then divided by 2, yielding 5 as the
 quotient and 1 as the remainder. This process continues until we get a
-quotient of 0 and a remainder of 1 in Step 5. We now collect the
-remainders and get the same result as before,
-<inlineequation><alt><![CDATA[23 = 10111_2]]></alt><mathphrase><![CDATA[23 = 10111_2]]></mathphrase></inlineequation>.</simpara>
+quotient of 0 and a remainder of 1 in Step 5. We now write the
+remainders from the most recent to the least recent and get the same result as before,
+23 = 10111<subscript>2</subscript>.</simpara>
+</example>
 </section>
 <section xml:id="_other_conversions">
 <title>Other conversions</title>
@@ -1026,6 +1048,9 @@ either of the two procedures described above. Instead of writing a
 decimal number as a sum of powers of 2, one writes it as a sum of powers
 of 16. Similarly, when using the division method, instead of dividing by
 2, one divides by 16. Octal conversion is similar.</simpara>
+<sidebar>
+<simpara><link linkend="exercise1.9">Exercise 1.9</link></simpara>
+</sidebar>
 <simpara>We use hexadecimal because it is straightforward to convert from it to
 binary or back. The following table lists binary equivalents for the 16
 hexadecimal digits.</simpara>
@@ -1098,11 +1123,15 @@ digit</entry>
 </tgroup>
 </informaltable>
 <simpara>With the help of the table above, let&#8217;s convert
-<inlineequation><alt><![CDATA[3\mathrm{FA}_{16}]]></alt><mathphrase><![CDATA[3\mathrm{FA}_{16}]]></mathphrase></inlineequation> to binary. By simple substitution,
-<inlineequation><alt><![CDATA[3\mathrm{FA}_{16} = 0011\mbox{ }1111\mbox{ }1010_2]]></alt><mathphrase><![CDATA[3\mathrm{FA}_{16} = 0011\mbox{ }1111\mbox{ }1010_2]]></mathphrase></inlineequation>.
+3FA<subscript>16</subscript> to binary. By simple substitution,
+3FA<subscript>16</subscript> = 0011 1111 1010<subscript>2</subscript>.
 Note that we have grouped the binary digits into clusters of
 4 bits each. Of course, the leftmost zeroes in the binary equivalent are
 useless as they do not contribute to the value of the number.</simpara>
+<sidebar>
+<simpara><link linkend="exercise1.10">Exercise 1.10</link><?asciidoc-br?>
+<link linkend="exercise1.11">Exercise 1.11</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_integer_representation_in_a_computer">
 <title>Integer representation in a computer</title>
@@ -1117,7 +1146,7 @@ representations for integers using 8 and 16 bits.</simpara>
 <simpara>These representations are easy to determine for positive numbers: Find
 the binary equivalent of the number and then pad the left side with
 zeroes to fill the remaining space. For example,
-<inlineequation><alt><![CDATA[19 = 10011_2]]></alt><mathphrase><![CDATA[19 = 10011_2]]></mathphrase></inlineequation>. If stored using 8 bits, 19 would be
+19 = 10011<subscript>2</subscript>. If stored using 8 bits, 19 would be
 represented as <literal>0001 0011</literal>. If stored using 16 bits, 19 would be
 represented as <literal>0000 0000 0001 0011</literal>. (We separate groups of 4 bits for
 easier reading.)</simpara>
@@ -1160,9 +1189,11 @@ that are too large into the next position. In decimal addition, values
 over 9 must to be carried. In binary addition, values over 1 must be
 carried. The next example shows a sample binary addition. To simplify
 its presentation, we assume that integers are represented with 8 bits.</simpara>
+<example>
+<title>Binary addition</title>
 <simpara>Let&#8217;s add the numbers 60 and 6 in binary. Using the conversion
-techniques described above, we can find that <inlineequation><alt><![CDATA[60 = 111100_2]]></alt><mathphrase><![CDATA[60 = 111100_2]]></mathphrase></inlineequation>
-and <inlineequation><alt><![CDATA[6 = 110_2]]></alt><mathphrase><![CDATA[6 = 110_2]]></mathphrase></inlineequation>. Inside the computer, these numbers would
+techniques described above, we can find that 60 = 111100<subscript>2</subscript>
+and 6 = 110<subscript>2</subscript>. Inside the computer, these numbers would
 already be in binary and padded to fill 8 bits.<?asciidoc-br?></simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
 <tgroup cols="3">
@@ -1197,6 +1228,7 @@ already be in binary and padded to fill 8 bits.<?asciidoc-br?></simpara>
 </informaltable>
 <simpara>The result is no surprise, but note that the addition can proceed in
 binary without conversion to decimal at any point.</simpara>
+</example>
 <simpara>Subtraction in binary is also similar to subtraction in decimal. The
 rules are given in the following table.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
@@ -1225,6 +1257,8 @@ rules are given in the following table.</simpara>
 </informaltable>
 <simpara>When subtracting a 1 from a 0, a 1 is borrowed from the next left
 position. The next example illustrates binary subtraction.</simpara>
+<example>
+<title>Binary subtraction</title>
 <simpara>Again, we&#8217;ll use 60 and 6 and their binary equivalents given above.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
 <tgroup cols="3">
@@ -1257,6 +1291,10 @@ position. The next example illustrates binary subtraction.</simpara>
 </tbody>
 </tgroup>
 </informaltable>
+</example>
+<sidebar>
+<simpara><link linkend="exercise1.17">Exercise 1.17</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_negative_integers_in_a_computer">
 <title>Negative integers in a computer</title>
@@ -1267,7 +1305,7 @@ binary representation of a signed integer in a computer, the leftmost
 is positive. Unfortunately, there&#8217;s more to finding the representation
 of a negative number than flipping this bit.</simpara>
 <simpara>Suppose that we need to find the binary equivalent of the decimal number
-<inlineequation><alt><![CDATA[-12]]></alt><mathphrase><![CDATA[-12]]></mathphrase></inlineequation> using 8-bits in two&#8217;s complement form. The first step
+-12 using 8-bits in two&#8217;s complement form. The first step
 is to convert 12 to its 8-bit binary equivalent. Doing so we get 12 =
 <literal>0000 1100</literal>. Note that the leftmost bit of the representation is a 0,
 indicating that the number is positive. Next we take the two&#8217;s
@@ -1279,13 +1317,25 @@ complement. The result is <literal>1111 0011</literal> + <literal>1</literal> = 
 <simpara>Thus, the 8-bit, two&#8217;s complement binary equivalent of -12 is
 <literal>1111 0100</literal>. Note that the leftmost bit is a 1, indicating that this is
 a negative number.</simpara>
-<simpara>Let us convert -29 to its binary equivalent assuming that the number is
+<sidebar>
+<simpara><link linkend="exercise1.7">Exercise 1.7</link><?asciidoc-br?>
+<link linkend="exercise1.8">Exercise 1.8</link></simpara>
+</sidebar>
+<example>
+<title>Decimal to two&#8217;s complement</title>
+<simpara>Let&#8217;s convert -29 to its binary equivalent assuming that the number is
 to be stored in 8-bit, two&#8217;s complement form. First we convert positive
-29 to its 8-bit binary equivalent, <inlineequation><alt><![CDATA[29 =]]></alt><mathphrase><![CDATA[29 =]]></mathphrase></inlineequation> <literal>0001 1101</literal>.</simpara>
+29 to its 8-bit binary equivalent, 29 = <literal>0001 1101</literal>.</simpara>
 <simpara>Next we obtain the one&#8217;s complement of the binary representation by
 flipping 0s to 1s and 1s to 0s. This gives us <literal>1110 0010</literal>. Finally, we
 add 1 to the one&#8217;s complement representation to get <literal>1110 0010</literal> + <literal>1</literal> =
 <literal>1110 0011</literal>, which is the desired binary equivalent of -29.</simpara>
+</example>
+<sidebar>
+<simpara><link linkend="exercise1.14">Exercise 1.14</link></simpara>
+</sidebar>
+<example>
+<title>Two&#8217;s complement to decimal</title>
 <simpara>Let us now convert the 8-bit, two&#8217;s complement value <literal>1000 1100</literal> to
 decimal. We note that the leftmost bit of this number is 1, making it a
 negative number. Therefore, we reverse the process of making a two&#8217;s
@@ -1294,6 +1344,10 @@ complement. First, we subtract 1 from the representation, yielding
 one&#8217;s complement form, yielding <literal>0111 0100</literal>.</simpara>
 <simpara>Now we convert this binary representation to its decimal equivalent,
 yielding 116. Thus, the decimal equivalent of <literal>1000 1100</literal> is -116.</simpara>
+</example>
+<sidebar>
+<simpara><link linkend="exercise1.15">Exercise 1.15</link></simpara>
+</sidebar>
 <simpara>Why do we use two&#8217;s complement? First of all, we needed a system that
 could represent both positive and negative numbers. We could have simply
 used the leftmost bit as a sign bit and represented the rest of the
@@ -1307,6 +1361,8 @@ bit, and values that carry past the leftmost bit are ignored. Two&#8217;s
 complement has an advantage over one&#8217;s complement in that there is only
 one representation for zero. The next example shows two&#8217;s complement in
 action.</simpara>
+<example>
+<title>Two&#8217;s complement arithmetic</title>
 <simpara>We&#8217;ll add -126 and 126. If you perform the needed conversions, their
 8-bit, two&#8217;s complement representations are <literal>1000 0010</literal> and <literal>0111 1110</literal>.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
@@ -1376,6 +1432,10 @@ complement representations are <literal>1000 0010</literal> and <literal>1111 11
 </informaltable>
 <simpara>The result is -128, which is the smallest negative integer that can be
 represented in 8-bit two&#8217;s complement.</simpara>
+</example>
+<sidebar>
+<simpara><link linkend="exercise1.16">Exercise 1.16</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_overflow_and_underflow">
 <title>Overflow and underflow</title>
@@ -1388,6 +1448,8 @@ smallest possible value.</simpara>
 example, adding two positive numbers together can result in a negative
 number or adding two negative numbers together can result in a positive
 number.</simpara>
+<example>
+<title>Binary addition with overflow</title>
 <simpara>Let&#8217;s add the numbers 124 and 6. Their 8-bit, two&#8217;s complement
 representations are <literal>0111 1100</literal> and <literal>0000 0110</literal>.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
@@ -1422,6 +1484,7 @@ representations are <literal>0111 1100</literal> and <literal>0000 0110</literal
 <simpara>This surprising result happens because the largest 8-bit two&#8217;s
 complement integer is 127. Adding 124 and 6 yields 130, a value larger
 than this maximum, resulting in overflow with a negative answer.</simpara>
+</example>
 <simpara>The smallest (most negative) number that can be represented in 8-bit
 two&#8217;s complement is -128. A result smaller than this will result in
 underflow. For example, -115 - 31 = 110. Try out the conversions needed
@@ -1522,12 +1585,14 @@ shift moves the bits to the right, including the sign bit, filling the
 left side with 0s. And unsigned right shift will always make a value
 positive but is otherwise similar to a signed right shift. A few
 examples follow.</simpara>
+<example>
+<title>Bitwise operators</title>
 <simpara>Here are a few examples of the result of bitwise operations. We will
 assume that the values are represented using 32-bit two&#8217;s complement,
 instead of using 8-bit values as before. In Java, bitwise operators
 automatically convert smaller values to 32-bit representations before
 proceeding.</simpara>
-<simpara>Let&#8217;s consider the result of <inlineequation><alt><![CDATA[21 \& 27]]></alt><mathphrase><![CDATA[21 \& 27]]></mathphrase></inlineequation>.</simpara>
+<simpara>Let&#8217;s consider the result of <literal>21 &amp; 27</literal>.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
 <tgroup cols="3">
 <colspec colname="col_1" colwidth="33.3333*"/>
@@ -1559,7 +1624,7 @@ proceeding.</simpara>
 </tbody>
 </tgroup>
 </informaltable>
-<simpara>Note how this result is different from <inlineequation><alt><![CDATA[21 | 27]]></alt><mathphrase><![CDATA[21 | 27]]></mathphrase></inlineequation>.</simpara>
+<simpara>Note how this result is different from <literal>21 | 27</literal>.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
 <tgroup cols="3">
 <colspec colname="col_1" colwidth="33.3333*"/>
@@ -1591,7 +1656,7 @@ proceeding.</simpara>
 </tbody>
 </tgroup>
 </informaltable>
-<simpara>And also from <inlineequation><alt><![CDATA[21 \land 27]]></alt><mathphrase><![CDATA[21 \land 27]]></mathphrase></inlineequation>.</simpara>
+<simpara>And also from <literal>21 ^ 27</literal>.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
 <tgroup cols="3">
 <colspec colname="col_1" colwidth="33.3333*"/>
@@ -1626,27 +1691,23 @@ proceeding.</simpara>
 <simpara>Ignoring overflows, signed left shifting is equivalent to repeated
 multiplications by 2. Consider <literal>11 &lt;&lt; 3</literal>. The representation
 <literal>0000 0000 0000 0000 0000 0000 0000 1011</literal> is shifted to the left to make
-<literal>0000 0000 0000 0000 0000 0000 0101 1000</literal>
-<inlineequation><alt><![CDATA[= 88 = 11\times 2^3]]></alt><mathphrase><![CDATA[= 88 = 11\times 2^3]]></mathphrase></inlineequation>.</simpara>
+<literal>0000 0000 0000 0000 0000 0000 0101 1000</literal> = 88 = 11 × 2<superscript>3</superscript>.</simpara>
 <simpara>Signed right shifting is equivalent to repeated integer divisions by 2.
 Consider <literal>-104 &gt;&gt; 2</literal>. The representation
 <literal>1111 1111 1111 1111 1111 1111 1001 1000</literal> is shifted to the right to
-make <literal>1111 1111 1111 1111 1111 1111 1110 0110</literal>
-<inlineequation><alt><![CDATA[= -26 = -104\div 2^2]]></alt><mathphrase><![CDATA[= -26 = -104\div 2^2]]></mathphrase></inlineequation>.</simpara>
+make <literal>1111 1111 1111 1111 1111 1111 1110 0110</literal> = -26 = -104 ÷ 2<superscript>2</superscript>.</simpara>
 <simpara>Unsigned right shifting is the same as signed right shifting except when
 it is done on negative numbers. Since their sign bit is replaced by <literal>0</literal>,
 an unsigned right shift produces a (generally large) positive number.
 Consider <literal>-104 &gt;&gt;&gt; 2</literal>. The representation
 <literal>1111 1111 1111 1111 1111 1111 1001 1000</literal> is shifted to the right to
-make <literal>0011 1111 1111 1111 1111 1111 1110 0110</literal>
-<inlineequation><alt><![CDATA[= 1,073,741,798]]></alt><mathphrase><![CDATA[= 1,073,741,798]]></mathphrase></inlineequation>.</simpara>
+make <literal>0011 1111 1111 1111 1111 1111 1110 0110</literal> = 1,073,741,798.</simpara>
 <simpara>Because of the way two&#8217;s complement is designed, bitwise complement is
 equivalent to negating the sign of the number and then subtracting
-<inlineequation><alt><![CDATA[1]]></alt><mathphrase><![CDATA[1]]></mathphrase></inlineequation>. Consider <literal>~(-104)</literal>. The
+1. Consider <literal>~(-104)</literal>. The
 representation <literal>1111 1111 1111 1111 1111 1111 1001 1000</literal> is complemented
-to <literal>0000 0000 0000 0000 0000 0000 0110 0111</literal> <inlineequation><alt><![CDATA[=
-103]]></alt><mathphrase><![CDATA[=
-103]]></mathphrase></inlineequation>.</simpara>
+to <literal>0000 0000 0000 0000 0000 0000 0110 0111</literal> = 103.</simpara>
+</example>
 </section>
 <section xml:id="_rational_numbers">
 <title>Rational numbers</title>
@@ -1663,8 +1724,8 @@ of zeroes. A decimal number in scientific notation is written
 <inlineequation><alt><![CDATA[a\times 10^b]]></alt><mathphrase><![CDATA[a\times 10^b]]></mathphrase></inlineequation> where <inlineequation><alt><![CDATA[a]]></alt><mathphrase><![CDATA[a]]></mathphrase></inlineequation> is called the
 <emphasis>mantissa</emphasis> and <inlineequation><alt><![CDATA[b]]></alt><mathphrase><![CDATA[b]]></mathphrase></inlineequation> is called the <emphasis>exponent</emphasis>.</simpara>
 <simpara>For example, the number 3.14159 can be written in scientific notation as
-<inlineequation><alt><![CDATA[0.314159\times 10^1]]></alt><mathphrase><![CDATA[0.314159\times 10^1]]></mathphrase></inlineequation>. In this case, <inlineequation><alt><![CDATA[0.314159]]></alt><mathphrase><![CDATA[0.314159]]></mathphrase></inlineequation>
-is the mantissa, and <inlineequation><alt><![CDATA[1]]></alt><mathphrase><![CDATA[1]]></mathphrase></inlineequation> is the exponent. Here a few more
+0.314159 × 10<superscript>1</superscript>. In this case, 0.314159
+is the mantissa, and 1 is the exponent. Here a few more
 examples of writing numbers in scientific notation.<?asciidoc-br?>
 <inlineequation><alt><![CDATA[\begin{array}{ l c l}
 3.14159&=&3.14159\times 10^0\\
@@ -1693,10 +1754,9 @@ notation.<?asciidoc-br?>
 30,000&=& 3.0\times10^4\\
 \end{array}]]></mathphrase></inlineequation><?asciidoc-br?>
 A shorthand for scientific notation is E notation, which is written with
-the mantissa followed by the letter `E' followed by the exponent. For
-example, 39.2 in E notation can be written <inlineequation><alt><![CDATA[3.92\mathrm{E}1]]></alt><mathphrase><![CDATA[3.92\mathrm{E}1]]></mathphrase></inlineequation>
-or <inlineequation><alt><![CDATA[0.392\mathrm{E}2]]></alt><mathphrase><![CDATA[0.392\mathrm{E}2]]></mathphrase></inlineequation>. The letter `E' should be read
-``multiplied by 10 to the power.'' E notation can be used to represent
+the mantissa followed by the letter &#8216;E&#8217; followed by the exponent. For
+example, 39.2 in E notation can be written 3.92E1 or 0.392E2. The letter &#8216;E&#8217; should be read
+&#8220;multiplied by 10 to the power.&#8221; E notation can be used to represent
 numbers in scientific notation in Java. Instead of writing the number in
 Java code, or could be used instead.</simpara>
 </section>
@@ -1717,8 +1777,10 @@ fraction reduces to zero or enough binary digits for the desired
 precision have been found. The binary equivalent of <inlineequation><alt><![CDATA[f]]></alt><mathphrase><![CDATA[f]]></mathphrase></inlineequation> then
 consists of the bits in the order they have been recorded, as shown in
 the next example.</simpara>
+<example>
+<title>Fraction conversion to binary</title>
 <simpara>Let&#8217;s convert 0.8125 to binary. The table below shows the steps to do
-so.<?asciidoc-br?></simpara>
+so.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
 <tgroup cols="5">
 <colspec colname="col_1" colwidth="20*"/>
@@ -1767,19 +1829,22 @@ so.<?asciidoc-br?></simpara>
 </tbody>
 </tgroup>
 </informaltable>
-<simpara>We then collect all the integer parts and get 0.1101 as the binary
+<simpara>We then collect all the integer parts and get 0.1101<subscript>2</subscript> as the binary
 equivalent of 0.8125. We can convert this binary fraction back into
 decimal to verify that it is correct.</simpara>
 <informalequation>
-<alt><![CDATA[0.1101=1\times 2^{-1}+1\times2^{-2}+0\times 2^{-3}+1\times
+<alt><![CDATA[0.1101_2=1\times 2^{-1}+1\times2^{-2}+0\times 2^{-3}+1\times
 2^{-4}=0.5+0.25+0+0.0625=0.8125]]></alt>
-<mathphrase><![CDATA[0.1101=1\times 2^{-1}+1\times2^{-2}+0\times 2^{-3}+1\times
+<mathphrase><![CDATA[0.1101_2=1\times 2^{-1}+1\times2^{-2}+0\times 2^{-3}+1\times
 2^{-4}=0.5+0.25+0+0.0625=0.8125]]></mathphrase>
 </informalequation>
+</example>
 <simpara>In some cases, the process described above will never have a remainder
 of 0. In such cases we can only find an approximate representation of
 the given fraction as demonstrated in the next example.</simpara>
-<simpara>Let us convert 0.3 to binary assuming that we have only five bits in
+<example xml:id="Non-terminating_fraction">
+<title>Non-terminating fraction</title>
+<simpara>Let&#8217;s convert 0.3 to binary assuming that we have only five bits in
 which to represent the fraction. The following table shows the five
 steps in the conversion process.<?asciidoc-br?></simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
@@ -1837,28 +1902,36 @@ steps in the conversion process.<?asciidoc-br?></simpara>
 </tbody>
 </tgroup>
 </informaltable>
-<simpara>Collecting the integer parts we get 0.01001 as the binary representation
+<simpara>Collecting the integer parts we get 0.01001<subscript>2</subscript> as the binary representation
 of 0.3. Let&#8217;s convert this back to decimal to see how accurate it is.</simpara>
 <informalequation>
-<alt><![CDATA[0.01001=0\times2^{-1}+1\times 2^{-2}+ 0\times2^{-3}+ 0\times 2^{-4}+ 1\times
+<alt><![CDATA[0.01001_2=0\times2^{-1}+1\times 2^{-2}+ 0\times2^{-3}+ 0\times 2^{-4}+ 1\times
 2^{-5}= 0.25+0.03125=0.28125]]></alt>
-<mathphrase><![CDATA[0.01001=0\times2^{-1}+1\times 2^{-2}+ 0\times2^{-3}+ 0\times 2^{-4}+ 1\times
+<mathphrase><![CDATA[0.01001_2=0\times2^{-1}+1\times 2^{-2}+ 0\times2^{-3}+ 0\times 2^{-4}+ 1\times
 2^{-5}= 0.25+0.03125=0.28125]]></mathphrase>
 </informalequation>
 <simpara>Five bits are not enough to represent 0.3 fully. In this case, we have
-an error of <inlineequation><alt><![CDATA[0.3 - 0.28125=0.01875]]></alt><mathphrase><![CDATA[0.3 - 0.28125=0.01875]]></mathphrase></inlineequation>. Most computers use many
+an error of 0.3 - 0.28125 = 0.01875. Most computers use many
 more bits to represent fractions and obtain much better accuracy in
 their representation.</simpara>
+</example>
+<sidebar>
+<simpara><link linkend="exercise1.18">Exercise 1.18</link><?asciidoc-br?>
+<link linkend="exercise1.19">Exercise 1.19</link></simpara>
+</sidebar>
 <simpara>Now that we understand how integers as well as fractions can be
 converted from one number base to another, we can convert any rational
 number from one base to another. The next example demonstrates one such
 conversion.</simpara>
+<example>
+<title>Rational number converted to binary</title>
 <simpara>Let&#8217;s convert 14.3 to binary assuming that we will only use six bits to
 represent the fractional part. First we convert 14 to binary using the
-technique described earlier. This gives us <inlineequation><alt><![CDATA[14 = 1110_{2}]]></alt><mathphrase><![CDATA[14 = 1110_{2}]]></mathphrase></inlineequation>.
+technique described earlier. This gives us 14 = 1110<subscript>2</subscript>.
 Taking the method outlined in Example  one step further, our six bit
-representation of 0.3 is 0.010011. Combining the two representations
-gives <inlineequation><alt><![CDATA[14.3_{10} = 1110.010011_{2}]]></alt><mathphrase><![CDATA[14.3_{10} = 1110.010011_{2}]]></mathphrase></inlineequation>.</simpara>
+representation of 0.3 is 0.010011<subscript>2</subscript>. Combining the two representations
+gives 14.3 = 1110.010011<subscript>2</subscript>.</simpara>
+</example>
 </section>
 <section xml:id="_floating_point_notation">
 <title>Floating point notation</title>
@@ -1869,9 +1942,9 @@ in computer memory. In this notation a number is represented as
 exponent. The system is very similar to scientific notation, but
 computers usually have base <inlineequation><alt><![CDATA[b = 2]]></alt><mathphrase><![CDATA[b = 2]]></mathphrase></inlineequation> instead of
 <inlineequation><alt><![CDATA[10]]></alt><mathphrase><![CDATA[10]]></mathphrase></inlineequation>.</simpara>
-<simpara>For example, we could write the binary number 1010.1 in floating point
-notation as <inlineequation><alt><![CDATA[10.101\times 2^2]]></alt><mathphrase><![CDATA[10.101\times 2^2]]></mathphrase></inlineequation> or as
-<inlineequation><alt><![CDATA[101.01\times2^1]]></alt><mathphrase><![CDATA[101.01\times2^1]]></mathphrase></inlineequation>. In any case, this number is equivalent to
+<simpara>For example, we could write the binary number 1010.1<subscript>2</subscript> in floating point
+notation as 10.101<subscript>2</subscript> × 2<superscript>2</superscript> or as
+101.01<subscript>2</subscript> × 2<superscript>1</superscript>. In any case, this number is equivalent to
 10.5 in decimal.</simpara>
 <simpara>In standardized floating point notation, <inlineequation><alt><![CDATA[a]]></alt><mathphrase><![CDATA[a]]></mathphrase></inlineequation> is written so
 that only the most significant non-zero digit is to the left of the
@@ -1890,20 +1963,22 @@ exponent has a <emphasis>bias</emphasis> added to it so that the result is never
 This bias is 127 for single precision and 1,023 for double precision.
 The packing of the sign bit, the exponent, and the mantissa is shown in
 <xref linkend="numberRepresentationFigure"/> (a) and (b).</simpara>
+<example>
+<title>Single precision IEEE format</title>
 <simpara>The following is a step-by-step demonstration of how to construct the
 single precision binary representation in IEEE format of the number
 10.5.</simpara>
 <orderedlist numeration="start">
 <listitem>
 <simpara>Convert 10.5 to its binary equivalent using methods described
-earlier, yielding <inlineequation><alt><![CDATA[10.5_{10} = 1010.1_{2}]]></alt><mathphrase><![CDATA[10.5_{10} = 1010.1_{2}]]></mathphrase></inlineequation>. Unlike the case
+earlier, yielding 10.5<subscript>10</subscript> = 1010.1<subscript>2</subscript>. Unlike the case
 of integers, the sign of the number is taken care of separately for
-floating point. Thus, we would use <inlineequation><alt><![CDATA[1010.1_2]]></alt><mathphrase><![CDATA[1010.1_2]]></mathphrase></inlineequation> for
-<inlineequation><alt><![CDATA[-10.5]]></alt><mathphrase><![CDATA[-10.5]]></mathphrase></inlineequation> as well.</simpara>
+floating point. Thus, we would use 1010.1<subscript>2</subscript> for
+-10.5 as well.</simpara>
 </listitem>
 <listitem>
 <simpara>Write this binary number in standardized floating point notation,
-yielding <inlineequation><alt><![CDATA[1.0101\times2^3]]></alt><mathphrase><![CDATA[1.0101\times2^3]]></mathphrase></inlineequation>.</simpara>
+yielding 1.0101<subscript>2</subscript> × 2<superscript>3</superscript>.</simpara>
 </listitem>
 <listitem>
 <simpara>Remove the leading bit (always a 1 for non-zero numbers), leaving <literal>0101</literal>.</simpara>
@@ -1915,11 +1990,11 @@ point is ignored in this step.</simpara>
 </listitem>
 <listitem>
 <simpara>Add 127 to the exponent. This gives us an exponent of
-<inlineequation><alt><![CDATA[3+127=130]]></alt><mathphrase><![CDATA[3+127=130]]></mathphrase></inlineequation>.</simpara>
+3 + 127 = 130.</simpara>
 </listitem>
 <listitem>
 <simpara>Convert the exponent to its 8-bit unsigned binary equivalent. Doing
-so gives us <inlineequation><alt><![CDATA[130_{10}=10000011_2]]></alt><mathphrase><![CDATA[130_{10}=10000011_2]]></mathphrase></inlineequation>.</simpara>
+so gives us 130<subscript>10</subscript> = 10000011<subscript>2</subscript>.</simpara>
 </listitem>
 <listitem>
 <simpara>Set the sign bit to 0 if the number is positive and to 1 otherwise.
@@ -1930,8 +2005,12 @@ Since 10.5 is positive, we set the sign bit to 0.</simpara>
 representation of 10.5 is shown in <xref linkend="numberRepresentationFigure"/> (c).
 Note in the figure how the sign bit, the exponent, and the mantissa are
 packed into 32 bits.</simpara>
+</example>
+<sidebar>
+<simpara><link linkend="exercise1.20">Exercise 1.20</link></simpara>
+</sidebar>
 <figure xml:id="numberRepresentationFigure">
-<title>Layouts for floating point representation (a) in single precision, (b) in double precision, and (c) of <inlineequation><alt><![CDATA[10.5_{10}]]></alt><mathphrase><![CDATA[10.5_{10}]]></mathphrase></inlineequation> in single precision.</title>
+<title>Layouts for floating point representation (a) in single precision, (b) in double precision, and (c) of 10.5<subscript>10</subscript> in single precision.</title>
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/01-computer-basics/images/numberRepresentationFigure.svg" width="100%"/>
@@ -1948,20 +2027,19 @@ point notation. The largest rational number that can be represented in
 single precision has an exponent of 127 (254 after bias) with a mantissa
 consisting of all 1s:<?asciidoc-br?>
 <literal>0 1111 1110 1111 1111 1111 1111 1111 111</literal><?asciidoc-br?>
-This number is approximately <inlineequation><alt><![CDATA[3.402\times10^{38}]]></alt><mathphrase><![CDATA[3.402\times10^{38}]]></mathphrase></inlineequation>. To
+This number is approximately 3.402 × 10<superscript>38</superscript>. To
 represent the smallest (closest to zero) non-zero number, we need to
 examine one more complication in the IEEE format. An exponent of 0
 implies that the number is unnormalized. In this case, we no longer
 assume that there is a 1 bit to the left of the mantissa. Thus, the
 smallest non-zero single precision number has its exponent set to 0 and
 its mantissa set to all zeros with a 1 in its
-23<inlineequation><alt><![CDATA[^{\mathrm{rd}}]]></alt><mathphrase><![CDATA[^{\mathrm{rd}}]]></mathphrase></inlineequation> bit:<?asciidoc-br?>
+23<superscript>rd</superscript> bit:<?asciidoc-br?>
 <literal>0 0000 0000 0000 0000 0000 0000 0000 001</literal><?asciidoc-br?>
 Unnormalized single precision values are considered to have an exponent
 of -126. Thus, the value of this number is
-<inlineequation><alt><![CDATA[2^{-23} \times 2^{-126} =
-2^{-149} \approx 1.4 \times 10^{-45}.]]></alt><mathphrase><![CDATA[2^{-23} \times 2^{-126} =
-2^{-149} \approx 1.4 \times 10^{-45}.]]></mathphrase></inlineequation> Now that we know the rules for
+2<superscript>-23</superscript> × 2<superscript>-126</superscript> =
+2<superscript>-149</superscript> ≈ 1.4 × 10<superscript>-45</superscript>. Now that we know the rules for
 storing both integers and floating point numbers, we can list the
 largest and smallest values possible in 32- and 64-bit representations
 in Java as shown in the following table. Note that <emphasis role="strong">largest</emphasis> means the
@@ -2036,8 +2114,7 @@ number is the special value that Java recognizes as infinity. In the
 case of an underflow, it is a special negative infinity value. For
 example, dividing 1.0 by 0.0 in Java results in infinity and dividing
 -1.0 by 0.0 results in negative infinity. These values have well
-defined behavior. For example, adding 1.0 to infinity yields infinity.
-+
+defined behavior. For example, adding 1.0 to infinity yields infinity.<?asciidoc-br?>
 Note that floating point values and integers do not behave in the same
 way. Dividing the integer 1 by the integer 0 creates an error that can
 crash a Java program.</simpara>
@@ -2062,12 +2139,12 @@ negative number.</simpara>
 represented in computer memory. Thus, arithmetic done on the approximate
 values yields approximate answers. For example, 1.3 cannot be
 represented exactly using a 32-bit value. In this case, the product
-<inlineequation><alt><![CDATA[1.3\times
-3.0]]></alt><mathphrase><![CDATA[1.3\times
-3.0]]></mathphrase></inlineequation> will be 3.8999999 instead of 3.9. This error will propagate as
+1.3 × 3.0 will be 3.8999999 instead of 3.9. This error will propagate as
 additional operations are performed on previous results. The next
 example illustrates this propagation of errors when a sequence of
 floating point operations are performed.</simpara>
+<example>
+<title>Error propagation</title>
 <simpara>Suppose that the price of several products is to be added to determine
 the total price of a purchase at a cash register that uses floating-point arithmetic with a 32-bit variable (the equivalent of a <literal>float</literal> in Java).
 For simplicity, let&#8217;s assume that all items have a
@@ -2130,6 +2207,7 @@ point addition. The fourth and fifth columns give the absolute and
 relative errors, respectively, of the calculated value. Note how the
 error increases as the number of additions goes up. In the last row, the
 absolute error is almost two dollars.</simpara>
+</example>
 <simpara>While the above example may seem unrealistic, it does expose the
 inherent dangers of floating-point calculations. Although the errors are
 much less when using double precision representations, they still exist.</simpara>
@@ -2304,7 +2382,7 @@ bigger cache means better performance. Using a solid state drive (SSD)
 instead of a traditional hard drive has much better performance but
 higher cost.</simpara>
 <simpara>Installing optical drives and other storage devices depends on
-individual needs. Note that a DVD<inlineequation><alt><![CDATA[\pm]]></alt><mathphrase><![CDATA[\pm]]></mathphrase></inlineequation>RW drive is an
+individual needs. Note that a DVD-RW drive is an
 inexpensive solution for backing up data or reinstalling an operating
 system.</simpara>
 </listitem>
@@ -2366,7 +2444,7 @@ problem eight times as fast. A desktop processor with 100 cores that can
 solve a problem 100 times faster is not out of reach.</simpara>
 <simpara>In fact, modern graphics cards are already blazing this trail. Consider
 the 1080p standard for high definition video, which has a resolution of
-1,920 <inlineequation><alt><![CDATA[\times]]></alt><mathphrase><![CDATA[\times]]></mathphrase></inlineequation> 1,080 <emphasis>pixels</emphasis>. Each pixel (short for picture
+1,920 × 1,080 <emphasis>pixels</emphasis>. Each pixel (short for picture
 element) is a dot on the screen. A screen whose resolution is 1080p has
 2,073,600 dots. To maintain the illusion of smooth movement, these dots
 should be updated around 30 times per second. Computing the color for
@@ -2376,6 +2454,9 @@ render computer games have hundreds or thousands of cores. These cores
 are not general purpose or completely independent. Instead, they&#8217;re
 specialized to do certain kinds of matrix transformations and floating
 point computations.</simpara>
+<sidebar>
+<simpara><link linkend="exercise1.23">Exercise 1.23</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_the_bad">
 <title>The Bad</title>
@@ -2468,8 +2549,9 @@ point and how much precision) as well as what kind of errors to expect
 specific types of data that Java uses and introduces representation
 systems for individual characters and text.</simpara>
 </section>
-<section xml:id="_problems">
-<title>Problems</title>
+<section xml:id="_exercises">
+<title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
 <simpara>Name a few programming languages other than Java.</simpara>
@@ -2482,94 +2564,92 @@ systems for individual characters and text.</simpara>
 ahead-of-time compilation?</simpara>
 </listitem>
 <listitem>
-<simpara>Without converting to decimal, how can one find out whether a given
+<simpara><anchor xml:id="exercise1.4" xreflabel="[exercise1.4]"/> Without converting to decimal, how can one find out whether a given
 binary number is odd or even?</simpara>
 </listitem>
 <listitem>
-<simpara>Convert the following positive binary numbers into decimal.</simpara>
+<simpara><anchor xml:id="exercise1.5" xreflabel="[exercise1.5]"/> Convert the following positive binary numbers into decimal.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
-<simpara><inlineequation><alt><![CDATA[100_2]]></alt><mathphrase><![CDATA[100_2]]></mathphrase></inlineequation></simpara>
+<simpara>100<subscript>2</subscript></simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[111_2]]></alt><mathphrase><![CDATA[111_2]]></mathphrase></inlineequation></simpara>
+<simpara>111<subscript>2</subscript></simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[100000_2]]></alt><mathphrase><![CDATA[100000_2]]></mathphrase></inlineequation></simpara>
+<simpara>100000<subscript>2</subscript></simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[111101_2]]></alt><mathphrase><![CDATA[111101_2]]></mathphrase></inlineequation></simpara>
+<simpara>111101<subscript>2</subscript></simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[10101_2]]></alt><mathphrase><![CDATA[10101_2]]></mathphrase></inlineequation></simpara>
+<simpara>10101<subscript>2</subscript></simpara>
 </listitem>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Convert the following positive decimal numbers into binary.</simpara>
+<simpara><anchor xml:id="exercise1.6" xreflabel="[exercise1.6]"/> Convert the following positive decimal numbers into binary.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
-<simpara><inlineequation><alt><![CDATA[1]]></alt><mathphrase><![CDATA[1]]></mathphrase></inlineequation></simpara>
+<simpara>1</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[15]]></alt><mathphrase><![CDATA[15]]></mathphrase></inlineequation></simpara>
+<simpara>15</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[100]]></alt><mathphrase><![CDATA[100]]></mathphrase></inlineequation></simpara>
+<simpara>100</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[1025]]></alt><mathphrase><![CDATA[1025]]></mathphrase></inlineequation></simpara>
+<simpara>1,025</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[567,899]]></alt><mathphrase><![CDATA[567,899]]></mathphrase></inlineequation></simpara>
+<simpara>567,899</simpara>
 </listitem>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>What is the process for converting the representation of a binary
+<simpara><anchor xml:id="exercise1.7" xreflabel="[exercise1.7]"/> What is the process for converting the representation of a binary
 integer given in one&#8217;s complement into two&#8217;s complement?</simpara>
 </listitem>
 <listitem>
-<simpara>Perform the conversion from one&#8217;s complement to two&#8217;s complement on the
+<simpara><anchor xml:id="exercise1.8" xreflabel="[exercise1.8]"/> Perform the conversion from one&#8217;s complement to two&#8217;s complement on the
 representation <literal>1011 0111</literal>, which uses 8 bits for storage.</simpara>
 </listitem>
 <listitem>
-<simpara>Convert the following decimal numbers to their hexadecimal and octal
+<simpara><anchor xml:id="exercise1.9" xreflabel="[exercise1.9]"/> Convert the following decimal numbers to their hexadecimal and octal
 equivalents.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
-<simpara><inlineequation><alt><![CDATA[29]]></alt><mathphrase><![CDATA[29]]></mathphrase></inlineequation></simpara>
+<simpara>29</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[100]]></alt><mathphrase><![CDATA[100]]></mathphrase></inlineequation></simpara>
+<simpara>100</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[255]]></alt><mathphrase><![CDATA[255]]></mathphrase></inlineequation></simpara>
+<simpara>255</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[382]]></alt><mathphrase><![CDATA[382]]></mathphrase></inlineequation></simpara>
+<simpara>382</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[4,096]]></alt><mathphrase><![CDATA[4,096]]></mathphrase></inlineequation></simpara>
+<simpara>4,096</simpara>
 </listitem>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Create a table similar to the one on page  that lists the binary
-equivalents of octal digits. Hint: Each octal digit can be represented
-as a sequence of three binary digits.</simpara>
+<simpara><anchor xml:id="exercise1.10" xreflabel="[exercise1.10]"/> Create a table that lists the binary equivalents of octal digits, similar to the one in <xref linkend="_other_conversions"/>. Hint: Each octal digit can be represented as a sequence of three binary digits.</simpara>
 </listitem>
 <listitem>
-<simpara>Use this table to convert the following octal numbers to binary.</simpara>
+<simpara><anchor xml:id="exercise1.11" xreflabel="[exercise1.11]"/> Use this table to convert the following octal numbers to binary.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
-<simpara><inlineequation><alt><![CDATA[337_8]]></alt><mathphrase><![CDATA[337_8]]></mathphrase></inlineequation></simpara>
+<simpara>337<subscript>8</subscript></simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[24_8]]></alt><mathphrase><![CDATA[24_8]]></mathphrase></inlineequation></simpara>
+<simpara>24<subscript>8</subscript></simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[777_8]]></alt><mathphrase><![CDATA[777_8]]></mathphrase></inlineequation></simpara>
+<simpara>777<subscript>8</subscript></simpara>
 </listitem>
 </orderedlist>
 </listitem>
@@ -2581,33 +2661,33 @@ to construct numbers.</simpara>
 <simpara>Convert the following decimal numbers to their ternary equivalents.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
-<simpara><inlineequation><alt><![CDATA[23]]></alt><mathphrase><![CDATA[23]]></mathphrase></inlineequation></simpara>
+<simpara>23</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[333]]></alt><mathphrase><![CDATA[333]]></mathphrase></inlineequation></simpara>
+<simpara>333</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[729]]></alt><mathphrase><![CDATA[729]]></mathphrase></inlineequation></simpara>
+<simpara>729</simpara>
 </listitem>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Convert the following decimal numbers to 8-bit, two&#8217;s complement binary
+<simpara><anchor xml:id="exercise1.14" xreflabel="[exercise1.14]"/> Convert the following decimal numbers to 8-bit, two&#8217;s complement binary
 representations.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
-<simpara><inlineequation><alt><![CDATA[-15]]></alt><mathphrase><![CDATA[-15]]></mathphrase></inlineequation></simpara>
+<simpara>-15</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[-101]]></alt><mathphrase><![CDATA[-101]]></mathphrase></inlineequation></simpara>
+<simpara>-101</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[-120]]></alt><mathphrase><![CDATA[-120]]></mathphrase></inlineequation></simpara>
+<simpara>-120</simpara>
 </listitem>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Given the following 8-bit binary representations in two&#8217;s complement,
+<simpara><anchor xml:id="exercise1.15" xreflabel="[exercise1.15]"/> Given the following 8-bit binary representations in two&#8217;s complement,
 find their decimal equivalents.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
@@ -2622,7 +2702,7 @@ find their decimal equivalents.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Perform the following arithmetic operation on the following 8-bit, two&#8217;s
+<simpara><anchor xml:id="exercise1.16" xreflabel="[exercise1.16]"/> Perform the following arithmetic operation on the following 8-bit, two&#8217;s
 complement binary representations of integers. Check your answers by
 performing arithmetic on equivalent decimal numbers.</simpara>
 <orderedlist numeration="loweralpha">
@@ -2644,41 +2724,41 @@ performing arithmetic on equivalent decimal numbers.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Extrapolate the rules for decimal and binary addition to rules for the
+<simpara><anchor xml:id="exercise1.17" xreflabel="[exercise1.17]"/> Extrapolate the rules for decimal and binary addition to rules for the
 hexadecimal system. Then, use these rules to perform the following
 additions in hexadecimal. Check your answers by converting the values
 and their sums to decimal.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
-<simpara><inlineequation><alt><![CDATA[\mathrm{A}2\mathrm{F}_{16} + \mathrm{BB}_{16} =]]></alt><mathphrase><![CDATA[\mathrm{A}2\mathrm{F}_{16} + \mathrm{BB}_{16} =]]></mathphrase></inlineequation><?asciidoc-br?></simpara>
+<simpara>A2F<subscript>16</subscript> + BB<subscript>16</subscript> =</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[32\mathrm{C}_{16} + \mathrm{D}11\mathrm{F}_{16} =]]></alt><mathphrase><![CDATA[32\mathrm{C}_{16} + \mathrm{D}11\mathrm{F}_{16} =]]></mathphrase></inlineequation><?asciidoc-br?></simpara>
+<simpara>32C<subscript>16</subscript> + D11F<subscript>16</subscript> =</simpara>
 </listitem>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Expand Example  assuming that you have ten bits to represent the
+<simpara><anchor xml:id="exercise1.18" xreflabel="[exercise1.18]"/> Expand <xref linkend="Non-terminating_fraction"/> assuming that you have ten bits to represent the
 fraction. Convert the representation back to base 10. How far off is
 this value from 0.3?</simpara>
 </listitem>
 <listitem>
-<simpara>Will the process in Example  ever terminate assuming that we can use as
+<simpara><anchor xml:id="exercise1.19" xreflabel="[exercise1.19]"/> Will the process in <xref linkend="Non-terminating_fraction"/> ever terminate assuming that we can use as
 many bits as needed to represent 0.3 in binary?</simpara>
 </listitem>
 <listitem>
-<simpara>Derive the binary representation of the following decimal numbers
+<simpara><anchor xml:id="exercise1.20" xreflabel="[exercise1.20]"/> Derive the binary representation of the following decimal numbers
 assuming 32-bit (single) precision representation using the IEEE
 floating point format.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
-<simpara><inlineequation><alt><![CDATA[0.0125]]></alt><mathphrase><![CDATA[0.0125]]></mathphrase></inlineequation></simpara>
+<simpara>0.0125</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[7.7]]></alt><mathphrase><![CDATA[7.7]]></mathphrase></inlineequation></simpara>
+<simpara>7.7</simpara>
 </listitem>
 <listitem>
-<simpara><inlineequation><alt><![CDATA[-10.3]]></alt><mathphrase><![CDATA[-10.3]]></mathphrase></inlineequation></simpara>
+<simpara>-10.3</simpara>
 </listitem>
 </orderedlist>
 </listitem>
@@ -2718,7 +2798,7 @@ expressions are still always true and which are sometimes false.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>What is a multicore microprocessor? Why do you think a multicore chip
+<simpara><anchor xml:id="exercise1.23" xreflabel="[exercise1.23]"/> What is a multicore microprocessor? Why do you think a multicore chip
 might be better than a single core chip? Search on the Internet to find
 the names of a few common multicore chips. Which chip does your computer
 use?</simpara>
@@ -2726,7 +2806,7 @@ use?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Problem_Solving_and_Programming">
+<chapter xml:id="_problem_solving_and_programming">
 <title>Problem Solving and Programming</title>
 <blockquote>
 <attribution>
@@ -2746,14 +2826,14 @@ help people solve problems, but we want to solve new problems by writing
 our own programs. The art of writing these programs is called <emphasis>computer
 programming</emphasis> or just programming.</simpara>
 <simpara>Many people reading this book will be computer science students, and
-that’s great. However, computers have found their way into every segment
+that&#8217;s great. However, computers have found their way into every segment
 of commercial enterprise and personal life. Consequently, programming
 has become a general-purpose skill that can aid almost anyone in their
 career, whether it is in transportation, medicine, the military,
 commerce, or innumerable other areas.</simpara>
 <section xml:id="_what_is_a_program">
 <title>What is a program?</title>
-<simpara>If you don’t have a lot of experience with computer science, writing a
+<simpara>If you don&#8217;t have a lot of experience with computer science, writing a
 computer program may seem daunting. The programs that run on your
 computer are complex and varied. Where would you start if you wanted to
 create something like Microsoft Word or Adobe Photoshop?</simpara>
@@ -2765,7 +2845,7 @@ the list when it makes decisions about what to do next.</simpara>
 neither smart nor stupid because a computer has no intelligence to
 measure. A computer is a machine like a sewing machine or an internal
 combustion engine. It follows the instructions we give it blindly. It
-doesn’t have feelings or opinions about the instructions it receives.
+doesn&#8217;t have feelings or opinions about the instructions it receives.
 Computers do exactly what we tell them to and rarely make mistakes.</simpara>
 <simpara>Once in a while, a computer will make a mistake due to faulty
 construction, a bad power source, or cosmic rays, but well over 99.999%
@@ -2783,16 +2863,16 @@ closed door, shattering glass in the process.</simpara>
 </section>
 <section xml:id="_what_is_a_programming_language">
 <title>What is a programming language?</title>
-<simpara>What’s the right level of detail for instructions for a computer? It
+<simpara>What&#8217;s the right level of detail for instructions for a computer? It
 depends on the computer and the application. But how do we give these
 instructions? Programs are composed of instructions written in a
 <emphasis>programming language</emphasis>. In this book, we will use the Java programming
 language.</simpara>
-<simpara>Why can’t the instructions be given in English or some other natural
+<simpara>Why can&#8217;t the instructions be given in English or some other natural
 language? If the previous example of a robot walking through a glass
-door didn’t convince you, consider the quote from Groucho Marx, &#8220;One
+door didn&#8217;t convince you, consider the quote from Groucho Marx, &#8220;One
 morning I shot an elephant in my pajamas. How he got into my pajamas,
-I’ll never know.&#8221;</simpara>
+I&#8217;ll never know.&#8221;</simpara>
 <simpara>Natural languages are filled with idioms, metaphors, puns, and other
 ambiguities. Good writers use these to improve their poetry and prose,
 but our goal in this book is not to write poetry or prose. We want to
@@ -2800,19 +2880,19 @@ write instructions for a computer that are crystal clear.</simpara>
 <simpara>Learning Java is not like learning Spanish or Swahili. Like most
 programming languages, Java is highly structured. It has fewer than 100
 reserved words and special symbols. There are no exceptions to its
-grammatical rules. Don’t confuse the process of designing a solution to
+grammatical rules. Don&#8217;t confuse the process of designing a solution to
 a problem with the process of implementing that solution in a
 programming language. Learning to organize your thoughts into a
 sequential list of instructions is different from learning how to
 translate that list into Java or another programming language, but
-there’s a tight connection between the two.</simpara>
+there&#8217;s a tight connection between the two.</simpara>
 <simpara>Learning to program is patterning your mind to think like a machine, to
 break everything down into the simplest logical steps. At first, Java
 code will look like gobbledygook. Eventually, it will become so familiar
 that a glance will tell you volumes about how a program works. Learning
 to program is not easy, but the kind of logical analysis involved is
 valuable even if you never program afterward. If you do need to learn
-other programming languages in the future, it will be easy once you’ve
+other programming languages in the future, it will be easy once you&#8217;ve
 mastered Java.</simpara>
 </section>
 <section xml:id="_an_example_problem">
@@ -2848,7 +2928,7 @@ version with the following five steps:</simpara>
 <listitem>
 <simpara><emphasis role="strong">Understand the problem:</emphasis> It seems obvious, but, when you go to
 write a program, all kinds of details crop up. Consider a program that
-stores medical records. Should the program give an error if a patient’s
+stores medical records. Should the program give an error if a patient&#8217;s
 age is over 150 years? What if advances in long life or cryogenic
 storage make such a thing possible? What about negative ages? An unborn
 child could be considered to have a negative age (or more outlandishly,
@@ -2884,8 +2964,8 @@ algorithm. The steps for long division will work for any real numbers,
 and most human beings can follow the algorithm without difficulty.</simpara>
 <simpara>An algorithm is often expressed in <emphasis>pseudocode</emphasis>, a high level, generic,
 code-like system of notation. Pseudocode is similar to a programming
-language, but it doesn’t have the same detail. Algorithms are often
-designed in pseudocode so that they aren’t tied to any one programming
+language, but it doesn&#8217;t have the same detail. Algorithms are often
+designed in pseudocode so that they aren&#8217;t tied to any one programming
 language.</simpara>
 <simpara>When attacking a problem, it is typical to break it into several smaller
 subproblems and then create algorithms for the subproblems. This
@@ -2903,7 +2983,7 @@ each one separately and then integrate the solutions together.
 Professional developers often assign different parts of the solution to
 different programmers or even different teams of programmers.</simpara>
 <simpara>Students are often tempted to jump into the implementation step, but
-never forget that this is the third step of the process. If you don’t
+never forget that this is the third step of the process. If you don&#8217;t
 fully understand the problem and have a plan to attack it, the
 implementation process can become bogged down and riddled with mistakes.
 At first, the problems we introduce and the programs needed to solve
@@ -2927,7 +3007,7 @@ software bug is a source of annoyance to the user, but other times, as
 in aviation, automotive, or medical software, people die because of
 bugs.</simpara>
 <simpara>Most of this book is dedicated to designing solutions to problems and
-implementing them in Java, but Chapter <xref linkend="chapter:Testing_and_Debugging"/>
+implementing them in Java, but <xref linkend="_testing_and_debugging"/>
 is all about testing and debugging.</simpara>
 </listitem>
 <listitem>
@@ -2990,10 +3070,10 @@ testing with web servers distributing patches and e-mails and
 traditional letters apologizing for the mistake, a factor of 10,000
 could be a reasonable estimate.</simpara>
 </example>
-<simpara>Now that we have a sense of the software development lifecycle, let’s
+<simpara>Now that we have a sense of the software development lifecycle, let&#8217;s
 look at an example using the sample ball bouncing problem to walk
 through a few steps.</simpara>
-<example>
+<example xml:id="example-Ball_bouncing_problem">
 <title>Ball bouncing problem and plan</title>
 <simpara>Recall the statement of the problem from the <emphasis role="strong">Problem</emphasis> section:</simpara>
 <simpara>A rubber ball is dropped on a flat, hard surface from height
@@ -3011,14 +3091,14 @@ calculating the next bounce. Thus, it will bounce to a height of
 <inlineequation><alt><![CDATA[h\times c^2]]></alt><mathphrase><![CDATA[h\times c^2]]></mathphrase></inlineequation> the second time. By examining this pattern for
 the third and fourth bounce, it becomes clear that the ball will bounce
 to a height of <inlineequation><alt><![CDATA[h\times c^k]]></alt><mathphrase><![CDATA[h\times c^k]]></mathphrase></inlineequation> on the
-<inlineequation><alt><![CDATA[k^{\mathrm{th}}]]></alt><mathphrase><![CDATA[k^{\mathrm{th}}]]></mathphrase></inlineequation> time. See Figure <xref linkend="bouncingBallFigure"/>
+<inlineequation><alt><![CDATA[k^{\mathrm{th}}]]></alt><mathphrase><![CDATA[k^{\mathrm{th}}]]></mathphrase></inlineequation> time. See <xref linkend="bouncingBallFigure"/>
 for a graphic description of this process.</simpara>
 <simpara>We are assuming that <inlineequation><alt><![CDATA[k > 0]]></alt><mathphrase><![CDATA[k > 0]]></mathphrase></inlineequation> and that <inlineequation><alt><![CDATA[c < 1]]></alt><mathphrase><![CDATA[c < 1]]></mathphrase></inlineequation>.
 Note that <inlineequation><alt><![CDATA[c]]></alt><mathphrase><![CDATA[c]]></mathphrase></inlineequation> depends on many factors, such as the
 elasticity of the ball and the properties of the floor on which the ball
 is dropped. However, if we know that we will be given <inlineequation><alt><![CDATA[c]]></alt><mathphrase><![CDATA[c]]></mathphrase></inlineequation>,
-we don’t need to worry about any other details.</simpara>
-<figure role="text-center">
+we don&#8217;t need to worry about any other details.</simpara>
+<figure xml:id="bouncingBallFigure" role="text-center">
 <title>A ball is dropped from height <inlineequation><alt><![CDATA[h]]></alt><mathphrase><![CDATA[h]]></mathphrase></inlineequation>. The ball rises to height <inlineequation><alt><![CDATA[h c]]></alt><mathphrase><![CDATA[h c]]></mathphrase></inlineequation> after the first bounce and to <inlineequation><alt><![CDATA[hc^2]]></alt><mathphrase><![CDATA[hc^2]]></mathphrase></inlineequation> after the second.</title>
 <mediaobject>
 <imageobject>
@@ -3029,10 +3109,10 @@ we don’t need to worry about any other details.</simpara>
 </figure>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Design a solution:</emphasis> This problem is straightforward, but it’s
-always useful to practice good design. Remember that you’ve got to plan
+<simpara><emphasis role="strong">Design a solution:</emphasis> This problem is straightforward, but it&#8217;s
+always useful to practice good design. Remember that you&#8217;ve got to plan
 your input and output as well as the computation in a program. As
-practice for more complicated problems, let’s break this problem down
+practice for more complicated problems, let&#8217;s break this problem down
 into smaller subproblems.</simpara>
 <variablelist>
 <varlistentry>
@@ -3054,7 +3134,7 @@ bounce.</simpara>
 <listitem>
 <simpara>Display the calculated height.</simpara>
 <simpara>The solution to each of the three subproblems requires input and
-generates an output. Figure <xref linkend="subProblemRelationFigure"/> shows how these
+generates an output. <xref linkend="subProblemRelationFigure"/> shows how these
 solutions are connected. The first box in this figure represents the
 solution to subproblem 1. It asks a user to input values of parameters
 <inlineequation><alt><![CDATA[h]]></alt><mathphrase><![CDATA[h]]></mathphrase></inlineequation>, <inlineequation><alt><![CDATA[c]]></alt><mathphrase><![CDATA[c]]></mathphrase></inlineequation>, and <inlineequation><alt><![CDATA[k]]></alt><mathphrase><![CDATA[k]]></mathphrase></inlineequation>. It sends these
@@ -3062,7 +3142,7 @@ values to the next box, which represents a solution to subproblem 2.
 This second box computes the height of the ball after <inlineequation><alt><![CDATA[k]]></alt><mathphrase><![CDATA[k]]></mathphrase></inlineequation>
 bounces and makes it available to the third box, which represents a
 solution to subproblem 3. This third box displays the calculated height.</simpara>
-<figure role="text-center">
+<figure xml:id="subProblemRelationFigure" role="text-center">
 <title>Connections between solutions to the three subproblems in the bouncing ball problem.</title>
 <mediaobject>
 <imageobject>
@@ -3077,7 +3157,7 @@ solution to subproblem 3. This third box displays the calculated height.</simpar
 </listitem>
 </orderedlist>
 <simpara>Before we can continue on to Step 3, we need to learn some Java.
-Section <xref linkend="syntax:Java_basics"/> introduces you to the Java you’ll need to
+<xref linkend="_syntax_java_basics"/> introduces you to the Java you&#8217;ll need to
 solve this problem.</simpara>
 </example>
 </section>
@@ -3154,7 +3234,7 @@ students and Java beginners. It is also free and is available from
 Programming is a craft, and every craftsman has his or her favorite
 tools. Most of the content of this book is completely independent from
 the tools you use to write and compile your code. One exception is
-Chapter <xref linkend="chapter:Testing_and_Debugging"/>, in which we briefly discuss
+<xref linkend="_testing_and_debugging"/>, in which we briefly discuss
 the debugging tools in Eclipse and DrJava.</simpara>
 <simpara>If you choose Eclipse, NetBeans, or another complex IDE, you may wish to
 read some online tutorials to get started. These IDEs often require the
@@ -3191,9 +3271,9 @@ imperfect) system.</simpara>
 <title>Java program structure</title>
 <simpara>The first rule of Java is that all code goes inside of a <emphasis>class</emphasis>. A
 class is a container for blocks of code called <emphasis>methods</emphasis> and it can also
-be used as a template to create <emphasis>objects</emphasis>. We’ll talk a bit more about
+be used as a template to create <emphasis>objects</emphasis>. We&#8217;ll talk a bit more about
 classes in this chapter and then focus on them heavily in
-Chapter <xref linkend="chapter:Classes"/>.</simpara>
+<xref linkend="_classes"/>.</simpara>
 <simpara>For now, you only need to remember that every Java program has at least
 one class. It is possible to put more than one class in a file, but you
 can only have one top-level <emphasis>public</emphasis> class per file. A public class is
@@ -3210,16 +3290,19 @@ keyword <literal>class</literal> states that you are declaring a class. The name
 start with a capital letter. The braces (<literal>\{</literal> and <literal>\}</literal>) mark the start
 and end of the contents of the class. Right now, our class contains
 nothing.</simpara>
+<sidebar>
+<simpara><link linkend="exercise2.7">Exercise 2.7</link></simpara>
+</sidebar>
 <simpara>This text should be saved in a file called <literal>Example.java</literal>. It is
-required that the name of the public class matches the file that it’s
+required that the name of the public class matches the file that it&#8217;s
 in, including capitalization. Once <literal>Example.java</literal> has been saved, you
-can compile it into bytecode. However, since there’s nothing in class
-<literal>Example</literal>, you can’t run it as a program.</simpara>
+can compile it into bytecode. However, since there&#8217;s nothing in class
+<literal>Example</literal>, you can&#8217;t run it as a program.</simpara>
 <simpara>A program is a list of instructions, and that list has to start
 somewhere. For a normal Java application, that place is the <literal>main()</literal>
 method. (Throughout this book, we always append parentheses <literal>()</literal> to mark
 the name of a method.) If we want to do something inside of <literal>Example</literal>,
-we’ll have to add a <literal>main()</literal> method like so:</simpara>
+we&#8217;ll have to add a <literal>main()</literal> method like so:</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class Example {
     public static void main(String[] args) {
     }
@@ -3234,7 +3317,7 @@ Perhaps the most confusing part is the expression <literal>String[] args</litera
 is a list of text (strings) given as input to the <literal>main()</literal> method from
 the command line. As with the class, the braces mark the start and end
 of the contents of the <literal>main()</literal> method, which is currently empty.</simpara>
-<simpara>Right now, you don’t need to understand any of this. All you need to
+<simpara>Right now, you don&#8217;t need to understand any of this. All you need to
 know is that, to start a program, you need a <literal>main()</literal> method and its
 syntax is always the same as the code listed above. If you save this
 code, you can compile <literal>Example.java</literal> and then run it, and…nothing
@@ -3244,14 +3327,14 @@ instructions is empty.</simpara>
 <section xml:id="_command_line_input_and_output">
 <title>Command line input and output</title>
 <simpara>An important thing for a Java program to do is to communicate with the
-outside world (where we live). First, let’s look at printing data to the
+outside world (where we live). First, let&#8217;s look at printing data to the
 command line and reading data in from the command line.</simpara>
 <section xml:id="_the_literal_system_out_print_literal_method">
 <title>The <literal>System.out.print()</literal> method</title>
 <simpara>Methods allow us to perform actions in Java. They are blocks of code
 packaged up with a name so that we can run the same piece of code
 repeatedly but with different inputs. We discuss them in much greater
-depth in Chapter <xref linkend="chapter:Methods"/>.</simpara>
+depth in <xref linkend="_methods"/>.</simpara>
 <simpara>A common method for output is <literal>System.out.print()</literal>. The input (usually
 called <emphasis>arguments</emphasis>) to a method are given between its parentheses. Thus,
 if we want to print <literal>42</literal> to the terminal, we type:</simpara>
@@ -3365,8 +3448,8 @@ an initially empty box that could hold a <literal>Scanner</literal> object. The 
 <literal>System.in</literal>, which means that the input will be from the keyboard. The
 assignment stored this object into the variable <literal>in</literal>. The fact that
 <literal>System.in</literal> was used has <emphasis role="strong">nothing</emphasis> to do with the fact that our variable
-was named <literal>in</literal>. Again, don’t expect to understand all the details at
-first. Any time you need to read data from the keyboard, you’ll need
+was named <literal>in</literal>. Again, don&#8217;t expect to understand all the details at
+first. Any time you need to read data from the keyboard, you&#8217;ll need
 these two lines of code, which you should be able to copy verbatim. It
 is possible to both declare a variable and assign its value in one line.
 Instead of the two line version, most programmers would type:</simpara>
@@ -3388,12 +3471,15 @@ illustrate how `Scanner</literal> can be used to read input while solving
 problems. The first example shows how these elements can be applied to
 subproblem 1 of the bouncing ball problem, and the second example
 introduces and solves a new problem.</simpara>
+<sidebar>
+<simpara><link linkend="exercise2.13">Exercise 2.13</link></simpara>
+</sidebar>
 <example>
 <title>Command line input</title>
 <simpara>Subproblem 1 requires us to get the height, coefficient of restitution,
-and number of bounces from the user. Program <xref linkend="program:GetInputCLI"/>
+and number of bounces from the user. <xref linkend="GetInputCLIProgram"/>
 shows a Java program to solve this subproblem.</simpara>
-<formalpara xml:id="program:GetInputCLI" xreflabel="GetInputCLI">
+<formalpara xml:id="GetInputCLIProgram">
 <title>A Java program to get the height, coefficient of restitution, and number of bounces from the command line.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
@@ -3401,7 +3487,7 @@ shows a Java program to solve this subproblem.</simpara>
 public class GetInputCLI {
 	public static void main(String[] args) {
     	// Create an object named in for input
-        Scanner in = new Scanner(System.in); /*@\label{createScannerGetInputDataObject}@*/
+        Scanner in = new Scanner(System.in);
 
         // Declare variables to hold input data
         double height, coefficient;
@@ -3409,8 +3495,7 @@ public class GetInputCLI {
 
         // Declare user prompt strings
         String enterHeight = "Enter the height: ";
-        String enterCoefficient =
-        	"Enter restitution coefficient: ";
+        String enterCoefficient = "Enter restitution coefficient: ";
         String enterBounces = "Enter the number of bounces: ";
 
         // Prompt the user and read data from the keyboard
@@ -3430,16 +3515,19 @@ public class GetInputCLI {
 this line imports all the classes in the <literal>java.util</literal> package. The
 asterisk (<literal>*</literal>) is known as a <emphasis>wildcard</emphasis>. The wildcard notation is
 convenient if you need to import several classes from a package or if
-you don’t know in advance the names of all the classes you’ll need.</simpara>
+you don&#8217;t know in advance the names of all the classes you&#8217;ll need.</simpara>
+<sidebar>
+<simpara><link linkend="exercise2.8">Exercise 2.8</link></simpara>
+</sidebar>
 <simpara>After the import comes the class declaration, creating a class called
 <literal>GetInputCLI</literal>. We put a <literal>CLI</literal> at the end of this class name to mark that
 it uses the command line interface, contrasting with the GUI version
-that we’re going to show next. Inside the class declaration is the
+that we&#8217;re going to show next. Inside the class declaration is the
 definition of the <literal>main()</literal> method, showing where the program starts. The
 text that comes after double slashes (<literal>//</literal>) are called <emphasis>comments</emphasis>.
 Comments allow us to make our code more readable to humans, but the
 compiler ignores them.</simpara>
-<simpara>If you follow the comments, you’ll see that we declare two <literal>double</literal>
+<simpara>If you follow the comments, you&#8217;ll see that we declare two <literal>double</literal>
 variables (for holding double precision floating-point numbers) and an
 <literal>int</literal> variable (for holding an integer value). Next we declare three
 <literal>String</literal> variables and assign them three strings (segments of text).</simpara>
@@ -3454,9 +3542,9 @@ compile and run this program, the execution should match the steps
 described. Note that it only reads in the values needed to solve the
 problem. We have not added the code to compute the answer or display it.</simpara>
 </example>
-<example>
+<example xml:id="inputForDistanceComputationExample">
 <title>Input for distance computation</title>
-<simpara>Let’s write a program that takes as input the speed of a moving object
+<simpara>Let&#8217;s write a program that takes as input the speed of a moving object
 and the time it has been moving. The goal is to compute and display the
 total distance it travels. We can divide this problem into the following
 three subproblems.</simpara>
@@ -3480,10 +3568,15 @@ three subproblems.</simpara>
 </listitem>
 </varlistentry>
 </variablelist>
-<simpara>Program <xref linkend="program:Distance"/> solves each of these subproblems in order,
+<simpara><xref linkend="DistanceProgram"/> solves each of these subproblems in order,
 using the command-line input and output tools we have just discussed.</simpara>
-<formalpara xml:id="program:Distance" xreflabel="Distance">
-<title>Program to compute the distance a moving object travels.</title>
+<simpara>The program starts with import statements, the class definition, and the
+definition of the <literal>main()</literal> method. At the beginning of the <literal>main()</literal>
+method, we have code to declare and initialize a variable of type
+<literal>Scanner</literal> named <literal>in</literal>. We also declare variables of type <literal>double</literal> to hold
+the input speed and time and the resulting distance.</simpara>
+<formalpara xml:id="DistanceProgram">
+<title>Computes the distance a moving object travels.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -3496,13 +3589,13 @@ public class Distance {
 
         // Solution to subproblem 1: Read input
         // Prompt the user and get speed and time
-        System.out.print("Enter the speed: "); /*@\label{solutionSubProblemOneScanner}@*/
-        speed = in.nextDouble();/*@\label{getSpeed}@*/
+        System.out.print("Enter the speed: "); <co xml:id="CO1-1"/>
+        speed = in.nextDouble();
         System.out.print("Enter the time: ");
-        time = in.nextDouble();/*@\label{getDuration}@*/
+        time = in.nextDouble();
 
         // Solution to subproblem 2: Compute distance
-        distance = speed*time;/*@\label{solutionSubProblemTwoScanner}@*/
+        distance = speed*time; <co xml:id="CO1-2"/>
 
         // Solution to subproblem 3: Display output
         System.out.print("Distance traveled: ");
@@ -3512,18 +3605,16 @@ public class Distance {
 }</programlisting>
 </para>
 </formalpara>
-<simpara>The program starts with import statements, the class definition, and the
-definition of the <literal>main()</literal> method. At the beginning of the <literal>main()</literal>
-method, we have code to declare and initialize a variable of type
-<literal>Scanner</literal> named <literal>in</literal>. We also declare variables of type <literal>double</literal> to hold
-the input speed and time and the resulting distance.</simpara>
-<simpara>Starting at line <xref linkend="solutionSubProblemOneScanner"/>, we solve subproblem
-1, prompting the user for the speed and the time and using our <literal>Scanner</literal>
-object to read them in. Because they are both floating-point values with
-type <literal>double</literal>, we use the <literal>nextDouble()</literal> method for input.</simpara>
-<simpara>At line <xref linkend="solutionSubProblemTwoScanner"/>, we compute the distance
-traveled by multiplying <literal>speed</literal> by <literal>time</literal> and storing the result in
-<literal>distance</literal>. The last three lines of the <literal>main()</literal> method solve subproblem
+<calloutlist>
+<callout arearefs="CO1-1">
+<para>Starts solving subproblem 1, prompting the user for the speed and the time and using our <literal>Scanner</literal> object to read them in. Because they are both floating-point values with type <literal>double</literal>, we use the <literal>nextDouble()</literal> method for input.</para>
+</callout>
+<callout arearefs="CO1-2">
+<para>Computes the distance traveled by multiplying <literal>speed</literal> by <literal>time</literal> and storing the result in
+<literal>distance</literal>.</para>
+</callout>
+</calloutlist>
+<simpara>The last three lines of the <literal>main()</literal> method solve subproblem
 3 by outputting <literal>"Distance traveled: "</literal>, the computed distance, and
 <literal>" miles."</literal>. If you run the program, all three items are printed on the
 same line on the terminal.</simpara>
@@ -3536,8 +3627,8 @@ same line on the terminal.</simpara>
 and output with a GUI instead of on the command line. GUIs can become
 very complex, but in this chapter we introduce a relatively simple way
 to do GUI input and output and expand on it further in
-Chapter <xref linkend="chapter:Simple_Graphical_User_Interfaces"/>. Then, we go into
-GUIs in much more depth in Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/>.</simpara>
+<xref linkend="_simple_graphical_user_interfaces"/>. Then, we go into
+GUIs in much more depth in <xref linkend="_constructing_graphical_user_interfaces"/>.</simpara>
 <simpara>A limited tool for displaying output and reading input with a GUI is the
 <literal>JOptionPane</literal> class. This class has a complicated method called
 <literal>showMessageDialog()</literal> that opens a small <emphasis>dialog box</emphasis> to display a
@@ -3555,7 +3646,7 @@ public class Example {
 to use it. The <literal>showMessageDialog()</literal> method takes several arguments to
 tell it what to do. For our purposes, the first one is always the
 special Java literal <literal>null</literal>, which represents an empty value. The next
-is the message you want to display, but it has to be text. That’s why
+is the message you want to display, but it has to be text. That&#8217;s why
 <literal>"42"</literal> appears with quotation marks. The third argument is the title
 that appears at the top of the dialog. The final argument gives
 information about how the dialog should be presented.
@@ -3566,7 +3657,7 @@ dialog.</simpara>
 <simpara>If we wanted to make the call to <literal>showMessageDialog()</literal> a little easier
 to read, we could store the arguments into variables with short, easy to
 understand names. The following program does so and should behave
-exactly like the previous program. Figure <xref linkend="figure:showMessageDialog"/>
+exactly like the previous program. <xref linkend="showMessageDialogFigure"/>
 shows what the resulting GUI might look like.</simpara>
 <programlisting language="java" linenumbering="unnumbered">import javax.swing.JOptionPane;
 
@@ -3578,7 +3669,7 @@ public class Example {
             JOptionPane.INFORMATION_MESSAGE);
     }
 }</programlisting>
-<figure role="text-center">
+<figure xml:id="showMessageDialogFigure" role="text-center">
 <title>Example of <literal>showMessageDialog()</literal> used for output.</title>
 <mediaobject>
 <imageobject>
@@ -3610,9 +3701,9 @@ public class Example {
 }</programlisting>
 <simpara>Note that whatever the user typed in will be stored in <literal>word</literal>. Finally,
 the last line of the program displays whatever word was entered with
-<literal>showMessageDialog()</literal>. Figure <xref linkend="figure:showInputDialog"/> shows the
+<literal>showMessageDialog()</literal>. <xref linkend="showInputDialogFigure"/> shows the
 resulting GUI as the user is entering input.</simpara>
-<figure role="text-center">
+<figure xml:id="showInputDialogFigure" role="text-center">
 <title>Example of <literal>showInputDialog()</literal> used for input.</title>
 <mediaobject>
 <imageobject>
@@ -3645,22 +3736,21 @@ int a = Integer.parseInt("Twenty three");
 
 double b = Double.parseDouble("pi");
 // Causes the program to crash</programlisting>
-<simpara>You might wonder why the computer isn’t smart enough to know that <literal>"23"</literal>
+<simpara>You might wonder why the computer isn&#8217;t smart enough to know that <literal>"23"</literal>
 means <literal>23</literal>. Remember, the computer has no intelligence. If something is
-marked as text, it doesn’t know that it can interpret it as a number.
-What kind of data something is depends on its type, which doesn’t
-change. We’ll discuss types more deeply in Chapter <xref linkend="chapter:Primitive
-Types and Strings"/>.</simpara>
+marked as text, it doesn&#8217;t know that it can interpret it as a number.
+What kind of data something is depends on its type, which doesn&#8217;t
+change. We&#8217;ll discuss types more deeply in <xref linkend="_primitive_types_and_strings"/>.</simpara>
 <simpara>The next example uses these two type conversion methods with methods
 from <literal>JOptionPane</literal> in a GUI-based solution to subproblem 1 of the
 bouncing ball problem.</simpara>
 <example>
 <title>GUI input</title>
-<simpara>We can change the solution given in Program <xref linkend="program:GetInputCLI"/> to
+<simpara>We can change the solution given in <xref linkend="GetInputCLIProgram"/> to
 use the GUI-based input tools in <literal>JOptionPane</literal>.
-Program <xref linkend="program:GetInputCLI"/> this equivalent GUI-based Java program.</simpara>
-<formalpara xml:id="program:GetInputGUI" xreflabel="GetInputGUI">
-<title>Program to get the height, coefficient of restitution, and number of bounces using a GUI.</title>
+<xref linkend="GetInputCLIProgram"/> this equivalent GUI-based Java program.</simpara>
+<formalpara xml:id="GetInputGUIProgram">
+<title>Gets the height, coefficient of restitution, and number of bounces using a GUI.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 
@@ -3674,32 +3764,32 @@ public class GetInputGUI {
 
         // Declare user prompt strings
         String enterHeight = "Enter the height: ";
-        String enterCoefficient =
-        	"Enter restitution coefficient: ";
+        String enterCoefficient = "Enter restitution coefficient: ";
         String enterBounces = "Enter the number of bounces: ";
 
-        // Prompt the user, get data, and convert it
-        String response = JOptionPane.showInputDialog(null,/*@\label{inputDialogLineOne}@*/
-        	enterHeight, title, JOptionPane.QUESTION_MESSAGE);
-        height = Double.parseDouble(response); /*@\label{convertToDoubleLineOne}@*/
-        response = JOptionPane.showInputDialog(null,/*@\label{inputDialogLineTwo}@*/
-        	enterCoefficient, title, JOptionPane.QUESTION_MESSAGE);
-        coefficient = Double.parseDouble(response);/*@\label{convertToDoubleLineTwo}@*/
-        response = JOptionPane.showInputDialog(null,/*@\label{inputDialogLineThree}@*/
-        	enterBounces, title, JOptionPane.QUESTION_MESSAGE);
-        bounces = Integer.parseInt(response);/*@\label{convertToDoubleLineThree}@*/
+        // Prompt the user, get data, and convert it <co xml:id="CO2-1"/>
+        String response = JOptionPane.showInputDialog(null,
+			enterHeight, title, JOptionPane.QUESTION_MESSAGE);
+        height = Double.parseDouble(response);
+        response = JOptionPane.showInputDialog(null,
+			enterCoefficient, title, JOptionPane.QUESTION_MESSAGE);
+        coefficient = Double.parseDouble(response);
+        response = JOptionPane.showInputDialog(null,
+			enterBounces, title, JOptionPane.QUESTION_MESSAGE);
+        bounces = Integer.parseInt(response);
     }
 }</programlisting>
 </para>
 </formalpara>
-<simpara>The code in this program is very similar to
-Program <xref linkend="program:GetInputCLI"/> until line <xref linkend="inputDialogLineOne"/>. At
-that point, we use the <literal>showInputDialog()</literal> method to read a <literal>String</literal>
-version of the height from the user. On the next line, we have to
+<calloutlist>
+<callout arearefs="CO2-1">
+<para>At this point the code in this program diverges from <xref linkend="GetInputCLIProgram"/>. We use the <literal>showInputDialog()</literal> method to read a <literal>String</literal> version of the height from the user. On the next line, we have to
 convert this <literal>String</literal> version into the <literal>double</literal> version that we store in
 the <literal>height</literal> variable. The next four lines read in the coefficient of
 restitution and the number of bounces and convert them to their
-appropriate numerical types.</simpara>
+appropriate numerical types.</para>
+</callout>
+</calloutlist>
 </example>
 </section>
 <section xml:id="_a_few_operations">
@@ -3712,8 +3802,8 @@ to the <literal>System.out.print()</literal> method to print <literal>42</litera
 use the add (<literal>+</literal>), subtract (<literal>-</literal>), multiply (<literal>*</literal>), and divide(<literal>/</literal>)
 operators on numbers to solve arithmetic problems. These operators work
 the way you expect them to (except that division has a few surprises).
-We’ll go into these operators and others more deeply in
-Chapter <xref linkend="chapter:Primitive_Types_and_Strings"/>. Here are examples of
+We&#8217;ll go into these operators and others more deeply in
+<xref linkend="_primitive_types_and_strings"/>. Here are examples of
 these four operators used with integer and floating-point numbers.</simpara>
 <programlisting language="java" linenumbering="unnumbered">int a = 2 + 3;         // a will hold 5
 int b = 2 - 3;         // b will hold -1
@@ -3745,8 +3835,8 @@ double q = Math.sqrt(2.0);
 ball problem. To do so, we have to multiply the height by the
 coefficient of restitution raised to the power of the number of bounces.
 The following program does so, using the <literal>Math.pow()</literal> method.</simpara>
-<formalpara xml:id="program:ComputeHeight" xreflabel="ComputeHeight">
-<title>Program to compute height of a ball after bounces.</title>
+<formalpara xml:id="ComputeHeightProgram">
+<title>Computes height of a ball after bounces.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class ComputeHeight {
 	public static void main(String[] args) {
@@ -3754,13 +3844,13 @@ The following program does so, using the <literal>Math.pow()</literal> method.</
         double height = 15, coefficient = 0.3;
         int bounces = 10;
         // Compute height after bounces
-        double bounceHeight = height*Math.pow(coefficient,bounces);/*@\label{computeHeight}@*/
+        double bounceHeight = height*Math.pow(coefficient,bounces);
         System.out.println(bounceHeight); // For testing
     }
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Program <xref linkend="program:ComputeHeight"/> is only focusing on subproblem 2, but,
+<simpara><xref linkend="ComputeHeightProgram"/> is only focusing on subproblem 2, but,
 if we want to test it, we need to supply some dummy values for <literal>height</literal>,
 <literal>coefficient</literal>, and <literal>bounces</literal>, since these are read in by the solution to
 subproblem 1. Likewise, the output statement on the last line of the
@@ -3775,7 +3865,7 @@ together. In Java, text has the type <literal>String</literal>. If you use the <
 operator between two values or variables of type <literal>String</literal>, the result is
 a new <literal>String</literal> that is the <emphasis>concatenation</emphasis> of the two previous <literal>String</literal>
 values, meaning that the result is the two pieces of text pasted
-together, one after the other. Concatenation doesn’t change the <literal>String</literal>
+together, one after the other. Concatenation doesn&#8217;t change the <literal>String</literal>
 values you are concatenating.</simpara>
 <simpara>At this point, it becomes confusing if you mix types (<literal>String</literal>, <literal>int</literal>,
 <literal>double</literal>) together when doing mathematical operations. However, feel
@@ -3799,8 +3889,8 @@ String text4 = 5 + " " + word1 + "es";
 concatenate the results together with an appropriate message and then
 use the <literal>System.out.println()</literal> method for output. The following program
 does so.</simpara>
-<formalpara xml:id="program:DisplayHeightCLI" xreflabel="DisplayHeightCLI">
-<title>Program to display height of a ball using the command line.</title>
+<formalpara xml:id="DisplayHeightCLIProgram">
+<title>Displays height of a ball using the command line.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class DisplayHeightCLI {
 	public static void main(String[] args) {
@@ -3815,15 +3905,15 @@ does so.</simpara>
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Program <xref linkend="program:DisplayHeightCLI"/> is only focusing on subproblem 3,
+<simpara><xref linkend="DisplayHeightCLIProgram"/> is only focusing on subproblem 3,
 but, if we want to test it, we need to supply dummy values for <literal>bounces</literal>
 and <literal>bounceHeight</literal>, since these are generated by the solution to earlier
 subproblems.</simpara>
 <simpara>The same concatenation can be used for GUI output as well. The only
 difference is the use of<?asciidoc-br?>
 <literal>JOptionPane.showMessageDialog()</literal> instead of <literal>System.out.println()</literal>.</simpara>
-<formalpara xml:id="program:DisplayHeightGUI" xreflabel="DisplayHeightGUI">
-<title>Program to display height of a ball using a GUI.</title>
+<formalpara xml:id="DisplayHeightGUIProgram">
+<title>Displays height of a ball using a GUI.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 
@@ -3929,7 +4019,7 @@ specify that they must start with an uppercase or lowercase letter (or
 an underscore) and that the remaining characters must be letters,
 underscores, or numerical digits. Thus, <literal>mötleyCrüe</literal>, <literal>Tupac</literal>, and even
 the absurd <literal><emphasis>_</emphasis>5</literal> are legal identifiers, but <literal>Motley Crue</literal> and
-<literal>2Pac</literal> are not. Java has support for many of the world’s languages,
+<literal>2Pac</literal> are not. Java has support for many of the world&#8217;s languages,
 allowing identifiers to contain characters from Chinese, Thai,
 Devanagari, Cyrillic, and other scripts.</simpara>
 <simpara>Remember that keywords cannot be used as identifiers. For example,
@@ -3968,8 +4058,8 @@ public
 <programlisting language="java" linenumbering="unnumbered">public class Example{public static void main(String[]args){System.out.print(42);}}</programlisting>
 <simpara>These three programs are identical in the eyes of the Java compiler, but
 the first one is easier for a human to read. You should use whitespace
-to increase readability. Don’t add too much whitespace with lots of
-blank lines between sections of code. On the other hand, don’t use too
+to increase readability. Don&#8217;t add too much whitespace with lots of
+blank lines between sections of code. On the other hand, don&#8217;t use too
 little and cramp the code together. Whenever code is nested inside of a
 set of braces, indent the contents so that it is easy to see the
 hierarchical relationship.</simpara>
@@ -4028,7 +4118,7 @@ public class Example {
     }
 }</programlisting>
 <simpara>Comments are a wonderful tool, but clean code with meaningful variable
-names and careful use of whitespace doesn’t require too much commenting.
+names and careful use of whitespace doesn&#8217;t require too much commenting.
 Never hesitate to comment, but always ask yourself if there is a way to
 write the code so clearly that a comment is unnecessary.</simpara>
 </section>
@@ -4036,32 +4126,30 @@ write the code so clearly that a comment is unnecessary.</simpara>
 </section>
 <section xml:id="_solution_how_to_solve_problems">
 <title>Solution: How to solve problems</title>
-<simpara>The problem solving steps given in Section <xref linkend="concepts:Developing
-software"/> are sound, but they depend on being able to implement your
-planned solution in Java. We have introduced far too little Java so far
-to expect to solve <emphasis role="strong">all</emphasis> the problems that can be solved with a computer
-in this chapter. However, we can show the solution to the bouncing ball
+<simpara>The problem solving steps given in <xref linkend="_concepts_developing_software"/> are sound, but they depend on being able to implement your
+planned solution in Java. In this chapter we have introduced far too little Java
+to expect to solve <emphasis role="strong">all</emphasis> the problems that can be solved with a computer. However, we can show the solution to the bouncing ball
 problem and explain how our solution works through the software
 development lifecycle.</simpara>
 <section xml:id="_bouncing_ball_solution_command_line_version">
 <title>Bouncing ball solution (command line version)</title>
-<simpara>In Example <xref linkend="example:Ball_bouncing_problem_and_plan"/> we made sure that
+<simpara>In <xref linkend="example-Ball_bouncing_problem"/> we made sure that
 we understood the problem and then formed a three-part plan to read in
 the input, compute the height of the bounce, and then output it.</simpara>
-<simpara>In Program <xref linkend="program:GetInputCLI"/>, we implemented subproblem 1, reading
-the input from the command line. In Program <xref linkend="program:ComputeHeight"/>,
+<simpara>In <xref linkend="GetInputCLIProgram"/>, we implemented subproblem 1, reading
+the input from the command line. In <xref linkend="ComputeHeightProgram"/>,
 we implemented subproblem 2, computing the height of the final bounce.
-In Program <xref linkend="program:DisplayHeightCLI"/>, we implemented subproblem 3,
+In <xref linkend="DisplayHeightCLIProgram"/>, we implemented subproblem 3,
 displaying the height that was computed. In the final, integrated
 program, the portion of the code that corresponds to solving subproblem
 1 is below.</simpara>
-<programlisting language="java" linenumbering="numbered">import java.util.*;
+<programlisting language="java" linenumbering="unnumbered">import java.util.*;
 
 public class BouncingBallCLI {
 	public static void main(String[] args) {
     	// Solution to subproblem 1
     	// Create an object named in for input
-        Scanner in = new Scanner(System.in); /*@\label{scannerObjectLine}@*/
+        Scanner in = new Scanner(System.in);
 
         // Declare variables to hold input data
         double height, coefficient;
@@ -4069,8 +4157,7 @@ public class BouncingBallCLI {
 
         // Declare user prompt strings
         String enterHeight = "Enter the height: ";
-        String enterCoefficient =
-        	"Enter restitution coefficient: ";
+        String enterCoefficient = "Enter restitution coefficient: ";
         String enterBounces = "Enter the number of bounces: ";
 
         System.out.println("Bouncing Ball");
@@ -4078,23 +4165,21 @@ public class BouncingBallCLI {
         // Prompt the user and read data from the keyboard
         System.out.println("Bouncing Ball: Subproblem 1");
         System.out.print(enterHeight);
-        height = in.nextDouble(); /*@\label{inputDialogScannerIntegratedLineOne}@*/
+        height = in.nextDouble();
         System.out.print(enterCoefficient);
-        coefficient = in.nextDouble(); /*@\label{inputDialogScannerIntegratedLineTwo}@*/
+        coefficient = in.nextDouble();
         System.out.print(enterBounces);
-        bounces = in.nextInt(); /*@\label{inputDialogScannerIntegratedLineThree}@*/</programlisting>
+        bounces = in.nextInt();</programlisting>
 <simpara>With the imports, class declaration, and <literal>main()</literal> method set up by the
 solution to subproblem 1, the solution to subproblem 2 is very short.</simpara>
-<programlisting language="java" linenumbering="numbered">        // Solution to subproblem 2
-        double bounceHeight = height*Math.pow(coefficient,bounces);/*@\label{solutionScannerSubProblemTwo}@*/</programlisting>
+<programlisting language="java" linenumbering="unnumbered">        double bounceHeight = height*Math.pow(coefficient,bounces);</programlisting>
 <simpara>The solution to subproblem 3 and the braces that mark the end of the
 <literal>main()</literal> method and then the end of the class only take up a few
 additional lines.</simpara>
-<programlisting language="java" linenumbering="numbered">        // Solution to subproblem 3
-        String message = "After " + bounces +
+<programlisting language="java" linenumbering="unnumbered">        String message = "After " + bounces +
     		" bounces the height of the ball is: " +
     		bounceHeight + " feet";
-        System.out.println(message);/*@\label{constructorExecutionIntegratedEnds}@*/
+        System.out.println(message);
     }
 }</programlisting>
 </section>
@@ -4102,10 +4187,10 @@ additional lines.</simpara>
 <title>Bouncing ball solution (GUI version)</title>
 <simpara>If you prefer a GUI for your input and output, we can integrate the
 GUI-based versions of the solutions to subproblems 1, 2, and 3 from
-Programs <xref linkend="program:GetInputCLI"/>, <xref linkend="program:ComputeHeight"/>, and
-<xref linkend="program:DisplayHeightGUI"/>. The final program is below. It only
+<xref linkend="GetInputCLIProgram"/>, <xref linkend="ComputeHeightProgram"/>, and
+<xref linkend="DisplayHeightGUIProgram"/>. The final program is below. It only
 differs from the command line version in a few details.</simpara>
-<formalpara xml:id="program:BouncingBallGUI" xreflabel="BouncingBallGUI">
+<formalpara xml:id="BouncingBallGUIProgram">
 <title>Full program to compute the height of the final bounce of a ball and display the result with a GUI.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
@@ -4119,12 +4204,11 @@ public class BouncingBallGUI {
 
         // Declare user prompt strings
         String enterHeight = "Enter the height: ";
-        String enterCoefficient =
-        	"Enter restitution coefficient: ";
+        String enterCoefficient = "Enter restitution coefficient: ";
         String enterBounces = "Enter the number of bounces: ";
 
         // Prompt the user, get data, and convert it
-        String response = JOptionPane.showInputDialog(null,/*@\label{sampleDeclarationAndExecutableStatement}@*/
+        String response = JOptionPane.showInputDialog(null,
         	enterHeight, title, JOptionPane.QUESTION_MESSAGE);
         height = Double.parseDouble(response);
         response = JOptionPane.showInputDialog(null,
@@ -4141,8 +4225,8 @@ public class BouncingBallGUI {
         String message = "After " + bounces +
 			" bounces the height of the ball is: " +
 			bounceHeight + " feet";
-	    JOptionPane.showMessageDialog(null, message, title,
-	    	JOptionPane.INFORMATION_MESSAGE);
+	    JOptionPane.showMessageDialog(null,
+			message, title, JOptionPane.INFORMATION_MESSAGE);
     }
 }</programlisting>
 </para>
@@ -4161,14 +4245,14 @@ computed by our program should be the same, ignoring floating point
 error. We can also check some boundary test cases. If the coefficient of
 restitution is 1, the ball should bounce back perfectly, reaching
 whatever height we input. If the coefficient of restitution is 0, the
-ball doesn’t bounce at all, and the final height should be 0.</simpara>
+ball doesn&#8217;t bounce at all, and the final height should be 0.</simpara>
 <simpara>Our code does not account for users entering badly formatted data like
 <literal>two</literal> instead of <literal>2</literal>. Likewise, our code does not detect invalid values
 such as a coefficient of restitution greater than 1 or a negative number
-of bounces. An industrial-grade program should. We’ll discuss testing
-further in Chapter <xref linkend="chapter:Testing_and_Debugging"/>.</simpara>
+of bounces. An industrial-grade program should. We&#8217;ll discuss testing
+further in <xref linkend="_testing_and_debugging"/>.</simpara>
 <simpara>As with most of the problems we discuss in this book, issues of
-maintenance will not apply. We don’t have a customer base to keep happy.
+maintenance will not apply. We don&#8217;t have a customer base to keep happy.
 However, it is a good thought exercise to imagine a large-scale version
 of this program that can solve many different kinds of physics problems.
 Who are likely to be your clients? What are the kinds of bugs that are
@@ -4206,21 +4290,21 @@ managing the interactions between threads.</simpara>
 <section xml:id="_sequential_versus_concurrent_programming">
 <title>Sequential versus concurrent programming</title>
 <simpara>Imagine that the evil Lellarap aliens are attacking Earth. They have
-sent an extensive list of demands to the world’s leaders, but only a few
+sent an extensive list of demands to the world&#8217;s leaders, but only a few
 people, including you, have mastered their language, Lellarapian. To
 save the people of Earth, it is imperative that you translate their
 demands as quickly as possible so that world leaders can decide what
 course of action to take. If you do it alone, as illustrated in
-Figure <xref linkend="documentTranslationFigure"/>(a), the Lellaraps might attack
+<xref linkend="documentTranslationFigure"/>(a), the Lellaraps might attack
 before you finish.</simpara>
 <simpara>In order to finish the work faster, you hire a second translator whose
 skills in Lellarap are as good as yours. As shown in
-Figure <xref linkend="documentTranslationFigure"/>(b), you divide the document into
+<xref linkend="documentTranslationFigure"/>(b), you divide the document into
 two nearly equal parts, Document A and Document B. You translate
 Document A and your colleague translates Document B. When both
 translations are complete, you merge the two, check the translation, and
-send the result to the world’s leaders.</simpara>
-<figure>
+send the result to the world&#8217;s leaders.</simpara>
+<figure xml:id="documentTranslationFigure">
 <title>(a) Translation by one translator. Time <inlineequation><alt><![CDATA[t_s]]></alt><mathphrase><![CDATA[t_s]]></mathphrase></inlineequation> gives the sequential time taken. (b) Translation by translators A and B. Times <inlineequation><alt><![CDATA[t_1]]></alt><mathphrase><![CDATA[t_1]]></mathphrase></inlineequation>, <inlineequation><alt><![CDATA[t_2]]></alt><mathphrase><![CDATA[t_2]]></mathphrase></inlineequation>, <inlineequation><alt><![CDATA[t_3]]></alt><mathphrase><![CDATA[t_3]]></mathphrase></inlineequation>, and <inlineequation><alt><![CDATA[t_4]]></alt><mathphrase><![CDATA[t_4]]></mathphrase></inlineequation> give the times needed to do each component of the concurrent approach.</title>
 <mediaobject>
 <imageobject>
@@ -4237,21 +4321,24 @@ together.</simpara>
 <simpara>If you were to write a computer program to translate the demands using
 the sequential approach, you would produce a <emphasis>sequential program</emphasis>. If
 you write a computer program that uses the approach shown in
-Figure <xref linkend="documentTranslationFigure"/>(b), it would be a <emphasis>concurrent
+<xref linkend="documentTranslationFigure"/>(b), it would be a <emphasis>concurrent
 program</emphasis>. A concurrent program is also referred to as a <emphasis>multi-threaded</emphasis>
 program. <emphasis>Threads</emphasis> are sequences of code that can execute independently
-and access each other’s memory. Imagine you are one thread of execution
+and access each other&#8217;s memory. Imagine you are one thread of execution
 and your colleague is another. Thus, the concurrent approach will have
 at least two threads. It may have more if separate threads are used to
 divide up the document and merge it back together.</simpara>
-<simpara>Because we’re interested in the time the process takes, we have labeled
-different tasks in Figure <xref linkend="documentTranslationFigure"/> with their
+<simpara>Because we&#8217;re interested in the time the process takes, we have labeled
+different tasks in <xref linkend="documentTranslationFigure"/> with their
 running times. We let <inlineequation><alt><![CDATA[t_s]]></alt><mathphrase><![CDATA[t_s]]></mathphrase></inlineequation> be the time for one person to
 complete the translation. The times <inlineequation><alt><![CDATA[t_1]]></alt><mathphrase><![CDATA[t_1]]></mathphrase></inlineequation> through
 <inlineequation><alt><![CDATA[t_4]]></alt><mathphrase><![CDATA[t_4]]></mathphrase></inlineequation> mark the times needed to complete tasks 1 through 4,
-indicated in Figure <xref linkend="documentTranslationFigure"/>(b).
-Exercise <xref linkend="exercise:translationTimingExercise"/> asks you to calculate
+indicated in <xref linkend="documentTranslationFigure"/>(b).
+<link linkend="exercise2.10">Exercise 2.10</link> asks you to calculate
 these times for the sequential and concurrent approaches.</simpara>
+<sidebar>
+<simpara><link linkend="exercise2.10">Exercise 2.10</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_kinds_of_concurrency">
 <title>Kinds of concurrency</title>
@@ -4272,8 +4359,8 @@ examples explore each of these approaches.</simpara>
 <simpara>Suppose we have an autonomous robot called the Room Rating Robot or
 R<superscript>3</superscript>. The R<superscript>3</superscript> can measure the area of any home. Suppose that we want to
 use an R<superscript>3</superscript> to measure the area of the home with two floors sketched in
-Figure <xref linkend="figure:floorPlan"/>.</simpara>
-<figure role="text-center">
+<xref linkend="figure-floorPlan"/>.</simpara>
+<figure xml:id="figure-floorPlan" role="text-center">
 <title>A home with two floors.</title>
 <mediaobject>
 <imageobject>
@@ -4312,13 +4399,16 @@ us the total living area of the house. This is a sequential approach for
 measuring the area.</simpara>
 <simpara>Now suppose we have two R<superscript>3</superscript> robots, named R<superscript>3</superscript>A and R<superscript>3</superscript>B. We can put
 R<superscript>3</superscript>A on the first floor and R<superscript>3</superscript>B on the second. Both robots are then
-instructed to find the area of the floor they’re on using steps very
+instructed to find the area of the floor they&#8217;re on using steps very
 similar to the ones listed above for a sequential solution. When done,
 we add together the answers from R<superscript>3</superscript>A and R<superscript>3</superscript>B to get the total. This
 is a concurrent (and also parallel) approach for measuring the living
 area of a home with two floors. Using two robots in this way can speed
 up the time it takes to measure the area.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise2.11">Exercise 2.11</link></simpara>
+</sidebar>
 <simpara>In the example above, the tasks are the same, i.e., measuring the area,
 but are performed on two different input domains, i.e., the floors.
 Thus, both robots are performing essentially the same operations but on
@@ -4330,6 +4420,9 @@ on each subdomain. When done, the final answer is found by combining the
 answers. Running the robots on each floor is purely parallel, but
 combining the answers is concurrent since some interaction between the
 robots is necessary.</simpara>
+<sidebar>
+<simpara><link linkend="exercise2.12">Exercise 2.12</link></simpara>
+</sidebar>
 <simpara>Another way of solving a problem concurrently is to divide it into
 fundamentally different tasks. The tasks could be executed on different
 processors and perhaps on different input domains. Eventually, some
@@ -4337,8 +4430,7 @@ coordination of the tasks must be done to generate the final result. The
 next example illustrates such a division.</simpara>
 <example>
 <title>Task decomposition</title>
-<simpara>Let’s expand the problem given in Example <xref linkend="example:Domain
-decomposition"/>. R<superscript>3</superscript> robots can do more than just measure area. In
+<simpara>Let&#8217;s expand the problem given in <xref linkend="_domain_decomposition"/>. R<superscript>3</superscript> robots can do more than just measure area. In
 addition to calculating the living area of a home, we want an R<superscript>3</superscript> robot
 to check if the electrical outlets are in working condition. The robot
 should give us the area of the house as well as a list of electrical
@@ -4351,7 +4443,7 @@ pass and make a list of electrical outlets that are not working.</simpara>
 the area and R<superscript>3</superscript>B to identify broken electrical outlets. Once the
 respective tasks are assigned, we place the robots at the entrance to
 the house and activate them. It is possible that the two robots will
-bump into each other while working, and that’s one of the difficulties
+bump into each other while working, and that&#8217;s one of the difficulties
 of concurrency. The burden is on the programmer to give instructions so
 that the robots can avoid or recover from collisions. After the robots
 are done, we ask R<superscript>3</superscript>A for the living area of the house and R<superscript>3</superscript>B for a
@@ -4382,64 +4474,61 @@ interface and <literal>JOptionPane</literal> methods for a GUI.</simpara>
 solutions to problems and clarified the subtle difference between
 parallelism and concurrency.</simpara>
 </section>
-<section xml:id="_exercises">
+<section xml:id="_exercises_2">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara><xref linkend="exercise:problemSolvingExericise"/> When solving a problem using a
+<simpara><anchor xml:id="exercise2.1" xreflabel="[exercise2.1]"/> When solving a problem using a
 computer, what problem is solved by the programmer and what problem is
 solved by the program written by the programmer? Are they the same?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:doubleTypeExercise"/> In Example <xref linkend="example:Input for
-distance computation"/>, we declared all variables to be of type
+<simpara><anchor xml:id="exercise2.2" xreflabel="[exercise2.2]"/> In <xref linkend="DistanceProgram"/>, we declared all variables to be of type
 <literal>double</literal>. How would the program behave differently if we had declared
 all the variables with type <literal>int</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara>What is the purpose of the statement at
-line <xref linkend="createScannerGetInputDataObject"/> in
-Program <xref linkend="program:GetInputCLI"/>?</simpara>
+<simpara>What is the purpose of the statement <literal>Scanner in = new Scanner(System.in);</literal> in
+<xref linkend="GetInputCLIProgram"/>?</simpara>
 </listitem>
 <listitem>
 <simpara>Explain the difference between a declaration and an assignment
 statement.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:statementCategorizationExercise"/> Is the following
-statement from line <xref linkend="sampleDeclarationAndExecutableStatement"/> of
-Program <xref linkend="program:BouncingBallGUI"/> a declaration, an assignment, or a
+<simpara><anchor xml:id="exercise2.5" xreflabel="[exercise2.5]"/> Is the following
+statement from <xref linkend="BouncingBallGUIProgram"/> a declaration, an assignment, or a
 combination of the two?</simpara>
-<programlisting language="java" linenumbering="unnumbered">String response = JOptionPane.showInputDialog(
-    null, enterHeight, title,
-    JOptionPane.QUESTION_MESSAGE);</programlisting>
+<programlisting language="java" linenumbering="unnumbered">String response = JOptionPane.showInputDialog(null,
+	enterHeight, title, JOptionPane.QUESTION_MESSAGE);</programlisting>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:textOutputGraphicalOutputComparison"/> When would you
+<simpara><anchor xml:id="exercise2.6" xreflabel="[exercise2.6]"/> When would you
 prefer using the <literal>JOptionPane</literal> class for output over
 <literal>System.out.print()</literal>? When might you prefer <literal>System.out.print()</literal> to
 using <literal>JOptionPane</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:keywordLabeling"/> Review
-Program <xref linkend="program:BouncingBallGUI"/> and identify all the Java keywords
+<simpara><anchor xml:id="exercise2.7" xreflabel="[exercise2.7]"/> Review
+<xref linkend="BouncingBallGUIProgram"/> and identify all the Java keywords
 used in it.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:importStatementExercise"/> Try to recompile
-Program <xref linkend="program:BouncingBallGUI"/> after removing the <literal>import</literal>
+<simpara><anchor xml:id="exercise2.8" xreflabel="[exercise2.8]"/> Try to recompile
+<xref linkend="BouncingBallGUIProgram"/> after removing the <literal>import</literal>
 statement at the top. Read and explain the error message generated by
 the compiler.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:concurrentParallelExercise"/> Explain the difference
+<simpara><anchor xml:id="exercise2.9" xreflabel="[exercise2.9]"/> Explain the difference
 between parallel and concurrent tasks. Give examples of tasks that are
 parallel but not concurrent, tasks that are concurrent but not parallel,
 and tasks that are both.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:translationTimingExercise"/> Refer to
-Figure <xref linkend="documentTranslationFigure"/>. Suppose that you and your
+<simpara><anchor xml:id="exercise2.10" xreflabel="[exercise2.10]"/> Refer to
+<xref linkend="documentTranslationFigure"/>. Suppose that you and your
 colleague translate from English to Lellarapian at the rate of 200 words
 per hour. Suppose that the list of demands contains 10,000 words.</simpara>
 <orderedlist numeration="loweralpha">
@@ -4478,62 +4567,61 @@ increasing as you add more translators? Explain your answer.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:homeAreaCalculationAnalogyExercise"/> In
-Example <xref linkend="example:Domain_decomposition"/>, what aspect of a multicore
+<simpara><anchor xml:id="exercise2.11" xreflabel="[exercise2.11]"/> In
+<xref linkend="_domain_decomposition"/>, what aspect of a multicore
 system do the robots represent?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:homeAreaCalculationExerciseDifferentHomeStructures"/> In
-Example <xref linkend="example:Domain_decomposition"/>, suppose that you have two R<superscript>3</superscript>
+<simpara><anchor xml:id="exercise2.12" xreflabel="[exercise2.12]"/> In
+<xref linkend="_domain_decomposition"/>, suppose that you have two R<superscript>3</superscript>
 robots available. You would like to use these to measure the living area
 of a single floor home. Suggest how two robots could be programmed to
 work concurrently to measure the living area faster than one.</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:scannerPractice"/> Write a program that prompts the user
+<simpara><anchor xml:id="exercise2.13" xreflabel="[exercise2.13]"/> Write a program that prompts the user
 for three integers from the command line. Read each integer in using the
 <literal>nextInt()</literal> method of a <literal>Scanner</literal> object. Compute the sum of these
 values and print it to the screen using <literal>System.out.print()</literal> or
 <literal>System.out.println()</literal>.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:scannerAverage"/> Expand the program from
-Exercise <xref linkend="exercise:scannerPractice"/> so that it finds the average of
+<simpara><anchor xml:id="exercise2.14" xreflabel="[exercise2.14]"/> Expand the program from
+<link linkend="exercise2.13">Exercise 2.13</link> so that it finds the average of
 the three numbers instead of the sum. (Hint: Try dividing by <literal>3.0</literal>
 instead of <literal>3</literal> to get an average with a fractional part. Then, store the
 result in a variable of type <literal>double</literal>.)</simpara>
 </listitem>
 <listitem>
-<simpara>Rewrite your solution to Exercise <xref linkend="exercise:scannerAverage"/> so
+<simpara>Rewrite your solution to <link linkend="exercise2.14">Exercise 2.14</link> so
 that it uses a <literal>JOptionPane</literal>-based GUI instead of <literal>Scanner</literal> and
 <literal>System.out.print()</literal>.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:getInputDataExercise"/> Copy and paste
-Program <xref linkend="program:GetInputCLI"/> into the Java IDE you prefer. Compile
+<simpara><anchor xml:id="exercise2.16" xreflabel="[exercise2.16]"/> Copy and paste
+<xref linkend="GetInputCLIProgram"/> into the Java IDE you prefer. Compile
 and run it and make sure that the program executes as intended. Then,
 add statements to prompt the user for the color of the ball and read it
 in. Store the color in a <literal>String</literal> value. Add an output statement that
 mentions the color of the ball.</simpara>
 </listitem>
 <listitem>
-<simpara>Rewrite your solution to Exercise <xref linkend="exercise:getInputDataExercise"/>
+<simpara>Rewrite your solution to <link linkend="exercise2.16">Exercise 2.16</link>
 so that it uses a <literal>JOptionPane</literal>-based GUI instead of <literal>Scanner</literal> and
 <literal>System.out.print()</literal>.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:distanceComputationExercise"/> In Example <xref linkend="example:Input
-for distance computation"/>, we assumed that the speed is given in miles
-per hour and the time in hours. Change Program <xref linkend="program:Distance"/> to
+<simpara><anchor xml:id="exercise2.18" xreflabel="[exercise2.18]"/> In <xref linkend="inputForDistanceComputationExample"/>, we assumed that the speed is given in miles
+per hour and the time in hours. Change <xref linkend="DistanceProgram"/> to
 compute the distance traveled by a moving object given its speed in
 miles per hour but time in seconds. You will need to perform a
 conversion from seconds to hours before you can find the distance.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:stringInputExercise"/> A program can use both a command
+<simpara><anchor xml:id="exercise2.19" xreflabel="[exercise2.19]"/> A program can use both a command
 line interface and a GUI to interact with a user. Write a program that
-uses the <literal>Scanner</literal> class to read a <literal>String</literal> value containing the user’s
+uses the <literal>Scanner</literal> class to read a <literal>String</literal> value containing the user&#8217;s
 favorite food. Then display the name of the food using <literal>JOptionPane</literal>.</simpara>
 </listitem>
 <listitem>
@@ -4568,7 +4656,7 @@ error handling be different from an audience of architects?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Primitive_Types_and_Strings">
+<chapter xml:id="_primitive_types_and_strings">
 <title>Primitive Types and Strings</title>
 <blockquote>
 <attribution>
@@ -4626,7 +4714,7 @@ amount, however, requires a formula from financial mathematics. Let
 divided by 12). Let <inlineequation><alt><![CDATA[N]]></alt><mathphrase><![CDATA[N]]></mathphrase></inlineequation> be the number of months to pay back
 the loan (years of the loan times 12). Let <inlineequation><alt><![CDATA[M]]></alt><mathphrase><![CDATA[M]]></mathphrase></inlineequation> be the
 monthly payment we want to calculate, then:</simpara>
-<simpara><inlineequation><alt><![CDATA[M = P \times \frac{J}{1 - (1 + J)^{-N}}]]></alt><mathphrase><![CDATA[M = P \times \frac{J}{1 - (1 + J)^{-N}}]]></mathphrase></inlineequation></simpara>
+<simpara><inlineequation><alt><![CDATA[M = P \cdot \frac{J}{1 - (1 + J)^{-N}}]]></alt><mathphrase><![CDATA[M = P \cdot \frac{J}{1 - (1 + J)^{-N}}]]></mathphrase></inlineequation></simpara>
 <simpara>If you use the concepts and syntax from the previous chapter carefully,
 you might be able to solve this problem without reading further.
 However, there is a depth to the ideas of types and operations that we
@@ -4677,7 +4765,7 @@ int y;</programlisting>
 only contain integer values in this range. Furthermore, a type only
 allows specific operations. In Java, the <literal>int</literal> type allows addition,
 subtraction, multiplication, division, and several other operations we
-will talk about in Section <xref linkend="syntax:Types_in_Java"/>, but you cannot
+will talk about in <xref linkend="_syntax_types_in_java"/>, but you cannot
 directly raise an <literal>int</literal> value to a power in Java. Let&#8217;s assume that <literal>x</literal>
 is of type <literal>int</literal>. As we discussed in the previous chapter, the
 expression <literal>x + 2</literal> performs addition between the variable represented by
@@ -4698,7 +4786,7 @@ if all the types make sense.</simpara>
 </section>
 <section xml:id="_primitive_and_reference_types_in_java">
 <title>Primitive and reference types in Java</title>
-<simpara>As shown in Figure <xref linkend="typesInJavaFigure"/>(a), there are two kinds of
+<simpara>As shown in <xref linkend="typesInJavaFigure"/>(a), there are two kinds of
 types in Java: <emphasis>primitive types</emphasis> and <emphasis>reference types</emphasis>. Primitive types
 are like boxes that hold single, concrete values. The primitive types in
 Java are <literal>byte</literal>, <literal>short</literal>, <literal>int</literal>, <literal>long</literal>, <literal>float</literal>, <literal>double</literal>, <literal>boolean</literal>,
@@ -4706,8 +4794,8 @@ and <literal>char</literal>. These are types provided by the designers of Java, 
 not possible to create new ones. Each primitive type has a set of
 <emphasis>operators</emphasis> that are legal for it. For example, all the numerical types
 can be used with <literal>+</literal> and <literal>-</literal>. We&#8217;ll talk about these types and their
-operators in great detail in Section <xref linkend="syntax:Types_in_Java"/>.</simpara>
-<figure>
+operators in great detail in <xref linkend="_syntax_types_in_java"/>.</simpara>
+<figure xml:id="typesInJavaFigure">
 <title>(a) The two categories of types in Java. The <literal>int</literal> primitive type (b), the <literal>boolean</literal> primitive type (c), the <literal>String</literal> reference type (d), and a possible <literal>Aircraft</literal> reference type (e) are represented as sets of items with operations.</title>
 <mediaobject>
 <imageobject>
@@ -4759,6 +4847,9 @@ concrete instance of the data. The reference is the variable that gives
 a name to (points to) the object. The type is the class that both the
 variable and the object have, which defines what kinds of data the
 object has and what operations it can perform.</simpara>
+<sidebar>
+<simpara><link linkend="exercise3.12">Exercise 3.12</link></simpara>
+</sidebar>
 <simpara>The following table lists some of the differences between primitive
 types and reference types.</simpara>
 <informaltable frame="all" rowsep="1" colsep="1">
@@ -4875,7 +4966,7 @@ expressions. Just like variables, literals have types. The type of <literal>5</l
 is <literal>int</literal> while the type of <literal>5.0</literal> is <literal>double</literal>. Other types have literals
 written in ways we&#8217;ll discuss below.</simpara>
 </section>
-<section xml:id="subsection:Primitive_types">
+<section xml:id="_primitive_types">
 <title>Primitive types</title>
 <simpara>The building blocks of all Java programs are primitive types. Even
 objects must fundamentally contain primitive types deep down inside.
@@ -4888,7 +4979,7 @@ the four types <literal>byte</literal>, <literal>short</literal>, <literal>int</
 (holding positive and negative numbers) and represent numbers in two&#8217;s
 complement. They only differ by the range of values that each type can
 hold. These ranges and the number of bytes used to represent variables
-from each type are given in Table <xref linkend="rangePrimitiveTypes"/>.</simpara>
+from each type are given below.</simpara>
 <table role="center" frame="all" rowsep="1" colsep="1">
 <title>Ranges for primitive integer types in Java.</title>
 <tgroup cols="5">
@@ -4941,11 +5032,14 @@ from each type are given in Table <xref linkend="rangePrimitiveTypes"/>.</simpa
 <simpara>Note that the range of <literal>byte</literal> is included in that of <literal>short</literal>, of <literal>short</literal>
 in that of <literal>int</literal>, and so on. We say that <literal>short</literal> is <emphasis>broader</emphasis> than
 <literal>byte</literal>, <literal>int</literal> is broader than <literal>short</literal>, and <literal>long</literal> is broader than <literal>int</literal>.</simpara>
+<sidebar>
+<simpara><link linkend="exercise3.1">Exercise 3.1</link></simpara>
+</sidebar>
 <simpara>A variable declared with type <literal>byte</literal> can only represent 256 different
 values, the integers in the range -128 to 127. Why use <literal>byte</literal> at all,
 then? Since a <literal>byte</literal> value only takes up a single byte, it can save
 memory, especially if you have a list of variables called an <emphasis>array</emphasis>,
-which we will discuss in Chapter <xref linkend="chapter:Arrays"/>. However, too narrow
+which we will discuss in <xref linkend="_arrays"/>. However, too narrow
 of a range will result in underflow and overflow. Java programmers are
 advised to stick with <literal>int</literal> for general use. If you need to represents
 values larger than 2 billion or smaller than -2 billion, use <literal>long</literal>.
@@ -5007,7 +5101,7 @@ of Java.</simpara>
 <title>Floating point numbers: <literal>float</literal> and <literal>double</literal></title>
 <simpara>To represent numbers with fractional parts, Java provides two floating
 point types, <literal>double</literal> and <literal>float</literal>. Because of limits on floating point
-precision discussed in Chapter <xref linkend="chapter:Computer_Basics"/>, Java cannot
+precision discussed in <xref linkend="_computer_basics"/>, Java cannot
 represent all rational or real numbers, but these types provide good
 approximations. If you have a variable that takes on floating point
 values such as 3.14, 1.707 × 10<superscript>25</superscript>,
@@ -5034,7 +5128,7 @@ if you would like to write the sign of the exponent explicitly).</simpara>
 </section>
 <section xml:id="_accuracy_in_number_representation">
 <title>Accuracy in number representation</title>
-<simpara>As discussed in Chapter <xref linkend="chapter:Computer_Basics"/>, integer types
+<simpara>As discussed in <xref linkend="_computer_basics"/>, integer types
 within their specified ranges have their exact representations. For
 example, if you assign <literal>19</literal> to a variable of type <literal>int</literal> and then print
 this value, you always get exactly <literal>19</literal>. Floating point numbers do not
@@ -5188,7 +5282,7 @@ instead of dividing by <literal>2</literal>.<?asciidoc-br?></simpara>
 <simpara>You may not have thought about this idea since elementary school, but
 the division operator (<literal>/</literal>) finds the quotient of two numbers. The
 modulus operator (<literal>%</literal>) finds the remainder. For example, <literal>15 / 6</literal> is
-<literal>2</literal>, but <literal>15 \% 6</literal> is <literal>3</literal> because <literal>6</literal> goes into <literal>15</literal> twice with <literal>3</literal> left
+<literal>2</literal>, but <literal>15 % 6</literal> is <literal>3</literal> because <literal>6</literal> goes into <literal>15</literal> twice with <literal>3</literal> left
 over. The modulus operator is usually used with integer values, but it
 is also defined to work with floating point values in Java. It&#8217;s easy to
 dismiss the modulus operator because we don&#8217;t often use it in daily
@@ -5449,7 +5543,7 @@ should always strive to make your own code as readable as possible.</simpara>
 <title>Bitwise operators</title>
 <simpara>In addition to normal mathematical operators, Java provides a set of
 <emphasis>bitwise</emphasis> operators corresponding to the operations we discussed in
-Chapter <xref linkend="chapter:Computer_Basics"/>. These operators perform bitwise
+<xref linkend="_computer_basics"/>. These operators perform bitwise
 operations on integer values. The bitwise operators are <literal>&amp;</literal>, <literal>|</literal>, <literal>^</literal>,
 and <literal>~</literal> (which is unary). In addition, there are bitwise <emphasis>shift</emphasis>
 operators: <literal>&lt;&lt;</literal> for signed left shift, <literal>&gt;&gt;</literal> for signed right shift, and
@@ -5523,7 +5617,10 @@ representation is a fundamental part of bitwise operators.</simpara>
 <simpara>The following example shows these operators in use. In order to
 understand the output, you need to understand how integers are
 represented in the binary number system, which is discussed in
-Section <xref linkend="syntax:Data_representation"/>.</simpara>
+<xref linkend="_syntax_data_representation"/>.</simpara>
+<sidebar>
+<simpara><link linkend="exercise3.5">Exercise 3.5</link></simpara>
+</sidebar>
 <example>
 <title>Binary operators in Java</title>
 <simpara>The following code shows a sequence of bitwise operations performed with
@@ -5590,7 +5687,7 @@ and Java allows it with no complaint. Most languages allow upcasts
 without any special syntax because it is always safer to move from a
 narrower, more restrictive type to a broader, less restrictive one.</simpara>
 </example>
-<example>
+<example xml:id="downcastErrorExample">
 <title>Downcast error</title>
 <simpara>Consider these statements that declare variables <literal>a</literal>, <literal>b</literal>, and <literal>c</literal> and
 compute a value for <literal>c</literal>.</simpara>
@@ -5611,6 +5708,9 @@ Java compiler is inherently cautious. It complains whenever the type of
 the expression to be evaluated is broader than the type of the
 destination variable.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise3.2">Exercise 3.2</link></simpara>
+</sidebar>
 <example>
 <title>Upcast from integers to floating point</title>
 <simpara>Integers are automatically converted to floating point when needed.
@@ -5666,6 +5766,9 @@ fit in an <literal>int</literal> value. Since <literal>long</literal> is a broad
 have to downcast the result to an <literal>int</literal> so that we can store it in
 <literal>count</literal>.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise3.10">Exercise 3.10</link></simpara>
+</sidebar>
 <example>
 <title>Conversion from double to float</title>
 <simpara>Consider the following declaration and assignment of variable
@@ -5690,6 +5793,9 @@ should you use <literal>float</literal> values. By making it illegal to store <l
 a <literal>float</literal> variable, Java is encouraging you to use high precision
 storage.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise3.3">Exercise 3.3</link></simpara>
+</sidebar>
 <simpara>Numerical types and the conversions between them are critical elements
 of programming in Java, which has a strong mathematical foundation. In
 addition to these numerical types, Java also provides two other types
@@ -5704,7 +5810,7 @@ we need a way to represent letters and other characters that we might
 find in printed text. Values with the <literal>char</literal> type are used to represent
 individual letters.</simpara>
 <simpara>In the older languages of C and C++, the <literal>char</literal> type used 8 bits for
-storage. From Chapter <xref linkend="chapter:Computer_Basics"/>, you know that you can
+storage. From <xref linkend="_computer_basics"/>, you know that you can
 represent up to 2<superscript>8</superscript> = 256 values with 8 bits. The Latin
 alphabet, which is used to write English, uses 26 letters. If we need to
 represent upper and lower case letters, the 10 decimal digits,
@@ -5809,7 +5915,7 @@ following statement adds the integer equivalents of the characters
 designed to hold only true and false values. These values are called
 <emphasis>Boolean values</emphasis>, and the logic used to manipulate them turns out to be
 crucial to almost every program. We use them to represent conditions in
-Chapters <xref linkend="chapter:Selection"/>, <xref linkend="chapter:Repetition"/>, and beyond.</simpara>
+<xref linkend="_selection"/>, <xref linkend="_repetition"/>, and beyond.</simpara>
 <simpara>To store these truth values, Java uses the type <literal>boolean</literal>. There are
 exactly two literals for type <literal>boolean</literal>: <literal>true</literal> and <literal>false</literal>. Here are
 two declarations and assignments of <literal>boolean</literal> variables.</simpara>
@@ -5933,7 +6039,7 @@ your operands is <literal>true</literal>. The unary logical NOT operator (<liter
 the opposite value of its operand, switching <literal>true</literal> to <literal>false</literal> or
 <literal>false</literal> to <literal>true</literal>. Both the relational operators and the logical
 operators are described in greater detail in
-Chapter <xref linkend="chapter:Selection"/>.</simpara>
+<xref linkend="_selection"/>.</simpara>
 </section>
 </section>
 <section xml:id="_reference_types">
@@ -6012,21 +6118,27 @@ double quotes (<literal>"</literal>), such as <literal>"Fight the power!"</liter
 <literal>String</literal> reference and initialize it by setting it equal to another
 <literal>String</literal> reference or a <literal>String</literal> literal. Like any other reference, you
 could leave it uninitialized.</simpara>
+<sidebar>
+<simpara><link linkend="exercise3.18">Exercise 3.18</link></simpara>
+</sidebar>
 <simpara>There is a difference between an uninitialized <literal>String</literal> (a reference
 that points to <literal>null</literal>) and a <literal>String</literal> of length 0. A <literal>String</literal> of length
 0 is also known as an <emphasis>empty string</emphasis> and is written <literal>""</literal>. The space
-character (<literal>' '</literal>) and escape sequences such as <literal>'\\n'</literal> can be a part of
+character (<literal>' '</literal>) and escape sequences such as <literal>'\n'</literal> can be a part of
 a <literal>String</literal> and add to its length. For example, <literal>"ABC"</literal> contains three
 characters, but the <literal>String</literal> <literal>"A B C"</literal> has five, because the spaces on
 each side of <literal>'B'</literal> count. The next example illustrates some ways of
 defining and using the <literal>String</literal> type.</simpara>
+<sidebar>
+<simpara><link linkend="exercise3.17">Exercise 3.17</link></simpara>
+</sidebar>
 <example>
 <title>String assignment</title>
 <simpara>The following declarations define two <literal>String</literal> references named
 <literal>greeting</literal> and <literal>title</literal> and initialize each with a literal.</simpara>
 <programlisting language="java" linenumbering="unnumbered">String greeting = "Bonjour!"
 String title = "French Greeting";</programlisting>
-<simpara>As you have seen in Chapter <xref linkend="chapter:Problem_Solving_and_Programming"/>,
+<simpara>As you have seen in <xref linkend="_problem_solving_and_programming"/>,
 <literal>String</literal> values can be output using <literal>System.out.print()</literal> and
 <literal>JOptionPane</literal> methods.</simpara>
 <programlisting language="java" linenumbering="unnumbered">System.out.println(greeting);
@@ -6038,7 +6150,7 @@ and the message <literal>Bonjour!</literal></simpara>
 </section>
 <section xml:id="_literal_string_literal_operations">
 <title><literal>String</literal> operations</title>
-<simpara>In Chapter <xref linkend="chapter:Problem_Solving_and_Programming"/>, you saw that we
+<simpara>In <xref linkend="_problem_solving_and_programming"/>, you saw that we
 can <emphasis>concatenate</emphasis> two <literal>String</literal> objects into a third <literal>String</literal> object
 using the <literal>+</literal> operator. This operator is unusual for a reference type.
 Almost all other reference types are only able to use the assignment
@@ -6090,7 +6202,7 @@ can use the <literal>charAt()</literal> method.</simpara>
 <simpara>This method is called with an <literal>int</literal> value giving the index you want to
 know about. Indexes inside of a <literal>String</literal> start at 0, not at 1.
 Zero-based numbering is used extensively in programming, and we discuss
-it further in Chapter <xref linkend="chapter:Arrays"/>. (It may help if you think of
+it further in <xref linkend="_arrays"/>. (It may help if you think of
 the index as the number of characters that appear before the character
 at the specified index.) The next example shows how <literal>charAt()</literal> can be
 used.</simpara>
@@ -6200,7 +6312,7 @@ values. If <literal>x</literal> were assigned <literal>6</literal> instead, <lit
 <programlisting language="java" linenumbering="unnumbered">String thing1 = new String("Magical mystery");
 String thing2 = new String("Magical mystery");
 String thing3 = new String("Tragical tapestry");</programlisting>
-<figure>
+<figure xml:id="differentObjectsFigure">
 <title>Objects <literal>thing1</literal>, <literal>thing2</literal>, and <literal>thing3</literal> (a) in their initial states and (b) after the assignment <literal>thing1 = thing2;</literal>.</title>
 <mediaobject>
 <imageobject>
@@ -6226,12 +6338,12 @@ the value held by a reference is the arrow that points to the object,
 the comparison operator only shows that two references are the same if
 they point at the same object.</simpara>
 <simpara>To better understand comparison between reference types, consider
-Figure <xref linkend="differentObjectsFigure"/>(a), which shows three different
+<xref linkend="differentObjectsFigure"/>(a), which shows three different
 objects. Note that each reference points at a distinct object, even
 though two objects have the same contents.</simpara>
 <simpara>Now consider the following assignment.</simpara>
 <programlisting language="java" linenumbering="unnumbered">thing1 = thing2;</programlisting>
-<simpara>As shown in Figure <xref linkend="differentObjectsFigure"/>(b), this assignment points
+<simpara>As shown in <xref linkend="differentObjectsFigure"/>(b), this assignment points
 reference <literal>thing1</literal> to the same location as reference <literal>thing2</literal>. Then,
 <literal>(thing1 == thing2)</literal> would be <literal>true</literal>.</simpara>
 <simpara>The <literal>==</literal> operator is generally not very useful with references, and the
@@ -6242,6 +6354,9 @@ For example,</simpara>
 <simpara>is <literal>true</literal> when <literal>thing1</literal> and <literal>thing2</literal> are pointing at distinct but
 identical <literal>String</literal> objects.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise3.13">Exercise 3.13</link></simpara>
+</sidebar>
 </section>
 </section>
 <section xml:id="_constants">
@@ -6296,15 +6411,12 @@ few other useful libraries.</simpara>
 <title>The <literal>Math</literal> library</title>
 <simpara>Basic arithmetic operators are useful, but Java also provides a rich set
 of mathematical methods through the <literal>Math</literal> class.
-Table <xref linkend="mathFunctionsTable"/> lists a few of the methods available. For a
+The following table lists a few of the methods available. For a
 complete list of methods provided by the <literal>Math</literal> class at the time of
 writing, visit
 <link xl:href="http://download.oracle.com/javase/7/docs/api/java/lang/Math.html">http://download.oracle.com/javase/7/docs/api/java/lang/Math.html</link>.</simpara>
-<formalpara>
-<title>A sample of methods available in the Java <literal>Math</literal> class. Arguments to</title>
-<para>trigonometric methods are given in radians.</para>
-</formalpara>
-<informaltable role="center" frame="all" rowsep="1" colsep="1">
+<table role="center" frame="all" rowsep="1" colsep="1">
+<title>A sample of methods available in the Java <literal>Math</literal> class. Arguments to trigonometric methods are given in radians.</title>
 <tgroup cols="3">
 <colspec colname="col_1" colwidth="33.3333*"/>
 <colspec colname="col_2" colwidth="33.3333*"/>
@@ -6377,15 +6489,15 @@ rounding a <literal>float</literal>).</simpara></entry>
 </row>
 </tbody>
 </tgroup>
-</informaltable>
+</table>
 <example>
 <title>Math library usage</title>
 <simpara>Here is a program that uses the <literal>Math.pow()</literal> method to compute compound
 interest. Unlike <literal>Scanner</literal> and <literal>JOptionPane</literal>, the <literal>Math</literal> class is
 imported by default in Java programs and requires no explicit import
 statement.</simpara>
-<formalpara xml:id="program:CompoundInterestCalculator" xreflabel="CompoundInterestCalculator">
-<title>Program to compute interest earned and new balance.</title>
+<formalpara xml:id="CompoundInterestCalculatorProgram">
+<title>Computes interest earned and new balance.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -6471,21 +6583,21 @@ video game.</simpara>
 <example>
 <title>Dragon attribute generation</title>
 <simpara>Suppose you are designing a video in which the hero must fight a dragon
-with random attributes. Program <xref linkend="program:DragonAttributes"/> generates
+with random attributes. <xref linkend="DragonAttributesProgram"/> generates
 random values for the age, height, gender, and hit points of the dragon.</simpara>
-<formalpara xml:id="program:DragonAttributes" xreflabel="DragonAttributes">
-<title>Program to set attributes of a randomly generated dragon for a video game.</title>
+<formalpara xml:id="DragonAttributesProgram">
+<title>Sets attributes of a randomly generated dragon for a video game.</title>
 <para>
-<programlisting language="java" linenumbering="numbered">import java.util.*;
+<programlisting language="java" linenumbering="numbered">import java.util.*; <co xml:id="CO3-1"/>
 
 public class DragonAttributes {
     public static void main(String[] args) {
-    	Random random = new Random();/*@\label{createRandomNumberGeneratorLine}@*/
-        int age = random.nextInt(100) + 1;/*@\label{generateAgeLine}@*/
-        double height = random.nextDouble()*30;/*@\label{generateHeightLine}@*/
-        boolean gender = random.nextBoolean();/*@\label{generateStatusLine}@*/
-        int hitPoints = random.nextInt(51) + 25;
-        System.out.println("Dragon Statistics");/*@\label{displayTurtleAttributesLine}@*/
+    	Random random = new Random(); <co xml:id="CO3-2"/>
+        int age = random.nextInt(100) + 1; <co xml:id="CO3-3"/>
+        double height = random.nextDouble()*30; <co xml:id="CO3-4"/>
+        boolean gender = random.nextBoolean(); <co xml:id="CO3-5"/>
+        int hitPoints = random.nextInt(51) + 25; <co xml:id="CO3-6"/>
+        System.out.println("Dragon Statistics");
         System.out.println("Age:\t\t" + age);
         System.out.format("Height:\t\t%.1f feet\n", height);
         System.out.println("Female:\t\t" + gender);
@@ -6494,20 +6606,33 @@ public class DragonAttributes {
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Note that we begin by importing <literal>java.util.*</literal> to include all the classes
-in the <literal>java.util</literal> package, including <literal>Random</literal>. At
-line <xref linkend="createRandomNumberGeneratorLine"/>, we create an object <literal>random</literal>
-of type <literal>Random</literal>. At line <xref linkend="generateAgeLine"/>, we use it to generate a
-random <literal>int</literal> between <literal>0</literal> and <literal>99</literal>, to which we add <literal>1</literal>, making an age
-between <literal>1</literal> and <literal>100</literal>. To generate the height, we multiply a random
-<literal>double</literal> by <literal>75</literal>, yielding a value between <literal>0.0</literal> and <literal>75.0</literal> (exclusive).
-Since there are only two choices for a dragon&#8217;s gender, we generate a
+<calloutlist>
+<callout arearefs="CO3-1">
+<para>We begin by importing <literal>java.util.*</literal> to include all the classes
+in the <literal>java.util</literal> package, including <literal>Random</literal>.</para>
+</callout>
+<callout arearefs="CO3-2">
+<para>Then, we create an object <literal>random</literal> of type <literal>Random</literal>.</para>
+</callout>
+<callout arearefs="CO3-3">
+<para>We use <literal>random</literal> to generate a random <literal>int</literal> between <literal>0</literal> and <literal>99</literal>, to which we add <literal>1</literal>, making an age between <literal>1</literal> and <literal>100</literal>.</para>
+</callout>
+<callout arearefs="CO3-4">
+<para>To generate the height, we multiply a random <literal>double</literal> by <literal>75</literal>, yielding a value between <literal>0.0</literal> and <literal>75.0</literal> (exclusive).</para>
+</callout>
+<callout arearefs="CO3-5">
+<para>Since there are only two choices for a dragon&#8217;s gender, we generate a
 random <literal>boolean</literal> value, interpreting <literal>true</literal> as female and <literal>false</literal> as
-male. Finally, we determine the number of hit points the dragon has by
+male.</para>
+</callout>
+<callout arearefs="CO3-6">
+<para>Finally, we determine the number of hit points the dragon has by
 generating a random <literal>int</literal> between <literal>0</literal> and <literal>50</literal>, then add <literal>25</literal> to it,
-yielding a value between <literal>25</literal> and <literal>75</literal>.</simpara>
+yielding a value between <literal>25</literal> and <literal>75</literal>.</para>
+</callout>
+</calloutlist>
 <simpara>Because we are using random values, the output of
-Program <xref linkend="program:DragonAttributes"/> changes every time we run the
+<xref linkend="DragonAttributesProgram"/> changes every time we run the
 program. Sample output is given below.</simpara>
 <literallayout class="monospaced">Dragon Statistics
 Age:            90
@@ -6549,7 +6674,7 @@ support: <literal>Byte</literal>, <literal>Short</literal>, <literal>Integer</li
 <simpara>A common task for a wrapper class is to convert a <literal>String</literal>
 representation of a number such as <literal>"37"</literal> or <literal>"2.097"</literal> to its
 corresponding numeric value. We had such a situation in
-Program <xref linkend="program:GetInputGUI"/>, where we did the conversion as follows.</simpara>
+<xref linkend="GetInputGUIProgram"/>, where we did the conversion as follows.</simpara>
 <programlisting language="java" linenumbering="unnumbered">String response = JOptionPane.showInputDialog(null, enterHeight, title, JOptionPane.QUESTION_MESSAGE);
 height = Double.parseDouble(response);</programlisting>
 <simpara>This code uses the <literal>JOptionPane.showInputDialog()</literal> method to get from
@@ -6578,12 +6703,15 @@ convert it to a number. We used the <literal>Integer.parseInt()</literal>,
 <literal>String</literal> to <literal>int</literal>, <literal>float</literal>, and <literal>double</literal> values, respectively. Each
 method gives us 15 stored as the appropriate type.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise3.19">Exercise 3.19</link></simpara>
+</sidebar>
 <simpara>What happens if the <literal>String</literal> <literal>"15.5"</literal> (or even <literal>"cinnamon"</literal>) is given as
 input to the <literal>Integer.parseInt()</literal> method? If the <literal>String</literal> is not
 formatted as the appropriate kind of number, Java throws a
 <literal>NumberFormatException</literal>, probably crashing the program. An <emphasis>exception</emphasis>
 is an error that happens in the middle of running a program. We discuss
-how to work with exceptions in Chapter <xref linkend="chapter:Exceptions"/>.</simpara>
+how to work with exceptions in <xref linkend="_exceptions"/>.</simpara>
 </section>
 <section xml:id="_literal_character_literal_methods">
 <title><literal>Character</literal> methods</title>
@@ -6656,7 +6784,7 @@ executed.</simpara>
 </section>
 <section xml:id="_maximum_and_minimum_values">
 <title>Maximum and minimum values</title>
-<simpara>As you recall from Chapter <xref linkend="chapter:Computer_Basics"/>, integer
+<simpara>As you recall from <xref linkend="_computer_basics"/>, integer
 arithmetic in Java has limitations. If you increase a large positive
 number past its maximum value, it becomes a large magnitude negative
 number, a phenomenon called overflow. Conversely, if you decrease a
@@ -6745,6 +6873,9 @@ integer arithmetic in Java is done assuming type <literal>int</literal>, unless
 explicitly specified otherwise. Thus, <literal>Short.MAX_VALUE + 1</literal> does not
 overflow to a negative value unless you store the result into a <literal>short</literal>.
 The same rules apply to underflow.</simpara>
+<sidebar>
+<simpara><link linkend="exercise3.6">Exercise 3.6</link></simpara>
+</sidebar>
 <simpara>Overflow and underflow do not work in the same way with the floating
 point numbers represented by <literal>float</literal> and <literal>double</literal>. The expression
 <literal>Double.MAX_VALUE + 1</literal> results in <literal>Double.MAX_VALUE</literal> because <literal>1</literal> is so
@@ -6753,6 +6884,10 @@ small in comparison that it is lost in rounding error. However,
 constant used to represent any value larger than <literal>Double.MAX_VALUE</literal>
 Since <literal>Double.MIN_VALUE</literal> is the smallest non-zero number,
 <literal>Double.MIN_VALUE - 1</literal> evaluates to <literal>-1.0</literal>.</simpara>
+<sidebar>
+<simpara><link linkend="exercise3.7">Exercise 3.7</link><?asciidoc-br?>
+<link linkend="exercise3.8">Exercise 3.8</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_using_wrapper_classes_for_storage">
 <title>Using wrapper classes for storage</title>
@@ -6784,7 +6919,7 @@ operations with wrapper classes.</simpara>
 <simpara>Fortunately, automatic boxing and unboxing reduces the need to think
 about wrapper classes, and most programmers will rarely need to declare
 an explicit wrapper reference. We will discuss wrapper classes further
-in Chapter <xref linkend="chapter:Dynamic_Data_Structures"/>, where they are used to
+in <xref linkend="_dynamic_data_structures"/>, where they are used to
 allow generic classes<emphasis>generic class</emphasis> to store primitive types as well
 as reference types.</simpara>
 </section>
@@ -6803,12 +6938,11 @@ uses all of these features at some level.</simpara>
 import <literal>java.util.*</literal> so that we can use the <literal>Scanner</literal> class. Then, we
 start the enclosing <literal>CollegeCosts</literal> class, begin the <literal>main()</literal> method,
 print a welcome message for the user, and create a <literal>Scanner</literal> object.</simpara>
-<programlisting language="java" linenumbering="numbered">import java.util.*;
+<programlisting language="java" linenumbering="unnumbered">import java.util.*;
 
 public class CollegeCosts {
 	public static void main(String[] args) {
-		System.out.println(
-			"Welcome to the College Cost Calculator!");
+		System.out.println("Welcome to the College Cost Calculator!");
 		Scanner in = new Scanner(System.in);</programlisting>
 <simpara>Next is a sequence of prompts to the user interspersed with input done
 with the <literal>Scanner</literal> object. The program reads the user&#8217;s first name as a
@@ -6817,7 +6951,7 @@ cost as a <literal>double</literal>, the monthly cost of rent as a <literal>doub
 cost of food as a <literal>double</literal>, the interest rate for the loan as a
 <literal>double</literal>, and the number of years needed to pay back the loan as an
 <literal>int</literal>.</simpara>
-<programlisting language="java" linenumbering="numbered">		System.out.print("Enter your first name:\t\t");
+<programlisting language="java" linenumbering="unnumbered">		System.out.print("Enter your first name:\t\t");
 		String firstName = in.next();
 		System.out.print("Enter your last name:\t\t");
 		String lastName = in.next();
@@ -6839,23 +6973,19 @@ monthly payment, we find the monthly interest by dividing the annual
 interest rate by 12 and plugging this value into the formula from the
 beginning of the chapter. Finally, the total cost of the loan is the
 monthly payment times 12 times the number of years.</simpara>
-<programlisting language="java" linenumbering="numbered">		double yearlyCost = semesterTuition * 2.0 +
-			(monthlyRent + monthlyFood) * 12.0;
+<programlisting language="java" linenumbering="unnumbered">		double yearlyCost = semesterTuition * 2.0 + (monthlyRent + monthlyFood) * 12.0;
 		double fourYearCost = yearlyCost * 4.0;
 		double monthlyInterest = annualInterest / 12.0;
 		double monthlyPayment = fourYearCost * monthlyInterest /
-			(1.0 - Math.pow(1.0 + monthlyInterest,
-			-years * 12.0));
+			(1.0 - Math.pow(1.0 + monthlyInterest, -years * 12.0));
 		double totalLoanCost = monthlyPayment * 12.0 * years;</programlisting>
 <simpara>All that remains is to print out the output. First, we output a header
 describing the following output as college costs for the user. Using
-<literal>System.out.format()</literal> as described in Subsection <xref linkend="subsection:Primitive_types"/>, we print out the yearly cost, four year cost, monthly loan
+<literal>System.out.format()</literal> as described in <xref linkend="_primitive_types"/>, we print out the yearly cost, four year cost, monthly loan
 payment, and total cost, all formatted with dollar signs, 2 places after
 the decimal point, and tabs so that the output lines up.</simpara>
-<programlisting language="java" linenumbering="numbered">		System.out.println("\nCollege costs for " +
-				firstName + " " + lastName );
-		System.out.println(
-				"***************************************");
+<programlisting language="java" linenumbering="unnumbered">		System.out.println("\nCollege costs for " + firstName + " " + lastName );
+		System.out.println("***************************************");
 		System.out.print("Yearly cost:\t\t\t$");
 		System.out.format("%.2f\n", yearlyCost);
 		System.out.print("Four year cost:\t\t\t$");
@@ -6869,7 +6999,7 @@ the decimal point, and tabs so that the output lines up.</simpara>
 </section>
 <section xml:id="_concurrency_expressions">
 <title>Concurrency: Expressions</title>
-<simpara>In Section <xref linkend="concurrency:Solving_problems_in_parallel"/>, we introduced
+<simpara>In <xref linkend="_concurrency_solving_problems_in_parallel"/>, we introduced
 the ideas of task and domain decomposition that could be used to solve a
 problem in parallel. By splitting up the jobs to be done (as in task
 decomposition) or dividing a large amount of data into pieces (as in
@@ -6908,13 +7038,13 @@ answer. The following example illustrates these steps.</simpara>
 <programlisting language="java" linenumbering="unnumbered">double value = f(a,b)*g(c);</programlisting>
 <simpara>This statement evaluates methods <literal>f()</literal> and <literal>g()</literal>, multiplies the
 computed values, and assigns the result to variable <literal>value</literal>. In
-Figure <xref linkend="splitExpressionFigure"/>, we show two ways of evaluating the
-expression <literal>f(a,b)*g(c)</literal>. Figure <xref linkend="splitExpressionFigure"/>(a) shows
+<xref linkend="splitExpressionFigure"/>, we show two ways of evaluating the
+expression <literal>f(a,b)*g(c)</literal>. <xref linkend="splitExpressionFigure"/>(a) shows
 sequential evaluation of the expression, where <literal>f()</literal> is computed, <literal>g()</literal>
 follows, and then the two results are multiplied to get the final value.
-Figure <xref linkend="splitExpressionFigure"/>(b) shows evaluation of the expression
+<xref linkend="splitExpressionFigure"/>(b) shows evaluation of the expression
 in which <literal>f()</literal> and <literal>g()</literal> are evaluated concurrently instead.</simpara>
-<figure>
+<figure xml:id="splitExpressionFigure">
 <title>Computation of <literal>value = f(a,b)*g(c)</literal> with (a) sequential and (b) concurrent approaches.</title>
 <mediaobject>
 <imageobject>
@@ -6927,29 +7057,23 @@ in which <literal>f()</literal> and <literal>g()</literal> are evaluated concurr
 carried out on separate cores. We can create one thread for each method
 and wait for the threads to complete. Upon completion, we can retrieve
 the results of each computation and multiply them together as in
-Figure <xref linkend="splitExpressionFigure"/>(b). Program <xref linkend="program:SplitExpression"/>
+<xref linkend="splitExpressionFigure"/>(b). <xref linkend="SplitExpressionProgram"/>
 illustrates this concurrent approach.</simpara>
-<simpara>In Program <xref linkend="program:SplitExpression"/>, we create two objects named
-<literal>fThread</literal> and <literal>gThread</literal> at lines <xref linkend="createFLine"/> and <xref linkend="createGLine"/>,
-respectively. Both of these objects have types that extend the <literal>Thread</literal>
-class, which means that they can be made to run independently. Object
-<literal>fThread</literal> needs two arguments (<literal>3.14</literal> and <literal>2.99</literal> in this example), and
-<literal>gThread</literal> needs one (<literal>5.55</literal>).</simpara>
-<formalpara xml:id="program:SplitExpression" xreflabel="SplitExpression">
-<title>Program for concurrent evaluation of an expression.</title>
+<formalpara xml:id="SplitExpressionProgram">
+<title>Concurrent evaluation of an expression.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class SplitExpression {
     public static void main(String[] args) {
-        ComputeF fThread = new ComputeF(3.14, 2.99);/*@\label{createFLine}@*/
-        ComputeG gThread = new ComputeG(5.55);/*@\label{createGLine}@*/
-        fThread.start();/*@\label{startFComputationLine}@*/
-        gThread.start();/*@\label{startGComputationLine}@*/
+        ComputeF fThread = new ComputeF(3.14, 2.99); <co xml:id="CO4-1"/>
+        ComputeG gThread = new ComputeG(5.55); <co xml:id="CO4-2"/>
+        fThread.start(); <co xml:id="CO4-3"/>
+        gThread.start(); <co xml:id="CO4-4"/>
         try {
-            fThread.join();  /*@\label{waitForFToFiniLinesh}@*/
-            gThread.join(); /*@\label{waitForGToFiniLinesh}@*/
-            double fResult = fThread.getResult();/*@\label{getResultFromFLine}@*/
-            double gResult = gThread.getResult();/*@\label{getResultFroLineG}@*/
-            double answer = fResult*gResult;/*@\label{computeFinalValueLine}@*/
+            fThread.join();  <co xml:id="CO4-5"/>
+            gThread.join(); <co xml:id="CO4-6"/>
+            double fResult = fThread.getResult(); <co xml:id="CO4-7"/>
+            double gResult = gThread.getResult(); <co xml:id="CO4-8"/>
+            double answer = fResult*gResult; <co xml:id="CO4-9"/>
             System.out.println("Result of f: " + fResult );
             System.out.println("Result of g: " + gResult );
             System.out.println("Final answer: " + answer);
@@ -6961,43 +7085,53 @@ class, which means that they can be made to run independently. Object
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Once the thread objects have been created, we start the threads at
-lines <xref linkend="startFComputationLine"/> and <xref linkend="startGComputationLine"/>. Every
-object whose type is <literal>Thread</literal> (or a child of <literal>Thread</literal>, which we will
-discuss in Chapter <xref linkend="chapter:Inheritance"/>) has a <literal>start()</literal> method which
-begins its execution as a separate thread.</simpara>
-<simpara>How do we know when a thread is done executing? Every <literal>Thread</literal> object
-has a <literal>join()</literal> method. If some code calls a thread&#8217;s <literal>join()</literal> method,
-the method will not return until the thread is finished. When code is
-waiting for a thread to finish, it is possible for it to be interrupted
-if some other thread has gotten tired of the code waiting around doing
-nothing. If that happens, an <literal>InterruptedException</literal> is thrown.
-Exceptions are the way that Java deals with errors and other unusual
-situations. We will discuss them further in
-Chapter <xref linkend="chapter:Exceptions"/>, but, for now, you only need to know that
+<calloutlist>
+<callout arearefs="CO4-1">
+<para>We create an object named <literal>fThread</literal> which takes two arguments, <literal>3.14</literal> and <literal>2.99</literal> in this example.</para>
+</callout>
+<callout arearefs="CO4-2">
+<para>We create another object named <literal>gThread</literal> that takes one, <literal>5.55</literal>. Both of these objects have types that extend the <literal>Thread</literal> class, which means that they can be made to run independently.</para>
+</callout>
+<callout arearefs="CO4-3">
+<para>We start the first thread running.</para>
+</callout>
+<callout arearefs="CO4-4">
+<para>We start the second thread running. Every object whose type is <literal>Thread</literal> (or a child of <literal>Thread</literal>, which we will discuss in <xref linkend="_inheritance"/>) has a <literal>start()</literal> method which begins its execution as a separate thread.</para>
+</callout>
+<callout arearefs="CO4-5">
+<para>We wait for the first thread to finish. How do we know when a thread is done executing? Every <literal>Thread</literal> object has a <literal>join()</literal> method. If some code calls a thread&#8217;s <literal>join()</literal> method, the method will not return until the thread is finished. When code is waiting for a thread to finish, it is possible for it to be interrupted if some other thread has gotten tired of the code waiting around doing nothing. If that happens, an <literal>InterruptedException</literal> is thrown. Exceptions are the way that Java deals with errors and other unusual situations. We will discuss them further in
+<xref linkend="_exceptions"/>, but, for now, you only need to know that
 code (like the <literal>join()</literal> method) that can cause certain kinds of
 exceptions (like the <literal>InterruptedException</literal>) needs to be enclosed in a
 <literal>try</literal> block. After the <literal>try</literal> block comes a <literal>catch</literal> block that says what
 to do in the even of that exception. In our case, we print out
-<literal>"Computation interrupted!"</literal></simpara>
-<simpara>Once the threads have completed their respective tasks, the execution of
-Program <xref linkend="program:SplitExpression"/> resumes at
-line <xref linkend="getResultFromFLine"/>, where we obtain the result of the
-computation done by <literal>fThread</literal> by calling its <literal>getResult()</literal> method. On
-the next line, we call the <literal>getResult()</literal> method on <literal>gThread</literal> to obtain
+<literal>"Computation interrupted!"</literal></para>
+</callout>
+<callout arearefs="CO4-6">
+<para>We wait for the second thread to finish.</para>
+</callout>
+<callout arearefs="CO4-7">
+<para>Once the threads have completed their respective tasks, the execution of
+<xref linkend="SplitExpressionProgram"/> resumes, and we obtain the result of the
+computation done by <literal>fThread</literal> by calling its <literal>getResult()</literal> method.</para>
+</callout>
+<callout arearefs="CO4-8">
+<para>On the next line, we call the <literal>getResult()</literal> method on <literal>gThread</literal> to obtain
 its result. Note that we could have called these <literal>getResult()</literal> methods
 before the <literal>join()</literal> calls, but the computations might not have
 completed, yielding invalid or incorrect results (or crashing the
-program). Finally, at line <xref linkend="computeFinalValueLine"/>, these two computed
-values are multiplied to get the final result, which is assigned to
-<literal>value</literal> and printed.</simpara>
+program).</para>
+</callout>
+<callout arearefs="CO4-9">
+<para>Finally, these two computed values are multiplied to get the final result, which is assigned to <literal>answer</literal> and printed.</para>
+</callout>
+</calloutlist>
 </example>
 <simpara>We would like to show how classes <literal>ComputeF</literal> and <literal>ComputeG</literal> are written,
 but we will hold off since they use concepts relating to methods, class
-design, and inheritance that we will not cover until Chapters
-<xref linkend="chapter:Methods"/>, <xref linkend="chapter:Classes"/>, and <xref linkend="chapter:Inheritance"/>.</simpara>
+design, and inheritance that we will cover in <xref linkend="_methods"/>, <xref linkend="_classes"/>, and <xref linkend="_inheritance"/>.</simpara>
 <simpara>If you don&#8217;t understand all the elements of
-Program <xref linkend="program:SplitExpression"/>, don&#8217;t despair. We&#8217;re trying to give
+<xref linkend="SplitExpressionProgram"/>, don&#8217;t despair. We&#8217;re trying to give
 you an example of what concurrency looks like in Java, but you cannot be
 expected to master all the details at this stage. However, concurrency
 in Java will often follow the steps shown:</simpara>
@@ -7029,7 +7163,7 @@ necessary threads. In the example above, the methods <literal>f()</literal> and 
 must be complex enough that it takes a significant amount of time to
 evaluate them. Otherwise, concurrency will not reduce the running time.
 This aspect of speedup is explained in detail in
-Chapter <xref linkend="chapter:Concurrent_Programming"/>.</simpara>
+<xref linkend="_concurrent_programming"/>.</simpara>
 <simpara>Second, splitting an expression (or any complex sequence of
 computations) is easy when its individual components are independent. If
 they are interdependent, splitting requires care or subtle programming
@@ -7037,7 +7171,7 @@ errors can occur. Consider the expression <literal>f(a)+g(b)</literal> and suppo
 <literal>f()</literal> modifies the value of <literal>b</literal> during execution. Such a modification is
 called a <emphasis>side effect</emphasis>. This side effect creates a dependency between
 <literal>f()</literal> and <literal>g()</literal>. Concurrent execution of these two methods must be done
-carefully, if it can be done at all. Chapter <xref linkend="chapter:Synchronization"/>
+carefully, if it can be done at all. <xref linkend="_synchronization"/>
 discusses concurrency in the presence of dependencies.</simpara>
 </section>
 </section>
@@ -7065,23 +7199,24 @@ for the completion of threads. Such threads could be used to speed up
 the evaluation of mathematical computations on multicore processors, but
 only if the computations are long, complex, and not too interdependent.</simpara>
 </section>
-<section xml:id="_exercises_2">
+<section xml:id="_exercises_3">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara><xref linkend="exercise:mathematicsAndIntExercise"/> What is the difference
+<simpara><anchor xml:id="exercise3.1" xreflabel="[exercise3.1]"/> What is the difference
 between the set of integers from mathematics and the sets defined by
 <literal>int</literal> and <literal>long</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:Downcast"/> In Example <xref linkend="example:Downcast_error"/>, the sum
+<simpara><anchor xml:id="exercise3.2" xreflabel="[exercise3.2]"/> In <xref linkend="downcastErrorExample"/>, the sum
 of two <literal>int</literal> variables was another <literal>int</literal> value, which could not be
 stored into a <literal>byte</literal> variable. Would this code have worked if variables
 <literal>a</literal> and <literal>b</literal> had been declared with type <literal>byte</literal>? What if <literal>a</literal> was assigned
 <literal>121</literal> and <literal>b</literal> was assigned <literal>98</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:floatFloatExampleExercise"/> The following three
+<simpara><anchor xml:id="exercise3.3" xreflabel="[exercise3.3]"/> The following three
 statements are legal Java (if properly included inside of a method).
 However, if we changed <literal>2</literal> to <literal>2.0</literal> or <literal>5</literal> to <literal>5.0</literal>, the statements
 would not be legal. Explain why.</simpara>
@@ -7090,7 +7225,7 @@ float homeArea = 5;
 float area = roomArea * homeArea;</programlisting>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:logicalOperatorExercise"/> Consider the following variable
+<simpara><anchor xml:id="exercise3.4" xreflabel="[exercise3.4]"/> Consider the following variable
 declarations.</simpara>
 <programlisting language="java" linenumbering="unnumbered">int x = 3, y = 4, z = -9;
 float p = 3.99f, q = -9.89f;
@@ -7109,7 +7244,7 @@ c.  <literal>age &lt; MAXIMUM_AGE &amp;&amp; allowed</literal>
 d.  <literal>(x &lt; y &amp;&amp; y &gt; z) || (p &gt; q &amp;&amp; population1 &lt; population2)</literal></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:bitwiselOperatorExercise"/> Evaluate the following
+<simpara><anchor xml:id="exercise3.5" xreflabel="[exercise3.5]"/> Evaluate the following
 expressions by hand and then check the results with a Java compiler.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
@@ -7136,7 +7271,7 @@ expressions by hand and then check the results with a Java compiler.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:overflowUnderflowExercise"/> Evaluate the following
+<simpara><anchor xml:id="exercise3.6" xreflabel="[exercise3.6]"/> Evaluate the following
 expressions by hand and then check the results with a Java compiler.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
@@ -7151,7 +7286,7 @@ expressions by hand and then check the results with a Java compiler.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:floatingPointOverflowExercise"/> Evaluate the following
+<simpara><anchor xml:id="exercise3.7" xreflabel="[exercise3.7]"/> Evaluate the following
 expressions by hand and then check the results with a Java compiler.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
@@ -7172,7 +7307,7 @@ expressions by hand and then check the results with a Java compiler.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:overFlowDoubleExercise"/> When evaluated in Java, the
+<simpara><anchor xml:id="exercise3.8" xreflabel="[exercise3.8]"/> When evaluated in Java, the
 expression <literal>2*Double.MAX_VALUE</literal> results in <literal>Double.POSITIVE_INFINITY</literal>
 to indicate that the maximum representable value has been exceeded.
 However, the expression <literal>Double.MAX_VALUE + 1</literal> results in
@@ -7180,14 +7315,14 @@ However, the expression <literal>Double.MAX_VALUE + 1</literal> results in
 <literal>Double.POSITIVE_INFINITY</literal> as well?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:conversionExercise"/> Explain what is printed when the
+<simpara><anchor xml:id="exercise3.9" xreflabel="[exercise3.9]"/> Explain what is printed when the
 following statements are executed.</simpara>
 <programlisting language="java" linenumbering="unnumbered">System.out.println(15 + 20);
 System.out.println("15" + 20);
 System.out.println("" + 15 + 20);</programlisting>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:typeValueDeterminationExercise"/> For each of the
+<simpara><anchor xml:id="exercise3.10" xreflabel="[exercise3.10]"/> For each of the
 following Java expressions, indicate the types of each value being used
 and the type of the result when the expression is evaluated.</simpara>
 <orderedlist numeration="loweralpha">
@@ -7227,10 +7362,10 @@ and the type of the result when the expression is evaluated.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:splitExpressionEvaluationExercise"/> For each of the
+<simpara><anchor xml:id="exercise3.11" xreflabel="[exercise3.11]"/> For each of the
 following expressions, determine the maximum amount of concurrency that
 can be achieved. Using a diagram similar to
-Figure <xref linkend="splitExpressionFigure"/>(b), show how the computation of each
+<xref linkend="splitExpressionFigure"/>(b), show how the computation of each
 expression will proceed. Assume there are no side effects. Note that you
 can create separate threads for multiple instances of method <literal>f()</literal>.</simpara>
 <orderedlist numeration="loweralpha">
@@ -7246,7 +7381,7 @@ can create separate threads for multiple instances of method <literal>f()</liter
 </orderedlist>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:referenceTypes"/> Answer the following questions about
+<simpara><anchor xml:id="exercise3.12" xreflabel="[exercise3.12]"/> Answer the following questions about
 types, values, and references.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
@@ -7269,7 +7404,7 @@ Java.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:objectComparsonExercise"/> Consider the following
+<simpara><anchor xml:id="exercise3.13" xreflabel="[exercise3.13]"/> Consider the following
 declarations of three <literal>Car</literal> objects.</simpara>
 <programlisting language="java" linenumbering="unnumbered"> Car car1 = new Car("Mercedes", "C300 Sport", 75000);
  Car car2 = new Car("Pontiac", "Vibe", 17000);
@@ -7277,22 +7412,38 @@ declarations of three <literal>Car</literal> objects.</simpara>
 <simpara>Let <literal>same</literal> be a variable of type <literal>boolean</literal>. What is the value of
 variable <literal>same</literal> after each of the following statements? Assume that the
 <literal>equals()</literal> method will return <literal>true</literal> if all of the attributes specified
-by the constructors for the two objects are the same.
-a.  <literal>same = (car1 == car2);</literal>
-b.  <literal>same = (car1 == car3);</literal>
-c.  <literal>same = car1.equals(car3);</literal>
-d.  <literal>car2 = car3;</literal>
-e.  <literal>same = (car2 == car1);</literal>
-f.  <literal>same = (car2 == car3);</literal>
-g.  <literal>same = car2.equals(car3);</literal></simpara>
+by the constructors for the two objects are the same.</simpara>
+<orderedlist numeration="loweralpha">
+<listitem>
+<simpara><literal>same = (car1 == car2);</literal></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:unicode"/> Characters <literal>'a'</literal> and <literal>'A'</literal> have Unicode values
+<simpara><literal>same = (car1 == car3);</literal></simpara>
+</listitem>
+<listitem>
+<simpara><literal>same = car1.equals(car3);</literal></simpara>
+</listitem>
+<listitem>
+<simpara><literal>car2 = car3;</literal></simpara>
+</listitem>
+<listitem>
+<simpara><literal>same = (car2 == car1);</literal></simpara>
+</listitem>
+<listitem>
+<simpara><literal>same = (car2 == car3);</literal></simpara>
+</listitem>
+<listitem>
+<simpara><literal>same = car2.equals(car3);</literal></simpara>
+</listitem>
+</orderedlist>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise3.14" xreflabel="[exercise3.14]"/> Characters <literal>'a'</literal> and <literal>'A'</literal> have Unicode values
 <literal>\u0061</literal> and <literal>\u0041</literal>, respectively. Give the representation of these
 two characters as 16-bit unsigned binary integers.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:representation"/> Assuming that each character occupies 16
+<simpara><anchor xml:id="exercise3.15" xreflabel="[exercise3.15]"/> Assuming that each character occupies 16
 bits (two bytes) in memory and is coded using Unicode, use hexadecimal
 numbers to show how the word <literal>"Java"</literal> will be represented in computer
 memory. Unicode values for the Latin alphabet are the same as the values
@@ -7300,14 +7451,14 @@ for the older ASCII standard. You can find a listing of these values on
 many websites such as <link xl:href="http://www.asciitable.com/">http://www.asciitable.com/</link>.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:stringLength"/> What is the output from the following
+<simpara><anchor xml:id="exercise3.16" xreflabel="[exercise3.16]"/> What is the output from the following
 sequence of statements?</simpara>
 <programlisting language="java" linenumbering="unnumbered">String p = "Break it";
 String q = "down like this!";
 System.out.println((p + q).length());</programlisting>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:emptyStringsExercise"/> What is the output from the
+<simpara><anchor xml:id="exercise3.17" xreflabel="[exercise3.17]"/> What is the output from the
 following sequence of statements? Note that <literal>r</literal> contains a single space
 character.</simpara>
 <programlisting language="java" linenumbering="unnumbered">String p = "This is not a string.";
@@ -7317,19 +7468,19 @@ System.out.println((p + q + r).length());</programlisting>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:uninitializedStringObjectExercise"/> Try compiling the
+<simpara><anchor xml:id="exercise3.18" xreflabel="[exercise3.18]"/> Try compiling the
 following program and observe the error reported by the compiler.</simpara>
-<programlisting xml:id="program:UninitializedString" xreflabel="UninitializedString" language="java" linenumbering="numbered">public class UninitializedString {
+<programlisting xml:id="UninitializedStringProgram" language="java" linenumbering="numbered">public class UninitializedString {
 	 public static void main(String[] args) {
           String greeting;
-          System.out.println(greeting);/*@ \label{uninitializedStringPrintout}@*/
+          System.out.println(greeting);
     }
 }</programlisting>
 <simpara>Now initialize the <literal>greeting</literal> object and rerun the program. Why does the
 program compile now?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:stringToNumericConversionProgramExercise"/> Write a Java
+<simpara><anchor xml:id="exercise3.19" xreflabel="[exercise3.19]"/> Write a Java
 program that prompts the user to enter the number of rooms in her home,
 uses a <literal>Scanner</literal> object to read the input into an <literal>int</literal> variable named
 <literal>rooms</literal>, and then outputs the value on the screen. If you compile and
@@ -7338,8 +7489,7 @@ output you see?</simpara>
 </listitem>
 <listitem>
 <simpara>Convert the college cost calculator solution given in
-Section <xref linkend="solution:College_cost_calculator"/> to use<?asciidoc-br?>
-<literal>JOptionPane</literal> methods for both input and output. Use the header giving
+<xref linkend="_solution_college_cost_calculator"/> to use <literal>JOptionPane</literal> methods for both input and output. Use the header giving
 the user&#8217;s first and last name for the title of the output dialog and
 omit the line of asterisks. If you put all the output in a single
 <literal>String</literal> with a newline (<literal>\n</literal>) separating each line, the output will
@@ -7348,7 +7498,7 @@ display properly.</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Selection">
+<chapter xml:id="_selection">
 <title>Selection</title>
 <blockquote>
 <attribution>
@@ -7356,10 +7506,10 @@ Albert Camus
 </attribution>
 <simpara>Life is a sum of all your choices.</simpara>
 </blockquote>
-<section xml:id="section:Monty_Hall">
+<section xml:id="_problem_monty_hall_simulation">
 <title>Problem: Monty Hall simulation</title>
 <simpara>There is a famous mathematical puzzle called the Monty Hall problem,
-based on the television show <emphasis>Let’s Make a Deal</emphasis> hosted by the eponymous
+based on the television show <emphasis>Let&#8217;s Make a Deal</emphasis> hosted by the eponymous
 Monty Hall. In this problem, you are presented with three doors. Two of
 the three doors have junk behind them. One randomly selected door
 conceals something like a pile of gold. If you can choose that door, you
@@ -7382,7 +7532,7 @@ probability of winning would be <inlineequation><alt><![CDATA[\frac{2}{3}]]></al
 you this option. Just pick the two doors you want and tell Monty the
 third. He reveals one of your two initial doors as junk, and you switch
 to the other one.</simpara>
-<simpara>If you still aren’t convinced, that’s fine. Your goal is to write a
+<simpara>If you still aren&#8217;t convinced, that&#8217;s fine. Your goal is to write a
 program that simulates the Monty Hall dilemma, allowing a user to guess
 a door and then, potentially, switch. Once you have written the
 simulation, you can choose to play repeatedly and see how well you do if
@@ -7392,7 +7542,7 @@ from problems in previous chapters. First, randomness play a role.
 Generating random numbers has become an important part of computer
 science, and most languages provide programmers with tools for
 generating random or nearly random numbers. Recall the <literal>Random</literal> class
-from Chapter <xref linkend="chapter:Primitive_Types_and_Strings"/>. With an object of
+from <xref linkend="_primitive_types_and_strings"/>. With an object of
 type <literal>Random</literal> called <literal>random</literal>, you can generate a random <literal>int</literal> between
 <literal>0</literal> and <literal>n - 1</literal> by calling <literal>random.nextInt(n)</literal>.</simpara>
 <simpara>The second and much more important feature of Java in the solution to
@@ -7412,7 +7562,7 @@ executions.</simpara>
 <section xml:id="_concepts_choosing_between_options">
 <title>Concepts: Choosing between options</title>
 <simpara>Before we get to random numbers and the complex choices involved in the
-Monty Hall problem, let’s talk about the simplified approach that most
+Monty Hall problem, let&#8217;s talk about the simplified approach that most
 programming languages take to conditional execution. When we come to a
 point in a program where there is a choice to be made, we can think of
 it as the question, &#8220;Do I want to perform this series of tasks?&#8221; Like
@@ -7455,15 +7605,15 @@ if it is false, she will do action <inlineequation><alt><![CDATA[c]]></alt><math
 <section xml:id="_boolean_operations">
 <title>Boolean operations</title>
 <simpara>Even by itself, the ability to pick between two options is powerful, but
-we can augment this ability in a couple of ways. First, we don’t have to
+we can augment this ability in a couple of ways. First, we don&#8217;t have to
 rely on simple conditions. Using Boolean logic, we can make arbitrarily
 complex conditions.</simpara>
-<simpara><emphasis>If I am bored, or it is late and I can’t sleep, then I will watch
+<simpara><emphasis>If I am bored, or it is late and I can&#8217;t sleep, then I will watch
 television.</emphasis></simpara>
 <simpara>Someone following this program will watch television if he is bored or
 if it is late and he also cannot sleep. We can break the condition into
 three sub-conditions: <emphasis>I am bored</emphasis> is condition <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation>, <emphasis>it is
-late</emphasis> is condition <inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation>, and <emphasis>I can’t sleep</emphasis> is condition
+late</emphasis> is condition <inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation>, and <emphasis>I can&#8217;t sleep</emphasis> is condition
 <inlineequation><alt><![CDATA[z]]></alt><mathphrase><![CDATA[z]]></mathphrase></inlineequation>. We have connected these three conditions together using
 the words &#8220;and&#8221; and &#8220;or.&#8221; These two simple words represent powerful
 concepts in Boolean logic, AND and OR. When two conditions are combined
@@ -7627,7 +7777,7 @@ then NOT applied to that condition will yield false, and vice versa.</simpara>
 <simpara>Now that we have nailed down some notation for Boolean logic, we can
 express the complicated expression that sent us down this path in the
 first place. Recall that <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation> is <emphasis>I am bored</emphasis>,
-<inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation> is <emphasis>it is late</emphasis>, and <inlineequation><alt><![CDATA[z]]></alt><mathphrase><![CDATA[z]]></mathphrase></inlineequation> is <emphasis>I can’t sleep</emphasis>.
+<inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation> is <emphasis>it is late</emphasis>, and <inlineequation><alt><![CDATA[z]]></alt><mathphrase><![CDATA[z]]></mathphrase></inlineequation> is <emphasis>I can&#8217;t sleep</emphasis>.
 Let <inlineequation><alt><![CDATA[d]]></alt><mathphrase><![CDATA[d]]></mathphrase></inlineequation> be the action <emphasis>I will watch television</emphasis>. We can
 express the choice in this way: If <inlineequation><alt><![CDATA[x \lor (y \land z)]]></alt><mathphrase><![CDATA[x \lor (y \land z)]]></mathphrase></inlineequation>,
 then do <inlineequation><alt><![CDATA[d]]></alt><mathphrase><![CDATA[d]]></mathphrase></inlineequation>. Using this notation, we have expressed
@@ -7646,8 +7796,8 @@ steakhouse, the options of shrimp and lobster might not be available.</simpara>
 <simpara>A <emphasis>nested</emphasis> choice is one that sits inside of another choice you have
 already made. We could describe choices of restaurant and meal as
 follows.</simpara>
-<simpara><emphasis>If I want seafood, then I will eat at Sharky’s, otherwise I will eat at
-the Golden Calf. When dining at Sharky’s, if I have at least $50, I will
+<simpara><emphasis>If I want seafood, then I will eat at Sharky&#8217;s, otherwise I will eat at
+the Golden Calf. When dining at Sharky&#8217;s, if I have at least $50, I will
 order the lobster, otherwise I will order the shrimp. When dining at the
 Golden Calf, if I have at least $30, I will order the filet mignon,
 otherwise I will order the pork chops.</emphasis></simpara>
@@ -7675,19 +7825,19 @@ is called an <literal>if</literal> statement.</simpara>
 <literal>boolean</literal> value, which can only be one of two things: <literal>true</literal> or <literal>false</literal>.</simpara>
 <simpara>For example, we could have a <literal>boolean</literal> variable called <literal>raining</literal>. Stored
 in this variable is the value <literal>true</literal> if it is raining and <literal>false</literal> if it
-isn’t. Using Java syntax, we could encode our first example in which our
+isn&#8217;t. Using Java syntax, we could encode our first example in which our
 actor takes her umbrella if it is raining.</simpara>
 <programlisting language="java" linenumbering="unnumbered">if( raining ) {
     umbrella.take();
 }</programlisting>
 <simpara>The action taken if it is raining is done by calling a <emphasis>method</emphasis> on an
-<emphasis>object</emphasis>. We’ll discuss objects and methods further in
-Chapters <xref linkend="chapter:Methods"/> and <xref linkend="chapter:Classes"/>. What we’re
+<emphasis>object</emphasis>. We&#8217;ll discuss objects and methods further in
+<xref linkend="_methods"/> and <xref linkend="_classes"/>. What we&#8217;re
 focusing on now is that the line <literal>umbrella.take();</literal> is executed only if
 <literal>raining</literal> has the value <literal>true</literal>. Nothing is done if it is <literal>false</literal>.
-Figure <xref linkend="figure:if"/> shows this pattern of conditional execution
+<xref linkend="figure-if"/> shows this pattern of conditional execution
 followed by all <literal>if</literal> statements.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-if" role="text-center">
 <title>Execution goes inside the <literal>if</literal> statement when its condition is <literal>true</literal> and skips past it otherwise.</title>
 <mediaobject>
 <imageobject>
@@ -7713,7 +7863,7 @@ if it is raining. We might accomplish these tasks in Java as follows.</simpara>
     window.close();
     raincoat.putOn();
 }</programlisting>
-<simpara>Within a matching pair of braces (<literal>\{\}</literal>), called a <emphasis>block</emphasis> of code,
+<simpara>Within a matching pair of braces (<literal>{ }</literal>), called a <emphasis>block</emphasis> of code,
 execution proceeds normally, line by line. First, the JVM will cause the
 umbrella to be taken, then the window to be closed, and finally the
 raincoat to be put on.</simpara>
@@ -7723,7 +7873,7 @@ would have written our first example as follows.</simpara>
 <programlisting language="java" linenumbering="unnumbered">if( raining )
     umbrella.take();</programlisting>
 <simpara>For beginning Java programmers, however, it is a good idea to use braces
-even when you don’t need to. Without braces, code can appear to be doing
+even when you don&#8217;t need to. Without braces, code can appear to be doing
 one thing when it really is doing another.</simpara>
 <simpara>Since programmers must often choose between two alternatives, Java
 provides an <literal>else</literal> statement to specify code that should be run if the
@@ -7738,7 +7888,7 @@ else {
     fastFood.eat();
 }</programlisting>
 <simpara>This Java code matches the logical statements we wrote before. If we
-have enough money, we’ll eat a lobster dinner, otherwise, we’ll eat fast
+have enough money, we&#8217;ll eat a lobster dinner, otherwise, we&#8217;ll eat fast
 food. As with an <literal>if</literal> statement, we use braces to mark a block of code
 for an <literal>else</literal> statement, too. Since a single line of code will be
 executed in each case, the braces are optional here. We could have
@@ -7747,9 +7897,9 @@ written code with the same functionality as follows.</simpara>
     lobsterDinner.eat();
 else
     fastFood.eat();</programlisting>
-<simpara>Figure <xref linkend="figure:else"/> shows the pattern of conditional execution
+<simpara><xref linkend="figure-else"/> shows the pattern of conditional execution
 followed by all <literal>if</literal> statements that have a matching <literal>else</literal> statement.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-else" role="text-center">
 <title>Execution goes inside the <literal>if</literal> statement when its condition is <literal>true</literal> and jumps into the <literal>else</literal> statement otherwise.</title>
 <mediaobject>
 <imageobject>
@@ -7762,7 +7912,7 @@ followed by all <literal>if</literal> statements that have a matching <literal>e
 <title>Pitfall: Misleading indentation</title>
 <simpara>Indentation is used to make the code more readable, but Java ignores
 whitespace, meaning that the indentation has no effect on the execution
-of the code. To demonstrate, let’s assume that our imaginary diner knows
+of the code. To demonstrate, let&#8217;s assume that our imaginary diner knows
 he will get a stomachache after eating fast food. Thus, he will take
 some Pepto-Bismol after eating it. If you modified the code above, which
 does not contain braces, you might get the following.</simpara>
@@ -7845,7 +7995,7 @@ boolean z = !((x || y) ^ (x &amp;&amp; y));</programlisting>
 it is perfectly legal to perform <literal>boolean</literal> operations this way, it is
 much more common to combine them &#8220;on the fly&#8221; inside of the condition
 of an <literal>if</literal> statement. Recall the statement from the previous section:</simpara>
-<simpara><emphasis>If I am bored, or it is late and I can’t sleep, then I will watch
+<simpara><emphasis>If I am bored, or it is late and I can&#8217;t sleep, then I will watch
 television.</emphasis></simpara>
 <simpara>If we let <literal>bored</literal>, <literal>late</literal>, and <literal>canSleep</literal> be <literal>boolean</literal> variables whose
 values indicate if we are bored, if it is late, and if we can sleep,
@@ -7853,7 +8003,7 @@ respectively, we can encode this statement in Java like so.</simpara>
 <programlisting language="java" linenumbering="unnumbered">if( bored || (late &amp;&amp; !canSleep) )
     television.watch();</programlisting>
 <simpara>Combining the <literal>||</literal> operator with other <literal>||</literal> operators is both
-commutative and associative: order and grouping doesn’t matter.
+commutative and associative: order and grouping doesn&#8217;t matter.
 Likewise, combining the <literal>&amp;&amp;</literal> operator with other <literal>&amp;&amp;</literal> operators is
 also commutative and associative. However, once you start mixing <literal>||</literal>
 with <literal>&amp;&amp;</literal>, it is a good idea to use parentheses for grouping. If, in
@@ -7918,10 +8068,11 @@ using the <literal>&gt;</literal> operator.</simpara>
 <simpara>This code allows you to call the appropriate emergency method when
 <literal>pressure</literal> is too high. Of course, the <literal>&gt;</literal> operator is not the only way
 to compare two values in Java. We list all the relational operators in
-Chapter <xref linkend="chapter:Primitive_Types_and_Strings"/>, but
-Table <xref linkend="table:relational_operators"/> below shows them again in a
+<xref linkend="_primitive_types_and_strings"/>, but
+the table below shows them again in a
 mathematical context.</simpara>
-<informaltable role="center" frame="all" rowsep="1" colsep="1">
+<table role="center" frame="all" rowsep="1" colsep="1">
+<title>Relational operators</title>
 <tgroup cols="4">
 <colspec colname="col_1" colwidth="25*"/>
 <colspec colname="col_2" colwidth="25*"/>
@@ -7981,7 +8132,7 @@ value is greater than or equal to the second</simpara></entry>
 </row>
 </tbody>
 </tgroup>
-</informaltable>
+</table>
 <simpara>The concepts and mathematical symbols for these operators should be
 familiar from mathematics. There are a few differences from the
 mathematical versions of these ideas that are worth pointing out. First,
@@ -8025,7 +8176,7 @@ statement, but an <literal>if</literal> statement does not know what to do with 
 other than a <literal>boolean</literal> value. Extreme care should be taken when
 comparing two <literal>boolean</literal> values. For example, we might have two <literal>boolean</literal>
 values <literal>genderA</literal> and <literal>genderB</literal>, corresponding to the genders of two
-different people. Let’s say that the value of each one is <literal>true</literal> if the
+different people. Let&#8217;s say that the value of each one is <literal>true</literal> if the
 person is female and <literal>false</literal> otherwise. We could create an <literal>if</literal>
 statement that would work only if their genders are the same.</simpara>
 <programlisting language="java" linenumbering="unnumbered">if( genderA == genderB )
@@ -8039,13 +8190,13 @@ could yield the following.</simpara>
 Then, that value would be given to the <literal>if</literal> statement. In this
 situation, the <literal>makeRoommates()</literal> method will be called only if <literal>genderB</literal>
 is <literal>true</literal>, meaning female. Thus, the two people will become roommates if
-the second one is female, and the gender of the first person won’t be
+the second one is female, and the gender of the first person won&#8217;t be
 considered. Unlike the <literal>x = 4</literal> example, this code will compile with no
 warning.</simpara>
 </warning>
 <simpara>The next few examples illustrate the use of the <literal>if</literal> statement. They
 also use some methods from class <literal>Math</literal>.</simpara>
-<example>
+<example xml:id="leapYearExample">
 <title>Leap year</title>
 <simpara>In the standard Gregorian calendar, leap years occur roughly once every
 four years. During leap years, the month of February has 29 days instead
@@ -8061,12 +8212,12 @@ divisible by 400. For example, 1988 was a leap year because it was
 divisible by 4. The year 1900 was not a leap year because it was
 divisible by 100 but not by 400, and the year 2000 was a leap year
 because it was divisible by 400.</simpara>
-<simpara>Recall that the mod operator (<literal>\%</literal>) allows us to find the remainder
-after integer division. Thus, if <literal>n \% 100</literal> gives zero, <literal>n</literal> has no
+<simpara>Recall that the mod operator (<literal>%</literal>) allows us to find the remainder
+after integer division. Thus, if <literal>n % 100</literal> gives zero, <literal>n</literal> has no
 remainder after being divided by <literal>100</literal> and must be evenly divisible by
 100.</simpara>
-<formalpara xml:id="program:LeapYear" xreflabel="LeapYear">
-<title>A program that prompts the user for a year and then determines whether or not it is a leap year.</title>
+<formalpara xml:id="LeapYearProgram">
+<title>Prompts the user for a year and then determines whether or not it is a leap year.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -8111,8 +8262,8 @@ two complex answers to the equation. Finally, if the discriminant is
 zero, there will be a single real answer to the problem. If you want to
 write a program to solve quadratic equations for you, it should take
 these three possibilities into account.</simpara>
-<formalpara xml:id="program:Quadratic" xreflabel="Quadratic">
-<title>Program to solve a quadratic equation.</title>
+<formalpara xml:id="QuadraticProgram">
+<title>Solves a quadratic equation.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -8175,10 +8326,10 @@ possible to differentiate <inlineequation><alt><![CDATA[2^{20} = 1,048,576]]></a
 are told ahead of time whether the thing is animal, vegetable, or
 mineral, it should be possible to guess over 3 million items! We are not
 yet ready to deal with such a large range of possibilities. To keep the
-size of the code reasonable, let’s narrow the field to 10 different
+size of the code reasonable, let&#8217;s narrow the field to 10 different
 items: a lizard, an eagle, a dolphin, a human, some lead, a diamond, a
 tomato, a peach, a maple tree, and a potato.</simpara>
-<figure>
+<figure xml:id="figure-flowchart">
 <title>Decision tree to distinguish 10 items.</title>
 <mediaobject>
 <imageobject>
@@ -8194,9 +8345,9 @@ mammal, we could ask if it lives on land, deciding between human and
 dolphin. If it is not a mammal, we could ask if it flies, deciding
 between an eagle and a lizard. We can construct similar questions for
 the things in the vegetable and mineral categories, matching
-Figure <xref linkend="figure:flowchart"/>.</simpara>
-<formalpara xml:id="program:TwentyQuestions" xreflabel="TwentyQuestions">
-<title>Program to navigate the possible choices in the decision tree.</title>
+<xref linkend="figure-flowchart"/>.</simpara>
+<formalpara xml:id="TwentyQuestionsProgram">
+<title>Navigates the possible choices in the decision tree.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -8587,8 +8738,8 @@ fall-through behavior can be useful. Imagine that you need to write a
 program that gives the length of each month (assume that February always
 has 28 days). Given the month as a number, we can easily write a program
 that maps the number of the month to the number of days it contains.</simpara>
-<formalpara xml:id="program:DaysInMonth" xreflabel="DaysInMonth">
-<title>This program computes the number of days in a given month.</title>
+<formalpara xml:id="DaysInMonthProgram">
+<title>Computes the number of days in a given month.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -8629,7 +8780,7 @@ integrate the leap year code from above for the February case. Note also
 that we do not have a <literal>default</literal> label. You might want to set <literal>days</literal> to
 some special value (like <literal>-1</literal>) for invalid months.</simpara>
 </example>
-<example>
+<example xml:id="ordinalNumbersExample">
 <title>Ordinal numbers</title>
 <simpara>The term <emphasis>ordinal numbers</emphasis> refers to numbers that are used for ordering
 within a set of items: first, second, third, and so on. When writing
@@ -8644,8 +8795,8 @@ should generally be used. If the number ends in a 3, the letters &#8220;rd&#8221
 should generally be used. For most other numbers, the letters &#8220;th&#8221;
 should be used. We can use a <literal>switch</literal> statement to write a program to
 give the correct ordinal endings for most numbers as follows.</simpara>
-<formalpara xml:id="program:Ordinals" xreflabel="Ordinals">
-<title>This program appends the appropriate suffix to a numeral to make it an ordinal.</title>
+<formalpara xml:id="OrdinalsProgram">
+<title>Appends the appropriate suffix to a numeral to make it an ordinal.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -8676,10 +8827,13 @@ name followed by ones place name between 11 and 19, inclusive, and the
 ordinals for any number ending in 11, 12, or 13 will be given the wrong
 suffix by our code. We leave a more complete solution as an exercise.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise4.12">Exercise 4.12</link></simpara>
+</sidebar>
 <example>
 <title>Astrology</title>
 <simpara>Many cultures practice astrology, a tradition that the time of a
-person’s birth impacts his or her personality or future. One important
+person&#8217;s birth impacts his or her personality or future. One important
 element of Chinese astrology is their zodiac, consisting of 12 animals.
 Each consecutive year in a 12-year cycle corresponds to an animal.
 Because this system repeats, the year one is born in modulo 12
@@ -8748,11 +8902,11 @@ modulo 12</entry>
 numbering from the Gregorian calendar. The years in question actually
 start and end based on Chinese New Year, which occurs between January 21
 and February 20. As a consequence, you may miscalculate your animal if
-your birthday is early in the year. Let’s ignore this problem for the
+your birthday is early in the year. Let&#8217;s ignore this problem for the
 moment and write a program using a <literal>switch</literal> statement designed to
 correctly output the animal corresponding to an input birth year.</simpara>
-<formalpara xml:id="program:ChineseZodiac" xreflabel="ChineseZodiac">
-<title>This program determines a Chinese zodiac animal based on birth year.</title>
+<formalpara xml:id="ChineseZodiacProgram">
+<title>Determines a Chinese zodiac animal based on birth year.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -8858,14 +9012,14 @@ public class ChineseZodiac {
 </tbody>
 </tgroup>
 </informaltable>
-<simpara>In Western astrology, an important element associated with a person’s
+<simpara>In Western astrology, an important element associated with a person&#8217;s
 birth is also called a zodiac sign. The dates for determining this kind
 of zodiac sign are given by the preceding table.</simpara>
 <simpara>If you want to implement the rules for this zodiac in code, a <literal>switch</literal>
 statement is a good place to start, but you also have to put <literal>if</literal>
 statements for each month to test the exact range of dates.</simpara>
-<formalpara xml:id="program:WesternZodiac" xreflabel="WesternZodiac">
-<title>This program determines Western zodiac signs based on birth month and day.</title>
+<formalpara xml:id="WesternZodiacProgram">
+<title>Determines Western zodiac signs based on birth month and day.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -8957,7 +9111,7 @@ down the sign.</simpara>
 the chapter. Recall that the <literal>Random</literal> class allows us to generate all
 kinds of random values. To implement this simulation successfully, our
 program must make all the decisions needed to set up the game for the
-user as well as respond to the user’s input. We begin with the <literal>import</literal>
+user as well as respond to the user&#8217;s input. We begin with the <literal>import</literal>
 statement that is necessary to use both the <literal>Scanner</literal> and <literal>Random</literal> class
 and then define the <literal>MontyHall</literal> class.</simpara>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
@@ -9080,7 +9234,7 @@ statements. Making decisions is at the heart of all programming
 languages running on all computers.</simpara>
 <simpara>The second reason is more troubling and is related to a problem with
 some concurrent programs called a <emphasis>race condition</emphasis>, which is discussed
-in great detail in Chapter <xref linkend="chapter:Synchronization"/>. Remember, one of
+in great detail in <xref linkend="_synchronization"/>. Remember, one of
 the biggest challenges of programming a computer is thinking in a
 completely sequential and logical way. Each line of code is executed one
 after the other. Adding in <literal>if</literal> statements means that some code is
@@ -9119,10 +9273,10 @@ protection of the <literal>if</literal> statement keeps our hero from being blow
 he tries to unpack the dynamite with lit sparklers, in a sequential
 program.</simpara>
 <simpara>In a concurrent program, all bets are off. Another thread of execution
-can be operating at the very same time. It’s as if our hero is trying to
+can be operating at the very same time. It&#8217;s as if our hero is trying to
 unpack the dynamite while the villain is lighting sparklers and tossing
 them into the storage room. If the thread of execution gets to the <literal>if</literal>
-statement and makes sure that the matches aren’t lit and that there are
+statement and makes sure that the matches aren&#8217;t lit and that there are
 no flying sparks, it continues onward. If sparks start flying after that
 check, it still continues onward, oblivious of the fact. Even though
 this risk of explosion exists, it depends on the timing of the two (or
@@ -9136,47 +9290,48 @@ or not you are programming concurrently, it is always important to keep
 in mind the assumptions your code makes and the way different parts of
 your program interact with each other.</simpara>
 </section>
-<section xml:id="_exercises_3">
+<section xml:id="_exercises_4">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>Given that <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation>, <inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation>, and <inlineequation><alt><![CDATA[z]]></alt><mathphrase><![CDATA[z]]></mathphrase></inlineequation> are
+<simpara><anchor xml:id="exercise4.1" xreflabel="[exercise4.1]"/> Given that <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation>, <inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation>, and <inlineequation><alt><![CDATA[z]]></alt><mathphrase><![CDATA[z]]></mathphrase></inlineequation> are
 propositions in Boolean logic, make a truth table for the expression
 <inlineequation><alt><![CDATA[(\lnot(x \land \lnot y)
 \oplus \lnot z)]]></alt><mathphrase><![CDATA[(\lnot(x \land \lnot y)
 \oplus \lnot z)]]></mathphrase></inlineequation>.</simpara>
 </listitem>
 <listitem>
-<simpara>What is the value of the Boolean expression <inlineequation><alt><![CDATA[\lnot((T
+<simpara><anchor xml:id="exercise4.2" xreflabel="[exercise4.2]"/> What is the value of the Boolean expression <inlineequation><alt><![CDATA[\lnot((T
 \oplus F) \land \lnot(F \lor T))]]></alt><mathphrase><![CDATA[\lnot((T
 \oplus F) \land \lnot(F \lor T))]]></mathphrase></inlineequation>?</simpara>
 </listitem>
 <listitem>
-<simpara>The calculation to determine the leap year given in
-Example <xref linkend="example:Leap_year"/> uses three <literal>if</literal> statements and three
+<simpara><anchor xml:id="exercise4.3" xreflabel="[exercise4.3]"/> The calculation to determine the leap year given in
+<xref linkend="leapYearExample"/> uses three <literal>if</literal> statements and three
 <literal>else</literal> statements. Write the leap year calculation using a single <literal>if</literal>
 and a single <literal>else</literal>. Feel free to use <literal>boolean</literal> connectors such as <literal>||</literal>
 and <literal>&amp;&amp;</literal>.</simpara>
 </listitem>
 <listitem>
-<simpara>The XOR operator (<literal>^</literal>) is useful for combining <literal>boolean</literal> values, but
+<simpara><anchor xml:id="exercise4.4" xreflabel="[exercise4.4]"/> The XOR operator (<literal>^</literal>) is useful for combining <literal>boolean</literal> values, but
 it can be replaced with a more commonly used <emphasis role="strong">relational</emphasis> operator in
 Java. Which one?</simpara>
 </listitem>
 <listitem>
-<simpara>De Morgan’s laws are the following, which show that the process of
+<simpara><anchor xml:id="exercise4.5" xreflabel="[exercise4.5]"/> De Morgan&#8217;s laws are the following, which show that the process of
 negating a clause changes an AND to an OR and vice versa.</simpara>
 <simpara><inlineequation><alt><![CDATA[\lnot(x \land y) = \lnot x \lor \lnot y]]></alt><mathphrase><![CDATA[\lnot(x \land y) = \lnot x \lor \lnot y]]></mathphrase></inlineequation>
 <inlineequation><alt><![CDATA[\lnot(x \lor y) = \lnot x \land \lnot y]]></alt><mathphrase><![CDATA[\lnot(x \lor y) = \lnot x \land \lnot y]]></mathphrase></inlineequation></simpara>
 <simpara>Create truth tables to verify both of these statements.</simpara>
 </listitem>
 <listitem>
-<simpara>Use De Morgan’s laws given above to rewrite the following statement
+<simpara><anchor xml:id="exercise4.6" xreflabel="[exercise4.6]"/> Use De Morgan&#8217;s laws given above to rewrite the following statement
 in Java to an equivalent statement that contains no negations.</simpara>
 <programlisting language="java" linenumbering="unnumbered">boolean value = !((x != 4) &amp;&amp; (y &lt; 2));</programlisting>
 </listitem>
 <listitem>
-<simpara>Consider the following fragment of code.</simpara>
+<simpara><anchor xml:id="exercise4.7" xreflabel="[exercise4.7]"/> Consider the following fragment of code.</simpara>
 <programlisting language="java" linenumbering="unnumbered">int x = 5;
 int y = 3;
 if( y &gt; 10 &amp;&amp; (x = 10) &gt; 5 )
@@ -9188,7 +9343,7 @@ statement is changed to<?asciidoc-br?>
 <literal>y &gt; 10 &amp; (x = 10) &gt; 5</literal>? Why?</simpara>
 </listitem>
 <listitem>
-<simpara>Consider the following fragment of code.</simpara>
+<simpara><anchor xml:id="exercise4.8" xreflabel="[exercise4.8]"/> Consider the following fragment of code.</simpara>
 <programlisting language="java" linenumbering="unnumbered">int a = 7;
 if( a++ == 7 )
     System.out.println("Seven");
@@ -9201,7 +9356,7 @@ of an <literal>if</literal> statement because of the confusion that can arise.</
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>This problem has two parts.</simpara>
+<simpara><anchor xml:id="exercise4.9" xreflabel="[exercise4.9]"/> This problem has two parts.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
 <simpara>Write a program that reads in two <literal>double</literal> values and prints the
@@ -9215,12 +9370,12 @@ Note: You should use nested <literal>if</literal> statements.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:coins"/> Write programs that:</simpara>
+<simpara><anchor xml:id="exercise4.10" xreflabel="[exercise4.10]"/> Write programs that:</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
 <simpara>Read an <literal>int</literal> value from the user specifying a certain number of
 cents. Use <literal>if</literal> statements to print out the name of the corresponding
-coin in U.S. currency according to the table below. If the value doesn’t
+coin in U.S. currency according to the table below. If the value doesn&#8217;t
 match any coin, print <literal>no coin</literal>.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
 <tgroup cols="2">
@@ -9264,42 +9419,40 @@ match any coin, print <literal>no coin</literal>.</simpara>
 <listitem>
 <simpara>Read a <literal>String</literal> value from the user that gives one of the 6 coin
 names given in the table above. Use <literal>if</literal> statements to print out the
-corresponding number of cents for the input. If the name doesn’t many
+corresponding number of cents for the input. If the name doesn&#8217;t many
 any coin, print <literal>unknown coin</literal>.</simpara>
 </listitem>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Re-implement both parts from Exercise <xref linkend="exercise:coins"/> using
-<literal>switch</literal> statements instead of <literal>if</literal> statements. Note: You cannot use
-<literal>switch</literal> statements for (b) unless you are using Java 7 or later.</simpara>
+<simpara><anchor xml:id="exercise4.11" xreflabel="[exercise4.11]"/> Re-implement both parts from <link linkend="exercise4.10">Exercise 4.10</link> using <literal>switch</literal> statements instead of <literal>if</literal> statements.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:ordinals"/> Expand the program given in
-Example <xref linkend="example:Ordinal_numbers"/> to give the correct suffixes (always
+<simpara><anchor xml:id="exercise4.12" xreflabel="[exercise4.12]"/> Expand the program given in
+<xref linkend="ordinalNumbersExample"/> to give the correct suffixes (always
 &#8220;th&#8221;) for numbers that end in 11, 12, and 13. Use the modulus operator
 to find the last two digits of the number. Using either an <literal>if</literal>
 statement, a <literal>switch</literal> statement, or a combination, check for those three
 cases before going into the normal cases.</simpara>
 </listitem>
 <listitem>
-<simpara>At the bottom of Section <xref linkend="subsection:switch_statements"/>, we use a
+<simpara><anchor xml:id="exercise4.14" xreflabel="[exercise4.14]"/> At the bottom of &lt;&lt;`switch` statements&gt;&gt;, we use a
 <literal>switch</literal> statement to determine the location of various area codes in
 New York state. Write an equivalent fragment of code using <literal>if</literal>-<literal>else</literal>
 statements instead.</simpara>
 </listitem>
 <listitem>
-<simpara>Every member of your secret club has an ID number. These ID numbers
+<simpara><anchor xml:id="exercise4.14" xreflabel="[exercise4.14]"/> Every member of your secret club has an ID number. These ID numbers
 are between 1 and 1,000,000 and have two special characteristics: They
-are multiples of 7 and all end with a 3 in the one’s place. For example,
+are multiples of 7 and all end with a 3 in the one&#8217;s place. For example,
 63 is the smallest such value, and 999,943 is the largest such value.
 Write a program that prompts the user for an <literal>int</literal> value, read it in,
 and then say whether or not it could be used as an ID number. Note: You
-need to use the <literal>\%</literal> operator in two different ways to test the value
+need to use the <literal>%</literal> operator in two different ways to test the value
 correctly.</simpara>
 </listitem>
 <listitem>
-<simpara>According to the North American Numbering Plan (NANP) used by the
+<simpara><anchor xml:id="exercise4.15" xreflabel="[exercise4.15]"/> According to the North American Numbering Plan (NANP) used by the
 United States, Canada, and a number of smaller countries, a legal
 telephone number takes the form <literal>XYY-XYY-YYYY</literal>, where <literal>X</literal> is any digit
 2-9 and <literal>Y</literal> is any digit 0-9. Write a program that reads in a <literal>String</literal>
@@ -9313,14 +9466,14 @@ statements you need to use, but the number of conditions may become
 large. (23 or more!)</simpara>
 </listitem>
 <listitem>
-<simpara>Re-implement the solution to the Monty Hall program given in
-Section <xref linkend="solution:Monty_Hall"/> using <literal>JOptionPane</literal> to generate GUIs for
+<simpara><anchor xml:id="exercise4.16" xreflabel="[exercise4.16]"/> Re-implement the solution to the Monty Hall program given in
+<xref linkend="_solution_monty_hall"/> using <literal>JOptionPane</literal> to generate GUIs for
 input and output.</simpara>
 </listitem>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Repetition">
+<chapter xml:id="_repetition">
 <title>Repetition</title>
 <blockquote>
 <attribution>
@@ -9361,7 +9514,7 @@ occurrences can overlap. For example, given the sequence TATTATTAGATTA
 and asked to search for TATTA, the correct answer is 2. The sequence
 begins with a TATTA, but the third T in the sequence is also the first T
 in a second instance of TATTA.</simpara>
-<simpara>In Chapter <xref linkend="chapter:Selection"/>, you learned tools that allow you to do
+<simpara>In <xref linkend="_selection"/>, you learned tools that allow you to do
 comparisons and make choices based on the results. These tools will
 still be useful. For example, when you come across a <literal>char</literal> in the
 sequence, you know how to compare it to a <literal>char</literal> in the subsequence you
@@ -9545,9 +9698,9 @@ parentheses with a block of code surrounded by braces (<literal>\{\}</literal>)
 afterward. This similarity is not accidental. The only difference
 between the two is that the body of the <literal>if</literal> statement will run a only
 single time, while the body of the <literal>while</literal> loop will run as long as the
-condition remains <literal>true</literal>. Figure <xref linkend="figure:while"/> shows the pattern of
+condition remains <literal>true</literal>. <xref linkend="figure-while"/> shows the pattern of
 execution for <literal>while</literal> loops.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-while" role="text-center">
 <title>If the condition is <literal>true</literal>, all of the statements in the body of the loop are executed, and then the condition is checked again. When the check is <literal>false</literal>, execution skips past the body of the loop.</title>
 <mediaobject>
 <imageobject>
@@ -9607,7 +9760,7 @@ System.out.println("is on fire!");</programlisting>
 binary equivalent of a number.</simpara>
 <example>
 <title>Binary Conversion</title>
-<simpara>As we discussed in Chapter <xref linkend="chapter:Computer_Basics"/>, binary numbers
+<simpara>As we discussed in <xref linkend="_computer_basics"/>, binary numbers
 are the building blocks of every piece of data inside of a modern
 computer&#8217;s memory. Integers are stored in binary. The representation of
 floating point numbers is more complicated, but it also uses 1s and 0s.
@@ -9616,12 +9769,12 @@ fundamentally stored as binary numbers. For this reason, computer
 scientists tend to be familiar with the base 2 number system and how to
 convert between it and base 10, our usual number system.</simpara>
 <simpara>In base 10, the number 379 is equal to
-<inlineequation><alt><![CDATA[3 \cdot 100 + 7 \cdot 10 + 9 \cdot 1 = 3 \cdot 10^2 + 7 \cdot 10^1 + 9 \cdot 10^0]]></alt><mathphrase><![CDATA[3 \cdot 100 + 7 \cdot 10 + 9 \cdot 1 = 3 \cdot 10^2 + 7 \cdot 10^1 + 9 \cdot 10^0]]></mathphrase></inlineequation>.
+3 · 100 + 7 · 10 + 9 · 1 = 3 · 10<superscript>2</superscript> + 7 · 10<superscript>1</superscript> + 9 · 10<superscript>0</superscript>.
 Moving from right to left, the value of each place increases by a factor
 of 10. A binary number is the same, except that the increase is by a
 factor of 2 and no single digit is greater than 1. Thus, the number
-<inlineequation><alt><![CDATA[101011_2 = 1 \cdot 2^5 + 0 \cdot 2^4 + 1 \cdot 2^3 + 0 \cdot 2^2 + 1 \cdot 2 + 1 \cdot 2^0 = 1 \cdot 32 + 0 \cdot 16 + 1 \cdot 8 + 0 \cdot 4 + 1 \cdot 2 + 1 \cdot 0 = 43]]></alt><mathphrase><![CDATA[101011_2 = 1 \cdot 2^5 + 0 \cdot 2^4 + 1 \cdot 2^3 + 0 \cdot 2^2 + 1 \cdot 2 + 1 \cdot 2^0 = 1 \cdot 32 + 0 \cdot 16 + 1 \cdot 8 + 0 \cdot 4 + 1 \cdot 2 + 1 \cdot 0 = 43]]></mathphrase></inlineequation>.
-In binary, the number <inlineequation><alt><![CDATA[379 = 101111011_2]]></alt><mathphrase><![CDATA[379 = 101111011_2]]></mathphrase></inlineequation>.</simpara>
+101011<subscript>2</subscript> = 1 · 2<superscript>5</superscript> + 0 · 2<superscript>4</superscript> + 1 · 2<superscript>3</superscript> + 0 · 2<superscript>2</superscript> + 1 · 2 + 1 · 2<superscript>0</superscript> = 1 · 32 + 0 · 16 + 1 · 8 + 0 · 4 + 1 · 2 + 1 · 0 = 43.
+In binary, the number 379 = 101111011<subscript>2</subscript>.</simpara>
 <simpara>To convert a number <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> to binary, we first find the largest
 power of 2 that is not larger than <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>. Then, we begin a
 repetitive process that stops when the power of 2 under consideration is
@@ -9632,8 +9785,8 @@ Otherwise, we print out a 1, subtract 2 raised to that power from
 process will print a 0 for every power of 2 that is not in
 <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> and a 1 for every one that is, giving exactly the
 definition of a number written in base 2.</simpara>
-<formalpara xml:id="program:DecimalToBinary" xreflabel="DecimalToBinary">
-<title>This program outputs a binary representation of a decimal number.</title>
+<formalpara xml:id="DecimalToBinaryProgram">
+<title>Outputs a binary representation of a decimal number.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -9705,9 +9858,9 @@ follows.</simpara>
 System.out.println("is on fire!");</programlisting>
 <simpara>The header of a <literal>for</literal> loop consists of those three parts: the
 initialization, the condition, and the update, all separated by
-semicolons. Figure <xref linkend="figure:for"/> shows the pattern of execution for
+semicolons. <xref linkend="figure-for"/> shows the pattern of execution for
 <literal>for</literal> loops.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-for" role="text-center">
 <title>The loop is initialized. If the condition is <literal>true</literal>, all of the statements in the body of the loop are executed, followed by the increment step. Then the condition is checked again. When the check is <literal>false</literal>, execution skips past the body of the loop.</title>
 <mediaobject>
 <imageobject>
@@ -9824,7 +9977,7 @@ alphabetical order does not really apply to some character systems like
 the hanzi and kanji of Chinese and Japanese. Regardless, using the
 <literal>Character.isLetter()</literal> method is recommended for almost all
 applications, since it is more general and more readable.</simpara>
-<example>
+<example xml:id="primalityTestingExample">
 <title>Primality testing</title>
 <simpara>Prime numbers are numbers whose only factors are 1 and themselves. If
 you have encountered prime numbers before, they probably seemed like a
@@ -9837,8 +9990,8 @@ write some code to determine if a number <inlineequation><alt><![CDATA[n]]></alt
 so, we can simply divide <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> by all the numbers between 2
 and <inlineequation><alt><![CDATA[n - 1]]></alt><mathphrase><![CDATA[n - 1]]></mathphrase></inlineequation>. If none of the numbers divide it evenly, it
 must be prime. Here is this basic solution.</simpara>
-<formalpara xml:id="program:PrimalityTester0" xreflabel="PrimalityTester0">
-<title>This program gives a naive approach for testing if a number is prime.</title>
+<formalpara xml:id="PrimalityTester0Program">
+<title>Gives a naive approach for testing if a number is prime.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -9868,8 +10021,8 @@ prime.</simpara>
 <simpara>One insight that we can use to make the program more efficient is that,
 after checking 2, we don&#8217;t have to divide it by any even numbers. So, we
 can do half the checking with a few simple modifications.</simpara>
-<formalpara xml:id="program:PrimalityTester1" xreflabel="PrimalityTester1">
-<title>This program gives a slightly cleverer approach for testing if a number is prime.</title>
+<formalpara xml:id="PrimalityTester1Program">
+<title>Gives a slightly cleverer approach for testing if a number is prime.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -9907,8 +10060,8 @@ the way up to <inlineequation><alt><![CDATA[n - 1]]></alt><mathphrase><![CDATA[n
 <inlineequation><alt><![CDATA[\frac{n}{x}]]></alt><mathphrase><![CDATA[\frac{n}{x}]]></mathphrase></inlineequation>, the point where <inlineequation><alt><![CDATA[x = \frac{n}{x}]]></alt><mathphrase><![CDATA[x = \frac{n}{x}]]></mathphrase></inlineequation>
 is when <inlineequation><alt><![CDATA[x = \sqrt{n}]]></alt><mathphrase><![CDATA[x = \sqrt{n}]]></mathphrase></inlineequation>. Thus, we only need to search up to
 <inlineequation><alt><![CDATA[\sqrt{n}]]></alt><mathphrase><![CDATA[\sqrt{n}]]></mathphrase></inlineequation>, which will save even more time.</simpara>
-<formalpara xml:id="program:PrimalityTester2" xreflabel="PrimalityTester2">
-<title>This program gives a much faster approach for testing if a number is prime.</title>
+<formalpara xml:id="PrimalityTester2Program">
+<title>Gives a much faster approach for testing if a number is prime.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -9933,6 +10086,9 @@ public class PrimalityTester2 {
 <simpara>Note in this version of the program we do go up to and including <literal>root</literal>,
 because there is the possibility that <literal>number</literal> is a perfect square.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise5.2">Exercise 5.2</link></simpara>
+</sidebar>
 <example>
 <title>DNA reverse complement</title>
 <simpara>DNA is usually double stranded, with each base paired to another
@@ -9985,8 +10141,8 @@ sequence entered by a user. This sequence will be entered as a sequence
 of characters made up of the four abbreviations for the bases: A, C, G,
 and T. We will store this sequence as a <literal>String</literal> and perform some
 manipulations on it to get the reverse complement.</simpara>
-<formalpara xml:id="program:ReverseComplement" xreflabel="ReverseComplement">
-<title>This program finds the reverse complement of a DNA sequence.</title>
+<formalpara xml:id="ReverseComplementProgram">
+<title>Finds the reverse complement of a DNA sequence.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -10020,8 +10176,8 @@ new <literal>String</literal> that is the reverse of the complement sequence. No
 complementary base at the <emphasis role="strong">end</emphasis> of <literal>complement</literal>. If we inserted each
 <literal>char</literal> at the beginning of <literal>complement</literal>, we would not need to reverse in
 a separate step.</simpara>
-<formalpara xml:id="program:CleverReverseComplement" xreflabel="CleverReverseComplement">
-<title>This program more cleverly finds the reverse complement of a DNA sequence.</title>
+<formalpara xml:id="CleverReverseComplementProgram">
+<title>More cleverly finds the reverse complement of a DNA sequence.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -10067,9 +10223,9 @@ will always run at least once. Neither of the other two loops give you
 that guarantee. The syntax for a <literal>do-while</literal> loop is a <literal>do</literal> at the top of
 a loop body enclosed in braces, with a normal <literal>while</literal> header at the end,
 including a condition in parentheses, followed by a semicolon.
-Figure <xref linkend="figure:do-while"/> shows the pattern of execution for <literal>do-while</literal>
+<xref linkend="figure-do-while"/> shows the pattern of execution for <literal>do-while</literal>
 loops.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-do-while" role="text-center">
 <title>The statements in the body of the loop are executed, and then the condition is checked. When the check is <literal>false</literal>, execution skips past the body of the loop. A <literal>do-while</literal> loop is guaranteed to run at least once.</title>
 <mediaobject>
 <imageobject>
@@ -10144,8 +10300,8 @@ numbers because they can be drawn as equilateral triangles in a very
 natural way, if you use a number of dots equal to the number.</simpara>
 <simpara>We can use nested loops to print out the first <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>
 triangular numbers, where <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> is specified by the user.</simpara>
-<formalpara xml:id="program:TriangularNumbers" xreflabel="TriangularNumbers">
-<title>This program prints out triangular numbers.</title>
+<formalpara xml:id="TriangularNumbersProgram">
+<title>Prints out triangular numbers.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -10174,8 +10330,8 @@ particularly certain types of problems using arrays, but we can generate
 triangular numbers using only a single <literal>for</literal> loop. The key insight is
 that we can keep track of the previous triangular number and add
 <inlineequation><alt><![CDATA[i]]></alt><mathphrase><![CDATA[i]]></mathphrase></inlineequation> to it, as <inlineequation><alt><![CDATA[i]]></alt><mathphrase><![CDATA[i]]></mathphrase></inlineequation> increases.</simpara>
-<formalpara xml:id="program:CleverTriangularNumbers" xreflabel="CleverTriangularNumbers">
-<title>This program prints out triangular numbers more cleverly.</title>
+<formalpara xml:id="CleverTriangularNumbersProgram">
+<title>Prints out triangular numbers more cleverly.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -10197,7 +10353,7 @@ public class CleverTriangularNumbers {
 greatly reduced.</simpara>
 </example>
 </section>
-<section xml:id="subsection:common_pitfalls">
+<section xml:id="_common_pitfalls">
 <title>Common pitfalls</title>
 <simpara>With great power comes great responsibility. The power to repeat things
 a large number of times means that we can also repeat our mistakes a
@@ -10438,6 +10594,9 @@ result, we print out the index of <literal>sequence</literal> where <literal>sub
 and increment the <literal>found</literal> counter.</simpara>
 <simpara>If you know the <literal>String</literal> class well, you can use the <literal>indexOf()</literal> method
 to replace the inner <literal>for</literal> loop. We leave that approach as an exercise.</simpara>
+<sidebar>
+<simpara><link linkend="exercise5.8">Exercise 5.8</link></simpara>
+</sidebar>
 <programlisting language="java" linenumbering="numbered">		if( found == 1 )
 			System.out.println("One match found.");
 		else
@@ -10499,18 +10658,18 @@ different pieces of data, we may be able to speed up the process by
 splitting up the data and letting different threads operate on their own
 segment of the data. Splitting up data this way is called <emphasis>domain
 decomposition</emphasis> which allows us to achieve <emphasis>data parallelism</emphasis>. These
-topics are discussed further in Section <xref linkend="concepts:Splitting_up_work"/>.</simpara>
+topics are discussed further in <xref linkend="_concepts_splitting_up_work"/>.</simpara>
 <simpara>Performing repetitive tasks is one of the great strengths of computers.
 For most programs that run a long time, incredible amounts of
 computation are being done inside of (usually nested) loops. Domain
 decomposition will not work for all of these programs. Some cannot be
 parallelized at all, but this book is about finding problems that can
 have parallel and concurrent solutions.</simpara>
-<simpara>In Chapter <xref linkend="chapter:Concurrent_Programming"/>, we will introduce tools
+<simpara>In <xref linkend="_concurrent_programming"/>, we will introduce tools
 for writing a concurrent program with different threads of execution
 running at the exactly the same time and potentially interacting. Using
 only the power of loops, you can see parallelism in action now.</simpara>
-<example>
+<example xml:id="parallelismWithoutThreadsExample">
 <title>Parallelism without threads</title>
 <simpara>Consider the problem of computing the sum of the sines of a range of
 integers. At its heart is a loop from the start of the range to the end.</simpara>
@@ -10519,8 +10678,8 @@ integers. At its heart is a loop from the start of the range to the end.</simpar
 <simpara>If we want to allow the user to specify the start and the end and print
 out the sum, we need to make a program with a little bit of input and
 output around this loop.</simpara>
-<formalpara xml:id="program:SumSines" xreflabel="SumSines">
-<title>Program to add the sines of all integers in a range specified by the user.</title>
+<formalpara xml:id="SumSinesProgram">
+<title>Adds the sines of all integers in a range specified by the user.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Scanner;
 
@@ -10574,8 +10733,8 @@ thread on. The OS does the job of scheduling and picks a free processor
 when it needs to run a program. It is even possible for programs and
 threads to change from one core to another while running if the OS needs
 to balance out the workload.</simpara>
-<simpara>This sines example is similar to Example <xref linkend="example:Array_summation"/>
-which we will cover in in Chapter <xref linkend="chapter:Concurrent_Programming"/>. As
+<simpara>This sines example is similar to <xref linkend="arraySummationExample"/>
+which we will cover in in <xref linkend="_concurrent_programming"/>. As
 you may have noticed, running four programs is not convenient. You have
 to open several windows, you have to type starting and ending points
 very carefully, and you have to combine the answers at the end since
@@ -10583,17 +10742,21 @@ your programs cannot interact directly with each other. Features of Java
 will make this job easier, allowing us to run more than one thread of
 execution at a time without the need to run multiple programs by hand.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise5.15">Exercise 5.15</link></simpara>
+</sidebar>
 </section>
-<section xml:id="_exercises_4">
+<section xml:id="_exercises_5">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>If you have a <literal>String</literal> containing a long text and you want to count
+<simpara><anchor xml:id="exercise5.1" xreflabel="[exercise5.1]"/> If you have a <literal>String</literal> containing a long text and you want to count
 the number of words in the text that begin with the letter <literal>'m'</literal>, which
 of the three kinds of loops would you use, and why?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:primalityroot"/> In Example <xref linkend="example:Primality_testing"/>,
+<simpara><anchor xml:id="exercise5.2" xreflabel="[exercise5.2]"/> In <xref linkend="primalityTestingExample"/>,
 our last version of the primality tester <literal>PrimalityTester2</literal> computes the
 square root of the number being tested. Instead of computing this value
 before the loop, how would performance be affected by changing the head
@@ -10601,11 +10764,11 @@ of the <literal>for</literal> loop to the following?</simpara>
 <programlisting language="java" linenumbering="unnumbered">for(long i = 3; i &lt;= Math.sqrt(number) &amp;&amp; prime; i += 2)</programlisting>
 </listitem>
 <listitem>
-<simpara>How many different DNA sequences of length <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> are
+<simpara><anchor xml:id="exercise5.3" xreflabel="[exercise5.3]"/> How many different DNA sequences of length <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> are
 there?</simpara>
 </listitem>
 <listitem>
-<simpara>There are three different errors in the following loop intended to
+<simpara><anchor xml:id="exercise5.4" xreflabel="[exercise5.4]"/> There are three different errors in the following loop intended to
 print out the numbers 1 through 10. What are they?</simpara>
 <programlisting language="java" linenumbering="unnumbered">for( int i = 1; i &lt; 10; i-- );
 {
@@ -10613,7 +10776,7 @@ print out the numbers 1 through 10. What are they?</simpara>
 }</programlisting>
 </listitem>
 <listitem>
-<simpara>Consider the following code containing nested <literal>for</literal> loops.</simpara>
+<simpara><anchor xml:id="exercise5.5" xreflabel="[exercise5.5]"/>  Consider the following code containing nested <literal>for</literal> loops.</simpara>
 <programlisting language="java" linenumbering="unnumbered">Scanner in = new Scanner(System.in);
 int n = in.nextInt();
 int count = 0;
@@ -10627,13 +10790,13 @@ try to detect a pattern.</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Write a program that converts base 10 numbers into base 3 numbers.
+<simpara><anchor xml:id="exercise5.6" xreflabel="[exercise5.6]"/> Write a program that converts base 10 numbers into base 3 numbers.
 If you find that task too easy, write a program that will convert base
 10 numbers to any base in the range 2 to 16. Hint: Use letters A through
 F, in order, to represent digits larger than 9.</simpara>
 </listitem>
 <listitem>
-<simpara>The greatest common divisor (GCD) of two integers is the largest
+<simpara><anchor xml:id="exercise5.7" xreflabel="[exercise5.7]"/> The greatest common divisor (GCD) of two integers is the largest
 integer that divides both of them evenly. The GCD for any two positive
 integers is at least 1 and at most the smaller of the two numbers. Write
 a program that prompts a user for two <literal>int</literal> values and finds their GCD.
@@ -10642,8 +10805,8 @@ either number. If the counter ever divides <emphasis role="strong">both</emphasi
 the GCD. The counter is guaranteed to divide them both if it reaches 1.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:String_indexOf"/> In the solution to the DNA searching
-problem given in Section <xref linkend="solution:DNA_searching"/>, we used two <literal>for</literal>
+<simpara><anchor xml:id="exercise5.8" xreflabel="[exercise5.8]"/> In the solution to the DNA searching
+problem given in <xref linkend="_solution_dna_searching"/>, we used two <literal>for</literal>
 loops to find occurrences of a DNA subsequence inside of a larger
 sequence. Professional Java developers would have used a single <literal>for</literal>
 loop and the <literal>indexOf()</literal> method in the <literal>String</literal> class. One version of
@@ -10659,7 +10822,7 @@ will return <literal>-1</literal>. Rewrite the solution to the DNA searching pro
 replacing the inner searching <literal>for</literal> loop with the <literal>indexOf()</literal> method.</simpara>
 </listitem>
 <listitem>
-<simpara>Write a program that reads a number <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> from a user and
+<simpara><anchor xml:id="exercise5.9" xreflabel="[exercise5.9]"/> Write a program that reads a number <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> from a user and
 then prints all possible DNA sequences of length <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>. Be
 careful not to supply too large of a value when you run this program.
 Hint: Represent the sequence as a <literal>String</literal>. On each iteration, focus on
@@ -10671,13 +10834,13 @@ odometer. You will have to design loops that can deal with carries that
 cascade across multiple indexes.</simpara>
 </listitem>
 <listitem>
-<simpara>Re-implement the solution to the DNA searching program given in
-Section <xref linkend="solution:DNA_searching"/> using <literal>JOptionPane</literal> to generate GUIs
+<simpara><anchor xml:id="exercise5.10" xreflabel="[exercise5.10]"/> Re-implement the solution to the DNA searching program given in
+<xref linkend="_solution_dna_searching"/> using <literal>JOptionPane</literal> to generate GUIs
 for input and output.</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Using a <literal>for</literal> loop, record the Monty Hall simulation so that you can
+<simpara><anchor xml:id="exercise5.11" xreflabel="[exercise5.11]"/> Using a <literal>for</literal> loop, record the Monty Hall simulation so that you can
 run it 100 times, always choosing to switch doors. Keep a record of how
 many times you win. Change your code again to run the Monty Hall
 simulation 100 more times, always choosing to keep your initial choice.
@@ -10688,7 +10851,7 @@ times. Does the performance of switching get closer to twice the
 performance of not switching?</simpara>
 </listitem>
 <listitem>
-<simpara>Write three nested <literal>for</literal> loops, each of which run 1,000 times.
+<simpara><anchor xml:id="exercise5.12" xreflabel="[exercise5.12]"/> Write three nested <literal>for</literal> loops, each of which run 1,000 times.
 Increment a counter in the innermost <literal>for</literal> loop. If that counter starts
 at 0, its final value should be 1,000,000,000. Time how long your
 program takes to run to completion using either a stopwatch or, if you
@@ -10698,7 +10861,7 @@ time. However, if you increase the values of all three loops too much,
 you may have to wait longer than you want.</simpara>
 </listitem>
 <listitem>
-<simpara>In Section <xref linkend="subsection:common_pitfalls"/>, one of the common loop
+<simpara><anchor xml:id="exercise5.13" xreflabel="[exercise5.13]"/> In <xref linkend="_common_pitfalls"/>, one of the common loop
 mistakes we discuss is an almost infinite loop. Create your own almost
 infinite loop that runs from <literal>10</literal> to <literal>0</literal>, incrementing instead of
 decrementing. Time the execution of your program. Unlike our example, do
@@ -10707,7 +10870,7 @@ much longer would your code take to run if you used a <literal>long</literal> in
 an <literal>int</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara>In Example <xref linkend="example:Primality_testing"/>, we gave three programs to
+<simpara><anchor xml:id="exercise5.14" xreflabel="[exercise5.14]"/> In <xref linkend="primalityTestingExample"/>, we gave three programs to
 test a number for primality. Run each of these prime testers on a large
 prime such as 982,451,653 and time them. Is there a significant
 difference in the running time of <literal>PrimalityTester0</literal> and
@@ -10715,10 +10878,9 @@ difference in the running time of <literal>PrimalityTester0</literal> and
 <literal>PrimalityTester2</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:primes_less_than"/> In Example <xref linkend="example:Parallelism
-without threads"/>, we ran four programs at the same time to solve a
+<simpara><anchor xml:id="exercise5.15" xreflabel="[exercise5.15]"/> In <xref linkend="parallelismWithoutThreadsExample"/>, we ran four programs at the same time to solve a
 problem in parallel. Use the same framework (combined with your
-knowledge of primes from Example <xref linkend="example:Primality_testing"/>) to write
+knowledge of primes from <xref linkend="primalityTestingExample"/>) to write
 a program that can see how many prime numbers are in a user specified
 range of integers. Then, use it to find the total number of primes
 between 2 and 500,000,000. Now, run two copies of the program with one
@@ -10732,7 +10894,7 @@ pieces run significantly faster or slower than the others?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Arrays">
+<chapter xml:id="_arrays">
 <title>Arrays</title>
 <blockquote>
 <attribution>
@@ -10814,7 +10976,7 @@ begin by randomly making 10% of all the cells living and the rest dead.</simpara
 <section xml:id="_terminal_limitations">
 <title>Terminal limitations</title>
 <simpara>One problem you might be worrying about is how to display the
-simulation. In Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/> you will learn how to make a graphical user interface (GUI)
+simulation. In <xref linkend="_constructing_graphical_user_interfaces"/> you will learn how to make a graphical user interface (GUI)
 that can display a grid of cells in black and white and much more
 interesting things as well. For now, the main tool that we can use for
 output is still the terminal. The output method we recommend is printing
@@ -10849,8 +11011,7 @@ we suggested before. The code to make your program sleep for that amount
 of time is:</simpara>
 <programlisting language="java" linenumbering="unnumbered">try { Thread.sleep(100); }
 catch( InterruptedException e ) {}</programlisting>
-<simpara>We will explain this code in much greater detail in
-Chapter <xref linkend="chapter:Concurrent_Programming"/>. The key item of importance
+<simpara>We will explain this code in much greater detail in <xref linkend="_concurrent_programming"/>. The key item of importance
 is the number passed into the <literal>sleep()</literal> method. This value is the number
 of milliseconds you want your program to sleep. 100 milliseconds is, of
 course, one tenth of a second.</simpara>
@@ -10876,7 +11037,7 @@ name implies, a data structure is a way to organize data, whether in a
 list, in a tree, in sorted order, in some kind of hierarchy, or in any
 other way that might be useful. We will only talk about the array data
 structure in this chapter, but other data structures will be discussed
-in Chapter <xref linkend="chapter:Dynamic_Data_Structures"/>. Below we give a short
+in <xref linkend="_dynamic_data_structures"/>. Below we give a short
 explanation of some of the attributes any given data structure might
 have.</simpara>
 <section xml:id="_data_structure_attributes">
@@ -10940,13 +11101,12 @@ other.</simpara>
 <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>, a length specified when the array is created. Each of
 the <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> elements is indexed using a number between 0 and
 <inlineequation><alt><![CDATA[n - 1]]></alt><mathphrase><![CDATA[n - 1]]></mathphrase></inlineequation>. Once again, zero-based counting rears its ugly
-head. Consider the following list of items:
-<inlineequation><alt><![CDATA[\{9, 4, 2, 1, 6, 8, 3 \}]]></alt><mathphrase><![CDATA[\{9, 4, 2, 1, 6, 8, 3 \}]]></mathphrase></inlineequation></simpara>
-<simpara>If this list is stored in an array, the first element, <inlineequation><alt><![CDATA[9]]></alt><mathphrase><![CDATA[9]]></mathphrase></inlineequation>,
-would have index <inlineequation><alt><![CDATA[0]]></alt><mathphrase><![CDATA[0]]></mathphrase></inlineequation>, <inlineequation><alt><![CDATA[4]]></alt><mathphrase><![CDATA[4]]></mathphrase></inlineequation> would have index
-<inlineequation><alt><![CDATA[1]]></alt><mathphrase><![CDATA[1]]></mathphrase></inlineequation>, and so on, finishing at <inlineequation><alt><![CDATA[3]]></alt><mathphrase><![CDATA[3]]></mathphrase></inlineequation> with an index
-of <inlineequation><alt><![CDATA[6]]></alt><mathphrase><![CDATA[6]]></mathphrase></inlineequation>, although the total number of items is
-<inlineequation><alt><![CDATA[7]]></alt><mathphrase><![CDATA[7]]></mathphrase></inlineequation>. Not all languages use zero-based counting for array
+head. Consider the following list of items: {9, 4, 2, 1, 6, 8, 3 \}</simpara>
+<simpara>If this list is stored in an array, the first element, 9,
+would have index 0, 4 would have index
+1, and so on, finishing at 3 with an index
+of 6, although the total number of items is
+7. Not all languages use zero-based counting for array
 indexes, but many do, including C, C++, and Java. The reason that
 languages like C originally used zero-based counting for indexes is that
 the variable corresponding to the array is an address inside the
@@ -11032,7 +11192,7 @@ of those elements contains the <literal>int</literal> value <literal>0</literal>
 <simpara>Whenever an array is instantiated, each of its <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> elements
 is set to some default value. For <literal>int</literal>, <literal>long</literal>, <literal>short</literal>, and <literal>byte</literal>
 this value is <literal>0</literal>. For <literal>double</literal> and <literal>float</literal>, this value is <literal>0.0</literal>. For
-<literal>char</literal>, this value is <literal>'\\0'</literal>, a special unprintable character. For
+<literal>char</literal>, this value is <literal>'\0'</literal>, a special unprintable character. For
 <literal>boolean</literal>, this value is <literal>false</literal>. For <literal>String</literal> or any other reference
 type, this value is <literal>null</literal>, a special value that means there is no
 object at that address.</simpara>
@@ -11134,7 +11294,7 @@ Note that the <literal>length</literal> field is read-only. If you try to set
 with a loop. Let&#8217;s assume that an array of type <literal>double</literal> named <literal>data</literal>
 has been declared, instantiated, and filled with user input. We could
 sum all its elements using the following code. A more elegant way to do
-the same summation is discussed in Section <xref linkend="subsection:The_for-each_loop"/>.</simpara>
+the same summation is discussed in <xref linkend="_the_for_each_loop"/>.</simpara>
 <programlisting language="java" linenumbering="unnumbered">double sum = 0.0;
 for( int i = 0; i &lt; data.length; i++ )
     sum += data[i];
@@ -11177,7 +11337,7 @@ reversed in the future.</simpara>
 programs that process a lot of data can be tedious. Instead of typing
 data into the terminal, we can read data from a file. In Java, file I/O
 is a messy process that involves several objects and method calls. We&#8217;re
-going to talk about it in depth in Chapter <xref linkend="chapter:File_I/O"/>, but for
+going to talk about it in depth in <xref linkend="_file_i_o"/>, but for
 now we can use a quick and easy workaround.</simpara>
 <simpara>If you create a text file using a simple text editor, you can <emphasis>redirect</emphasis>
 the file as input to a program. Everything you have written in the text
@@ -11194,8 +11354,8 @@ support input redirection, but virtually every flavor of Linux and Unix
 do, as well as the Windows command line and the Mac OS X terminal. We
 could write the program mentioned above and give it the simple task of
 summing all the numbers it gets as input.</simpara>
-<formalpara xml:id="program:Summer" xreflabel="Summer">
-<title>This program sums a list of numbers given as input.</title>
+<formalpara xml:id="SummerProgram">
+<title>Sums a list of numbers given as input.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -11237,8 +11397,8 @@ sequence of <literal>int</literal> values, you can use <literal>hasNextInt()</li
 have reached the end of the file or not. Using <literal>hasNextInt()</literal>, we can
 simplify the program and remove the expectation that the first number
 gives the total count of numbers.</simpara>
-<formalpara xml:id="program:QuietSummer" xreflabel="QuietSummer">
-<title>This program sums a list of numbers given as input without prompting the user.</title>
+<formalpara xml:id="QuietSummerProgram">
+<title>Sums a list of numbers given as input without prompting the user.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -11284,7 +11444,7 @@ countless real world problems.</simpara>
 <simpara>In the examples below, we will first discuss finding the largest (or
 smallest) value in a list, move on to sorting lists, and then talk about
 a task that searches for words, like a dictionary look up.</simpara>
-<example>
+<example xml:id="kingOfTheHillExample">
 <title>King of the hill</title>
 <simpara>Finding the largest value input by a user is not difficult. Applying
 that knowledge to an array is pretty straightforward as well. This
@@ -11326,7 +11486,7 @@ how repeatedly finding the smallest value in an array can be used to
 sort it. The largest value could be used equally well, but we will use
 the smallest.</simpara>
 </example>
-<example>
+<example xml:id="selectionSortExample">
 <title>Selection sort</title>
 <simpara>Sorting is the bread and butter of computer scientists. Much research
 has been devoted to finding the fastest ways to sort a list of data. The
@@ -11403,7 +11563,7 @@ only need to change the <literal>&lt;</literal> to a <literal>&gt;</literal> in 
 <literal>for</literal> loop, although other changes are recommended for the sake of
 readability.</simpara>
 </example>
-<example>
+<example xml:id="wordSearchExample">
 <title>Word search</title>
 <simpara>In this example, we will read in a list of words and a long passage of
 text and keep track of the number of times each word in the list occurs
@@ -11414,8 +11574,7 @@ word processors use some of the same techniques.</simpara>
 <simpara>To make this program work, however, we need to read in a (potentially
 long) list of words and then a lot of text. We are forced to use input
 redirection (or some other file input) because typing this text in
-multiple times would be tedious. When we get to Chapter <xref linkend="chapter:File
-I/O"/>, we will talk about ways to read from multiple files at the same
+multiple times would be tedious. When we get to <xref linkend="_file_i_o"/>, we will talk about ways to read from multiple files at the same
 time. Right now, we can only redirect input from a single file and so we
 are forced to put the list of words at the top of the file, followed by
 the text we want to search through.</simpara>
@@ -11464,7 +11623,7 @@ correspondence between their elements.</simpara>
 <simpara>To give a clear picture of how this program should behave, here is a
 sample input file with two paragraphs from the beginning of <emphasis>The Counte
 of Monte Cristo</emphasis> by Alexandre Dumas.</simpara>
-<programlisting language="java" linenumbering="unnumbered">7
+<literallayout class="monospaced">7
 and
 at
 bridge
@@ -11482,17 +11641,17 @@ Immediately, and according to custom, the ramparts of Fort Saint-Jean
 were covered with spectators; it is always an event at Marseilles for a
 ship to come into port, especially when this ship, like the Pharaon, has
 been built, rigged, and laden at the old Phocee docks, and belongs to an
-owner of the city.</programlisting>
+owner of the city.</literallayout>
 <simpara>And here is the output one should get from running <literal>WordCount</literal> with
 input redirected from the file given above.</simpara>
-<programlisting language="java" linenumbering="unnumbered">The word counts are:
+<literallayout class="monospaced">The word counts are:
 and 6
 at 3
 bridge 0
 for 1
 pilot 1
 vessel 1
-walnut 0</programlisting>
+walnut 0</literallayout>
 <simpara>For this example, the program works fine. However, our program would
 have given incorrect output if <literal>ship</literal>, <literal>spectators</literal>, or several other
 words in the text had been on the word list. You see, the <literal>next()</literal>
@@ -11503,7 +11662,10 @@ space only, the <literal>String</literal> <literal>"ship,"</literal> does not ma
 Dealing with punctuation is not difficult, but it would increase the
 length of the code, and we leave it as an exercise.</simpara>
 </example>
-<example>
+<sidebar>
+<simpara><link linkend="exercise6.8">Exercise 6.8</link></simpara>
+</sidebar>
+<example xml:id="statisticsExample">
 <title>Statistics</title>
 <simpara>Imagine that you are a teacher who has just given an exam. You want to
 produce statistics for the class so that the students have some idea how
@@ -11544,7 +11706,7 @@ produce the statistics, to save time now and in the future.</simpara>
 </tbody>
 </tgroup>
 </informaltable>
-<simpara>Example <xref linkend="example:King_of_the_hill"/> covered how to find the maximum and
+<simpara><xref linkend="kingOfTheHillExample"/> covered how to find the maximum and
 minimum scores in a list. The mean is simply the sum of all the scores
 divided by the total number of scores. Standard deviation is a little
 bit trickier. It gives a measurement of how spread out the data is. Let
@@ -12050,7 +12212,7 @@ later.</simpara>
 like most of the types we have discussed so far. A reference variable is
 a name for an object. You might recall that we described the difference
 between reference types and primitive types in
-Section <xref linkend="concepts:Types"/>, but the only reference type we have
+<xref linkend="_concepts_types"/>, but the only reference type we have
 considered in detail is <literal>String</literal>.</simpara>
 <simpara>More than one reference variable can point at the same object. When one
 object has more than one name, this is called <emphasis>aliasing</emphasis>. The <literal>String</literal>
@@ -12237,7 +12399,7 @@ System.out.println("The distance is: " + distances[city1][city2] +
 from the table, but then the ragged array would have one fewer row than
 the original two-dimensional array.</simpara>
 </section>
-<section xml:id="_common_pitfalls">
+<section xml:id="_common_pitfalls_2">
 <title>Common pitfalls</title>
 <simpara>Even one-dimensional arrays make many new errors possible. Below we list
 two of the most common mistakes made with both one-dimensional and
@@ -12333,8 +12495,8 @@ number of days in the month. Our program will print out labels for the
 seven days of the week, followed by numbering starting at the
 appropriate place, and wrapping such that each numbered day of the month
 falls under the appropriate day of the week.</simpara>
-<formalpara xml:id="program:Calendar" xreflabel="Calendar">
-<title>This program prints a calendar for a given month, formatted week by week.</title>
+<formalpara xml:id="CalendarProgram">
+<title>Prints a calendar for a given month, formatted week by week.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -12379,7 +12541,7 @@ public class Calendar {
 }</programlisting>
 </para>
 </formalpara>
-<simpara>First, our code creates a 7 <inlineequation><alt><![CDATA[\times]]></alt><mathphrase><![CDATA[\times]]></mathphrase></inlineequation> 7 array of type
+<simpara>First, our code creates a 7 × 7 array of type
 <literal>String</literal> called <literal>squares</literal>. The array needs 7 rows so that it can start
 with a row to label the days and then output up to 6 rows to cover the
 weeks. (Months with 31 days span parts of 6 different weeks if they
@@ -12395,7 +12557,7 @@ days in the month.</simpara>
 each square with a steadily increasing day number for each column,
 moving on to the next row when a row is filled. Finally, the two nested
 <literal>for</literal> loops at the end print out the contents of <literal>squares</literal>, putting a
-tab (<literal>'\\t'</literal>) between each column and starting a new line for each row.</simpara>
+tab (<literal>'\t'</literal>) between each column and starting a new line for each row.</simpara>
 </example>
 <example>
 <title>Matrix-vector multiplication</title>
@@ -12406,8 +12568,18 @@ a vector with three elements: <inlineequation><alt><![CDATA[x]]></alt><mathphras
 represented by this vector, we can multiply it by a matrix. For example,
 to rotate a point around the <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation>-axis by
 <inlineequation><alt><![CDATA[\theta]]></alt><mathphrase><![CDATA[\theta]]></mathphrase></inlineequation> degrees, we could use the following matrix.</simpara>
-<simpara><inlineequation><alt><![CDATA[\begin{bmatrix} 1 & 0 & 0 \\ 0 & \cos \theta & -\sin \theta \\[3pt]]></alt><mathphrase><![CDATA[\begin{bmatrix} 1 & 0 & 0 \\ 0 & \cos \theta & -\sin \theta \\[3pt]]></mathphrase></inlineequation> 0 &amp; \sin
-\theta  &amp; \cos \theta \\[3pt] \end{bmatrix}]</simpara>
+<informalequation>
+<alt><![CDATA[\begin{bmatrix}
+1 & 0 & 0 \\
+0 & \cos \theta & -\sin \theta \\
+0 & \sin \theta  & \cos \theta \\
+\end{bmatrix}]]></alt>
+<mathphrase><![CDATA[\begin{bmatrix}
+1 & 0 & 0 \\
+0 & \cos \theta & -\sin \theta \\
+0 & \sin \theta  & \cos \theta \\
+\end{bmatrix}]]></mathphrase>
+</informalequation>
 <simpara>Given an <inlineequation><alt><![CDATA[m\times n]]></alt><mathphrase><![CDATA[m\times n]]></mathphrase></inlineequation> matrix <inlineequation><alt><![CDATA[A]]></alt><mathphrase><![CDATA[A]]></mathphrase></inlineequation>, let
 <inlineequation><alt><![CDATA[A_{ij}]]></alt><mathphrase><![CDATA[A_{ij}]]></mathphrase></inlineequation> be the element in the <inlineequation><alt><![CDATA[i]]></alt><mathphrase><![CDATA[i]]></mathphrase></inlineequation><superscript>th</superscript> row,
 <inlineequation><alt><![CDATA[j]]></alt><mathphrase><![CDATA[j]]></mathphrase></inlineequation><superscript>th</superscript> column. Given a vector <inlineequation><alt><![CDATA[v]]></alt><mathphrase><![CDATA[v]]></mathphrase></inlineequation> of length
@@ -12419,8 +12591,8 @@ the resulting vector <inlineequation><alt><![CDATA[v']]></alt><mathphrase><![CDA
 <simpara>By transforming this equation to Java code, we can write a program that
 can read in a three-dimensional point and rotate it around the
 <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation>-axis by the amount specified by the user.</simpara>
-<formalpara xml:id="program:MatrixRotate" xreflabel="MatrixRotate">
-<title>This program uses matrix multiplication to rotate a point in three-dimensional space.</title>
+<formalpara xml:id="MatrixRotateProgram">
+<title>Uses matrix multiplication to rotate a point in three-dimensional space.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -12463,7 +12635,7 @@ multiplication and then print out the answer. Again, the summing done by
 our calculations uses the fact that all elements of <literal>rotatedPoint</literal> are
 initialized to <literal>0.0</literal>.</simpara>
 </example>
-<example>
+<example xml:id="ticTacToeExample">
 <title>Tic Tac Toe</title>
 <simpara>Almost every child knows the game of Tic Tac Toe. Its playing area is a
 3 <inlineequation><alt><![CDATA[\times]]></alt><mathphrase><![CDATA[\times]]></mathphrase></inlineequation> 3 grid. Players take turns placing X&#8217;s and O&#8217;s,
@@ -12583,6 +12755,9 @@ large board we mean that we would not want to check the entire thing
 each move. Instead, we could focus only on rows, columns, and diagonals
 affected by the last move.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise6.11">Exercise 6.11</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_advanced_special_array_tools_in_java">
 <title>Advanced: Special array tools in Java</title>
@@ -12590,9 +12765,9 @@ affected by the last move.</simpara>
 There are often special syntactical tools or libraries designed to make
 them easier to use. In this section, we explore two advanced tools, the
 for-each loop and the <literal>Arrays</literal> utility class.</simpara>
-<section xml:id="subsection:The_for-each_loop">
+<section xml:id="_the_for_each_loop">
 <title>The for-each loop</title>
-<simpara>In Chapter <xref linkend="chapter:Repetition"/> we describe three loops: <literal>while</literal>
+<simpara>In <xref linkend="_repetition"/> we describe three loops: <literal>while</literal>
 loops, <literal>for</literal> loops, and <literal>do-while</literal> loops. Although these are the only
 three loops in Java, there is a special form of the <literal>for</literal> loop designed
 for use with arrays (and some other data structures). This construct is
@@ -12643,9 +12818,9 @@ variable <literal>value</literal> but never changes <literal>array</literal>.</s
     value = 5;</programlisting>
 <simpara>Although for-each loops are great for arrays, they can also be used for
 any other data structures that implements the <literal>Iterable</literal> interface. We
-discuss interfaces in Chapter <xref linkend="chapter:Interfaces"/> and dynamic data
-structures in Chapters <xref linkend="chapter:Dynamic_Data_Structures"/> and
-<xref linkend="chapter:Recursion"/>.</simpara>
+discuss interfaces in <xref linkend="_interfaces"/> and dynamic data
+structures in <xref linkend="_dynamic_data_structures"/> and
+<xref linkend="_recursion"/>.</simpara>
 </section>
 <section xml:id="_the_literal_arrays_literal_class">
 <title>The <literal>Arrays</literal> class</title>
@@ -12740,8 +12915,7 @@ columns, although it would be easy to change those dimensions.</simpara>
 			for( int column = 0; column &lt; COLUMNS; column++ )
 				board[row][column] = (Math.random() &gt; 0.9);</programlisting>
 <simpara>The <literal>main()</literal> method of our program starts by defining <literal>ROWS</literal>, <literal>COLUMNS</literal>,
-and<?asciidoc-br?>
-<literal>GENERATIONS</literal> as named constants using the <literal>final</literal> keyword. Next, we
+and <literal>GENERATIONS</literal> as named constants using the <literal>final</literal> keyword. Next, we
 create <emphasis role="strong">two</emphasis> arrays with <literal>ROWS</literal> rows and <literal>COLUMNS</literal> columns. The <literal>board</literal>
 array will hold the current generation. The <literal>temp</literal> array will be used to
 fill in the next generation. Then, <literal>temp</literal> will be copied into <literal>board</literal>,
@@ -12813,14 +12987,13 @@ screen, as we explained earlier. The two nested <literal>for</literal> loops pri
 the state of the current generation, with a <literal>*</literal> for each living cell and
 a blank space for each dead one. After the output, the code sleeps for
 100 milliseconds to give the effect of an animation. We will discuss
-exceptions in general in Chapter <xref linkend="chapter:Exceptions"/> and give more
-information about the <literal>Thread.sleep()</literal> method in Chapter
-<xref linkend="chapter:Concurrent_Programming"/>.</simpara>
+exceptions in general in <xref linkend="_exceptions"/> and give more
+information about the <literal>Thread.sleep()</literal> method in <xref linkend="_concurrent_programming"/>.</simpara>
 </section>
 <section xml:id="_concurrency_arrays">
 <title>Concurrency: Arrays</title>
 <simpara>Arrays are critical to concurrent programming in Java. In
-Chapter <xref linkend="chapter:Concurrent_Programming"/>, we will explain how to
+<xref linkend="_concurrent_programming"/>, we will explain how to
 create independent threads of execution, each of which is tied to a
 <literal>Thread</literal> object. If you have a dual, quad, or higher core computer, you
 might want to use two or four threads to solve a problem, but some
@@ -12854,6 +13027,9 @@ arithmetic from the case in which the threads evenly divide the length
 of the array: Each thread gets <inlineequation><alt><![CDATA[\frac{n}{k}]]></alt><mathphrase><![CDATA[\frac{n}{k}]]></mathphrase></inlineequation> (using integer
 division) elements, and we stick the last thread with the leftovers. How
 bad can that be?</simpara>
+<sidebar>
+<simpara><link linkend="exercise6.7">Exercise 6.7</link></simpara>
+</sidebar>
 <simpara>This assignment of work can be very poorly balanced. Consider a case
 with 10 threads and 28 pieces of data. <inlineequation><alt><![CDATA[\frac{28}{10} = 2]]></alt><mathphrase><![CDATA[\frac{28}{10} = 2]]></mathphrase></inlineequation>,
 using integer division. Thus, the first nine threads have 2 units of
@@ -12894,8 +13070,9 @@ balancing</emphasis>, a broad term for dividing work across computing resources.
 <textobject><phrase>split2</phrase></textobject>
 </mediaobject>
 </figure>
-<formalpara xml:id="program:AssigningWork" xreflabel="AssigningWork">
-<title>Here is a short program that reads the length of an array and the number of threads from the user and then prints out the amount of work for each one. You should be able to adapt the ideas in it to your own multi-threaded programs in Chapter <xref linkend="chapter:Concurrent Programming"/>.</title>
+<simpara>The program below reads the length of an array and the number of threads from the user and then prints out the amount of work for each one. You should be able to adapt the ideas in it to your own multi-threaded programs in <xref linkend="_concurrent_programming"/>.</simpara>
+<formalpara xml:id="AssigningWorkProgram">
+<title>Template for assigning work to threads.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -12924,16 +13101,17 @@ public class AssigningWork {
 </formalpara>
 </example>
 </section>
-<section xml:id="_exercises_5">
+<section xml:id="_exercises_6">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>Why can&#8217;t an array be used to hold an arbitrarily long list of
+<simpara><anchor xml:id="exercise6.1" xreflabel="[exercise6.1]"/> Why can&#8217;t an array be used to hold an arbitrarily long list of
 numbers entered by a user? What are strategies that can be used to
 overcome this problem?</simpara>
 </listitem>
 <listitem>
-<simpara>In future chapters, we will introduce a data structure called a
+<simpara><anchor xml:id="exercise6.2" xreflabel="[exercise6.2]"/> In future chapters, we will introduce a data structure called a
 <emphasis>linked list</emphasis>. A linked list is a homogeneous, dynamic data structure,
 with sequential access (unlike an array, which has random access). You
 can instantly jump to any place in an array, but you have to step
@@ -12945,7 +13123,7 @@ copied over. List some tasks for which an array would be better than a
 linked list and vice versa.</simpara>
 </listitem>
 <listitem>
-<simpara>Given the following code:</simpara>
+<simpara><anchor xml:id="exercise6.3" xreflabel="[exercise6.3]"/> Given the following code:</simpara>
 <programlisting language="java" linenumbering="unnumbered">double[] array1 = new double[50];
 double[] array2 = new double[50];
 for( int i = 0; i &lt; array1.length; i++ ) {
@@ -12959,13 +13137,13 @@ for( int i = 1; i &lt; array1.length; i++ )
 executed?</simpara>
 </listitem>
 <listitem>
-<simpara>What error will be caused by the following code, and why?</simpara>
+<simpara><anchor xml:id="exercise6.4" xreflabel="[exercise6.4]"/> What error will be caused by the following code, and why?</simpara>
 <programlisting language="java" linenumbering="unnumbered">String[] array = new String[100];
 System.out.println(array[99].charAt(0) +
            " is the first letter of the last String.");</programlisting>
 </listitem>
 <listitem>
-<simpara>An array of length <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> in Java typically takes
+<simpara><anchor xml:id="exercise6.5" xreflabel="[exercise6.5]"/> An array of length <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> in Java typically takes
 <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> times the number of bytes for each element plus an
 additional 16 bytes of overhead. Since an <literal>int</literal> uses 4 bytes of storage,
 an array of 100 <literal>int</literal> elements would take 416 bytes. Consider the
@@ -12976,8 +13154,8 @@ overhead will occur repeatedly, since Java creates a three-dimensional
 array as an array of arrays of arrays.</simpara>
 </listitem>
 <listitem>
-<simpara>Our original table of city distances allocates
-<inlineequation><alt><![CDATA[5 \cdot 5 = 25]]></alt><mathphrase><![CDATA[5 \cdot 5 = 25]]></mathphrase></inlineequation> <literal>int</literal> elements to store all the distances
+<simpara><anchor xml:id="exercise6.6" xreflabel="[exercise6.6]"/> Our original table of city distances allocates
+5 · 5 = 25 <literal>int</literal> elements to store all the distances
 between the five cities, including repeats. How many <literal>int</literal> elements are
 allocated for the triangular, ragged array version of the city distance
 table? If we used the normal table style, <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> cities would
@@ -12985,9 +13163,9 @@ require <inlineequation><alt><![CDATA[n^2]]></alt><mathphrase><![CDATA[n^2]]></m
 triangular, ragged array version allocate for <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> cities?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:naive_array_split"/> Consider the naive method of dividing
+<simpara><anchor xml:id="exercise6.7" xreflabel="[exercise6.7]"/> Consider the naive method of dividing
 an array of length <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> among <inlineequation><alt><![CDATA[k]]></alt><mathphrase><![CDATA[k]]></mathphrase></inlineequation> threads that
-was discussed in Section <xref linkend="concurrency:Arrays"/>: Each thread gets
+was discussed in <xref linkend="_concurrency_arrays"/>: Each thread gets
 <inlineequation><alt><![CDATA[n/k]]></alt><mathphrase><![CDATA[n/k]]></mathphrase></inlineequation> (rounded down because of integer division) elements,
 and the last thread gets any extras. What mathematical expression
 describes how many extra elements are allocated to the last thread? Can
@@ -12997,10 +13175,10 @@ fair scheme for assigning the data to threads?</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:remove_punctuation"/> In Example <xref linkend="example:Word_search"/>,
+<simpara><anchor xml:id="exercise6.8" xreflabel="[exercise6.8]"/> In <xref linkend="wordSearchExample"/>,
 our code did not count <literal>ship,</literal> as an occurrence of <literal>ship</literal> because of the
 comma.</simpara>
-<simpara>Rewrite the code from Example <xref linkend="example:Word_search"/> to remove
+<simpara>Rewrite the code from <xref linkend="wordSearchExample"/> to remove
 punctuation from the beginning and end of a word. Use a loop that runs
 as long as the character at the beginning of a word is not a letter,
 replacing the word with a substring of itself that does not include the
@@ -13009,7 +13187,7 @@ a word. Be careful to stop if the length of the <literal>String</literal> become
 with text that is entirely composed of non-letters.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:binary_search"/> In Example <xref linkend="example:Word_search"/>, we
+<simpara><anchor xml:id="exercise6.9" xreflabel="[exercise6.9]"/> In <xref linkend="wordSearchExample"/>, we
 wrote a program that counts the occurrences of each word from a list
 within a text. If the list of words to search within is long, it can
 take quite some time to search through the entire list. If the list of
@@ -13024,9 +13202,8 @@ incorrect word, you can search much faster. This kind of searching is
 called <emphasis>binary search</emphasis> and uses around <inlineequation><alt><![CDATA[\log n]]></alt><mathphrase><![CDATA[\log n]]></mathphrase></inlineequation> comparisons
 to find an element in a list. In contrast, looking through the list one
 element at a time takes about <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> comparisons.</simpara>
-<simpara>Rewrite the code from Example <xref linkend="example:Word_search"/> to use binary
-search, after applying selection sort from Example <xref linkend="example:Selection
-sort"/>. Although selection sort will take some extra time, you should
+<simpara>Rewrite the code from <xref linkend="wordSearchExample"/> to use binary
+search, after applying selection sort from <xref linkend="selectionSortExample"/>. Although selection sort will take some extra time, you should
 more than make up the difference with such a fast search. To implement
 binary search, keep variables for the start, middle, and end of the
 list. Keep adjusting the three variables until the middle index has the
@@ -13034,11 +13211,11 @@ word you are looking for or start and end reach each other. Remember to
 use the <literal>compareTo()</literal> method from the <literal>String</literal> class to compare words.</simpara>
 </listitem>
 <listitem>
-<simpara>In Example <xref linkend="example:Statistics"/>, we gave a program that finds the
+<simpara><anchor xml:id="exercise6.10" xreflabel="[exercise6.10]"/> In <xref linkend="statisticsExample"/>, we gave a program that finds the
 maximum, minimum, mean, standard deviation, and median of a list of
 values. Another statistic that is sometimes important is the <emphasis>mode</emphasis>, or
 most commonly occurring element. For example, in the list
-<inlineequation><alt><![CDATA[\{ 1, 2, 3, 3, 3, 5, 6, 6, 10 \}]]></alt><mathphrase><![CDATA[\{ 1, 2, 3, 3, 3, 5, 6, 6, 10 \}]]></mathphrase></inlineequation>, the mode is 3. Write a
+{1, 2, 3, 3, 3, 5, 6, 6, 10}, the mode is 3. Write a
 program that can determine the mode of a given list of <literal>int</literal> values. A
 list can have multiple modes if more than one element occurs with
 maximum frequency. For our purposes, we will consider any list with
@@ -13046,11 +13223,11 @@ multiple modes to have no modes. You may wish to sort the list before
 starting the process of counting the frequency of each value.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:Connect_Four"/> We used the example of Tic Tac Toe in
-Example <xref linkend="example:Tic_Tac_Toe"/> because a more complex game would have
+<simpara><anchor xml:id="exercise6.11" xreflabel="[exercise6.11]"/> We used the example of Tic Tac Toe in
+<xref linkend="ticTacToeExample"/> because a more complex game would have
 taken too much space to solve. The game of Connect Four (or the
 Captain&#8217;s Mistress, as it was originally called) pits two players
-against each other on a 6 <inlineequation><alt><![CDATA[\times]]></alt><mathphrase><![CDATA[\times]]></mathphrase></inlineequation> 7 vertical board. One
+against each other on a 6 × 7 vertical board. One
 player uses red checkers while the other uses black. The two players
 take turns dropping their checkers into columns of the board in which
 the checkers will drop to the lowest empty row, due to gravity. The goal
@@ -13064,9 +13241,9 @@ four in a row is more difficult than the three in a row of Tic Tac Toe.
 You will need more loops to automate the process fully.</simpara>
 </listitem>
 <listitem>
-<simpara>Once you have mastered the material in
-Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/>, adapt the
-solution to Conway&#8217;s Game of Life from Section <xref linkend="_solution_game_of_life"/>
+<simpara><anchor xml:id="exercise6.12" xreflabel="[exercise6.12]"/> Once you have mastered the material in
+<xref linkend="_constructing_graphical_user_interfaces"/>, adapt the
+solution to Conway&#8217;s Game of Life from <xref linkend="_solution_game_of_life"/>
 to display on a graphical user interface. You can use a
 <literal>GridLayout</literal> to arrange a large number of <literal>JLabel</literal> objects in a grid and
 update their background colors to <literal>Color.BLACK</literal> and <literal>Color.WHITE</literal> as
@@ -13078,7 +13255,7 @@ representation.</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Creating arrays with longer and longer lengths requires more
+<simpara><anchor xml:id="exercise6.13" xreflabel="[exercise6.13]"/> Creating arrays with longer and longer lengths requires more
 processor time, since the all of those elements must be initialize to
 some default value. Using an OS <literal>time</literal> command, determine the amount of
 time it takes to create an <literal>int</literal> array of length 10, 10,000, and
@@ -13098,8 +13275,8 @@ memory size and the<?asciidoc-br?>
 memory being used.</simpara>
 </listitem>
 <listitem>
-<simpara>Run the implementation of the word search program using the binary
-search improvement from Exercise <xref linkend="exercise:binary_search"/>. Use the OS
+<simpara><anchor xml:id="exercise6.14" xreflabel="[exercise6.14]"/> Run the implementation of the word search program using the binary
+search improvement from <link linkend="exercise6.9">Exercise 6.9</link>. Use the OS
 <literal>time</literal> command to time the difference between the regular and binary
 search versions of the program with a long list of words. You may see
 very little difference on small input, but you can easily find a list of
@@ -13110,10 +13287,10 @@ should see a significant increase in speed for the binary search version
 relative to the regular version.</simpara>
 </listitem>
 <listitem>
-<simpara>Generate input files consisting of <inlineequation><alt><![CDATA[1,000]]></alt><mathphrase><![CDATA[1,000]]></mathphrase></inlineequation>,
-<inlineequation><alt><![CDATA[10,000]]></alt><mathphrase><![CDATA[10,000]]></mathphrase></inlineequation>, and <inlineequation><alt><![CDATA[100,000]]></alt><mathphrase><![CDATA[100,000]]></mathphrase></inlineequation> random <literal>int</literal> values.
+<simpara><anchor xml:id="exercise6.15" xreflabel="[exercise6.15]"/> Generate input files consisting of 1,000,
+10,000, and 100,000 random <literal>int</literal> values.
 Time our implementation of selection sort from
-Example <xref linkend="example:Selection_sort"/> running on each of these input files
+<xref linkend="selectionSortExample"/> running on each of these input files
 and redirecting output to output files. What is the behavior of the
 running time as the input length increases by a factor of 10? As a
 function of <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>, how many times does the body of the inner
@@ -13123,7 +13300,7 @@ parallel the increase in running time?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Simple_Graphical_User_Interfaces">
+<chapter xml:id="_simple_graphical_user_interfaces">
 <title>Simple Graphical User Interfaces</title>
 <blockquote>
 <attribution>
@@ -13134,7 +13311,7 @@ truth within the soul.</simpara>
 </blockquote>
 <section xml:id="_problem_codon_extractor">
 <title>Problem: Codon extractor</title>
-<simpara>Recall from Chapter <xref linkend="chapter:Repetition"/> that we can record DNA as a
+<simpara>Recall from <xref linkend="_repetition"/> that we can record DNA as a
 sequence of nucleotide bases A, C, G, and T. Using this idea, we can
 represent any sequence of DNA using a <literal>String</literal> made up of those four
 letters, such as <literal>"ATGGAAGTATTTAAATAG"</literal>.</simpara>
@@ -13155,7 +13332,7 @@ should be easy. However, we want to solve it with a <emphasis>graphical user
 interface</emphasis>, not with the command line interaction we have emphasized in
 previous chapters. That is, the input step should be done with a window
 that looks similar to the following.</simpara>
-<informalfigure role="text-center">
+<informalfigure xml:id="codoninput" role="text-center">
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/07-gui-basics/images/codoninput.png" width="50%"/>
@@ -13164,7 +13341,7 @@ that looks similar to the following.</simpara>
 </mediaobject>
 </informalfigure>
 <simpara>And the corresponding output should look very much like this.</simpara>
-<informalfigure role="text-center">
+<informalfigure xml:id="codonoutput" role="text-center">
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/07-gui-basics/images/codonoutput.png" width="50%"/>
@@ -13192,22 +13369,22 @@ using a combination of the keyboard and the mouse to respond to the
 program. While command line interfaces were dominant until the mid-70s,
 GUIs have become the prime mode of communication between a program and a
 human user. This chapter focuses on the design of simple GUIs using a
-few built-in Java classes. Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/> introduces more advanced tools for constructing complex
+few built-in Java classes. <xref linkend="_constructing_graphical_user_interfaces"/> introduces more advanced tools for constructing complex
 GUIs.</simpara>
 <example>
 <title>User interaction</title>
-<simpara>Figure <xref linkend="applicationInterfaceFigure"/>(a) shows a Java application
+<simpara><xref linkend="applicationInterfaceFigure"/>(a) shows a Java application
 interacting with a user through a command line interface. The
 application asks the user for a temperature value in degrees Fahrenheit,
 converts it to the equivalent Celsius, displays it, and prompts the user
-to enter another value. Figure <xref linkend="applicationInterfaceFigure"/>(b) shows a
+to enter another value. <xref linkend="applicationInterfaceFigure"/>(b) shows a
 similar application interacting with the user through a GUI. In this
 case, the application creates a window with five widgets (two text boxes
 and three buttons). The user enters a temperature value in the text box
 below either the Centigrade label or the Fahrenheit label and presses
 the appropriate Convert button. In turn the application displays the
 equivalent temperature in the other text box.</simpara>
-<figure role="text-center">
+<figure xml:id="applicationInterfaceFigure" role="text-center">
 <title>User interaction with a Java application (a) through a command line interface and (b) through a graphical user interface.</title>
 <mediaobject>
 <imageobject>
@@ -13223,11 +13400,11 @@ For example, these GUIs do not require the programmer to handle the
 details of events such as a user pressing an &#8220;OK&#8221; button or typing
 text into a text box and pressing the <literal>&lt;enter&gt;</literal> key. These events will
 be handled automatically by the tools we will introduce in this chapter.
-Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/> discusses the
+<xref linkend="_constructing_graphical_user_interfaces"/> discusses the
 creation of more complex GUIs that require the programmer to program
 event handling explicitly.</simpara>
 </section>
-<section xml:id="syntax:Dialogs_and_the_JOptionPane_class">
+<section xml:id="_syntax_dialogs_and_the_literal_joptionpane_literal_class">
 <title>Syntax: Dialogs and the <literal>JOptionPane</literal> class</title>
 <simpara><literal>JOptionPane</literal> is a utility class for creating GUIs consisting most often
 of a single dialog. It offers a variety of ways to create useful dialogs
@@ -13241,7 +13418,7 @@ you will learn how to construct the following four types of dialogs.</simpara>
 <listitem>
 <simpara>An information, or message, dialog displays a message to the user.
 Static method <literal>showMessageDialog()</literal> creates such a dialog. See
-Figure <xref linkend="simpleMessageFigure"/> for an example of a message dialog.</simpara>
+<xref linkend="simpleMessageFigure"/> for an example of a message dialog.</simpara>
 </listitem>
 </varlistentry>
 <varlistentry>
@@ -13250,7 +13427,7 @@ Figure <xref linkend="simpleMessageFigure"/> for an example of a message dialog
 <simpara>A confirm dialog asks a user to confirm a statement. Static method<?asciidoc-br?>
 <literal>showConfirmDialog()</literal> creates such a dialog. This dialog may return
 user input as <literal>YES_OPTION</literal>, <literal>NO_OPTION</literal>, <literal>OK_OPTION</literal>, or
-<literal>CANCEL_OPTION</literal>. See Figure <xref linkend="yes-noDialogFigure"/> for an example of
+<literal>CANCEL_OPTION</literal>. See <xref linkend="yes-noDialogFigure"/> for an example of
 a Yes-No dialog.</simpara>
 </listitem>
 </varlistentry>
@@ -13259,7 +13436,7 @@ a Yes-No dialog.</simpara>
 <listitem>
 <simpara>An option dialog asks the user to select one from an arbitrary set of
 options. Static method <literal>showOptionDialog()</literal> creates such a dialog. See
-Figure <xref linkend="CapitalDialogFigure"/> for an example.</simpara>
+<xref linkend="selectCapitalDialogFigure"/> for an example.</simpara>
 </listitem>
 </varlistentry>
 <varlistentry>
@@ -13268,7 +13445,7 @@ Figure <xref linkend="CapitalDialogFigure"/> for an example.</simpara>
 <simpara>An input dialog is useful for obtaining data provided by the user.
 Static method <literal>showInputDialog()</literal> creates such a dialog. The user can
 input a <literal>String</literal> that might represent a number, a name, or any
-arbitrary piece of text. See Figure <xref linkend="inputDialogFigure"/> for an
+arbitrary piece of text. See <xref linkend="inputDialogFigure"/> for an
 example.</simpara>
 </listitem>
 </varlistentry>
@@ -13279,6 +13456,9 @@ interact with the dialog before the program can continue. Thus, the
 dialog is dismissed and the program execution resumes only after the
 user has responded. Modal dialogs are useful in situations where user
 input is required for the program to proceed further.</simpara>
+<sidebar>
+<simpara><link linkend="exercise7.8">Exercise 7.8</link></simpara>
+</sidebar>
 <simpara>A non-modal dialog is one that is displayed on the screen and does not
 require the user to interact with it for the underlying program to
 proceed. It is easy to create a modal dialog using the static methods in
@@ -13286,6 +13466,9 @@ the <literal>JOptionPane</literal> class mentioned earlier. Creation of non-moda
 requires a bit more effort and is not covered in this chapter. In the
 remainder of this chapter we show how to use <literal>JOptionPane</literal> to create
 various types of modal dialogs.</simpara>
+<sidebar>
+<simpara><link linkend="exercise7.2">Exercise 7.2</link></simpara>
+</sidebar>
 <section xml:id="informationMessageDialog">
 <title>Generating an information dialog</title>
 <simpara>Often programs need to generate a message for the user and request a
@@ -13297,57 +13480,41 @@ purpose is to inform the user that a task has been completed. The next
 example shows how to generate such a dialog.</simpara>
 <example>
 <title>Simple dialog</title>
-<simpara>Program <xref linkend="program:SimpleDialog"/> creates a dialog to inform the user
+<simpara><xref linkend="SimpleDialogProgram"/> creates a dialog to inform the user
 that the task it was assigned to perform is now complete.
-Figure <xref linkend="simpleMessageFigure"/> shows the dialog generated by this
+<xref linkend="simpleMessageFigure"/> shows the dialog generated by this
 program.</simpara>
-<formalpara xml:id="program:SimpleDialog" xreflabel="SimpleDialog">
-<title>Program to generate a simple dialog.</title>
+<formalpara xml:id="SimpleDialogProgram">
+<title>Generates a simple dialog.</title>
 <para>
-<programlisting language="java" linenumbering="numbered">import javax.swing.*;/*@\label{importSwing}@*/
+<programlisting language="java" linenumbering="numbered">import javax.swing.*; <co xml:id="CO5-1"/>
 
 public class SimpleDialog {
     public static void main(String [] args) {
-        JOptionPane.showMessageDialog( null,/*@\label{showMessageDialogLine}@*/
+        JOptionPane.showMessageDialog( null, <co xml:id="CO5-2"/>
         	"Task completed. Click OK to exit",
             "Simple Dialog", JOptionPane.INFORMATION_MESSAGE);
-        System.out.println("Done."); /*@\label{displayMessageLine}@*/
+        System.out.println("Done."); <co xml:id="CO5-3"/>
     }
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Let&#8217;s dissect Program <xref linkend="program:SimpleDialog"/>. Line <xref linkend="importSwing"/> is
-needed to import classes used in this program. The <literal>swing</literal> package
+<calloutlist>
+<callout arearefs="CO5-1">
+<para>We import classes used in this program. The <literal>swing</literal> package
 contains a number of classes needed to create a GUI, and <literal>JOptionPane</literal>
 is one such class. If you try to compile the program without
-line <xref linkend="importSwing"/>, it will fail.</simpara>
-<figure role="text-center">
-<title>A simple dialog generated using <literal>JOptionPane</literal>.</title>
-<mediaobject>
-<imageobject>
-<imagedata fileref="chapters/07-gui-basics/images/simpleMessageFigure.svg" width="80%"/>
-</imageobject>
-<textobject><phrase>simpleMessageFigure</phrase></textobject>
-</mediaobject>
-</figure>
-<simpara>In Figure <xref linkend="simpleMessageFigure"/> the dialog titled &#8220;Simple Dialog&#8221;
-includes an icon, a message and a button labeled &#8220;OK.&#8221; This dialog is
-actually a <emphasis>frame</emphasis>, which is what windows are called in Java. We will
-discuss frames in greater detail in Section <xref linkend="syntax:GUIs_in_Java"/>.</simpara>
-<simpara>Note that the appearance of the dialog may be different on your
-computer. Even though Java is platform independent, GUIs are customized
-based on the OS you are running. Each OS has a default <emphasis>look and feel</emphasis>
-(L &amp; F) manager that specifies how widgets look and behave in your
-program. You can change the L&amp;F manager, but not all managers are
-available on all operating systems.</simpara>
-<simpara>Line <xref linkend="showMessageDialogLine"/> and the next two lines use a static
+this line, it will fail.</para>
+</callout>
+<callout arearefs="CO5-2">
+<para>This and the next two lines use a static
 method to create a modal dialog. <literal>JOptionPane</literal> is a utility class and
 <literal>showMessageDialog()</literal> is a static method in this class. This method,
 along with the other three <literal>JOptionPane</literal> methods we discuss in this
 chapter is a <emphasis>factory method</emphasis>, meaning that it creates a new object (in
 this case some kind of dialog object) on the fly with specific
 attributes. In this example, the program is informing the user that a
-task has been completed. The method has the following four parameters.</simpara>
+task has been completed. The method has the following four parameters.</para>
 <variablelist>
 <varlistentry>
 <term>Component</term>
@@ -13389,14 +13556,37 @@ the method that does not specify an icon.</simpara>
 </listitem>
 </varlistentry>
 </variablelist>
-<simpara>Line <xref linkend="displayMessageLine"/> displays a message on the console which is
+</callout>
+<callout arearefs="CO5-3">
+<para>We display a message on the console which is
 not needed in this program but illustrates an interesting point. When
 you run <literal>SimpleDialog</literal>, you will notice that the <literal>"Done."</literal> message
 displays on the console only after you have clicked the &#8220;OK&#8221; button in
 the dialog box. This is the modal behavior we mentioned earlier. The
-dialog blocks execution of the thread that generated it.</simpara>
+dialog blocks execution of the thread that generated it.</para>
+</callout>
+</calloutlist>
+<simpara>In <xref linkend="simpleMessageFigure"/> the dialog titled &#8220;Simple Dialog&#8221;
+includes an icon, a message and a button labeled &#8220;OK.&#8221; This dialog is
+actually a <emphasis>frame</emphasis>, which is what windows are called in Java. We will
+discuss frames in greater detail in <xref linkend="_syntax_guis_in_java"/>.</simpara>
+<figure xml:id="simpleMessageFigure" role="text-center">
+<title>A simple dialog generated using <literal>JOptionPane</literal>.</title>
+<mediaobject>
+<imageobject>
+<imagedata fileref="chapters/07-gui-basics/images/simpleMessageFigure.svg" width="80%"/>
+</imageobject>
+<textobject><phrase>simpleMessageFigure</phrase></textobject>
+</mediaobject>
+</figure>
+<simpara>Note that the appearance of the dialog may be different on your
+computer. Even though Java is platform independent, GUIs are customized
+based on the OS you are running. Each OS has a default <emphasis>look and feel</emphasis>
+(L &amp; F) manager that specifies how widgets look and behave in your
+program. You can change the L &amp; F manager, but not all managers are
+available on all operating systems.</simpara>
 </example>
-<simpara>In the above example, we have displayed a message of type
+<simpara>In the previous example, we have displayed a message of type
 <literal>INFORMATION_MESSAGE</literal>. These are additional message types that could be
 used.</simpara>
 <itemizedlist>
@@ -13415,17 +13605,17 @@ used.</simpara>
 </itemizedlist>
 <simpara>When used as parameters in <literal>showMessageDialog()</literal>, the constants above
 cause different default icons to be displayed in the dialog box.
-Figure <xref linkend="iconsInMessageDialogsFigure"/> shows dialogs generated by
+<xref linkend="iconsInMessageDialogsFigure"/> shows dialogs generated by
 <literal>showMessageDialog()</literal> when using <literal>JOptionPane.ERROR_MESSAGE</literal>, (left)
 and <literal>JOptionPane.WARNING_MESSAGE</literal> (right). Note the difference in the
 icons displayed towards the top left of the two dialogs.</simpara>
-<figure role="text-center">
+<figure xml:id="iconsInMessageDialogsFigure" role="text-center">
 <title>Two dialogs generated using the <literal>showMessageDialog()</literal> method. The left dialog uses <literal>JOptionPane.ERROR_MESSAGE</literal>, and the right uses <literal>JOptionPane.WARNING_MESSAGE</literal>. The only difference is the icon displayed.</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="chapters/07-gui-basics/images/iconsinMessageDialogsFigure.png" width="100%"/>
+<imagedata fileref="chapters/07-gui-basics/images/iconsInMessageDialogsFigure.png" width="100%"/>
 </imageobject>
-<textobject><phrase>iconsinMessageDialogsFigure</phrase></textobject>
+<textobject><phrase>iconsInMessageDialogsFigure</phrase></textobject>
 </mediaobject>
 </figure>
 </section>
@@ -13434,55 +13624,60 @@ icons displayed towards the top left of the two dialogs.</simpara>
 <simpara>There are situations when a program needs to obtain a binary answer from
 the user, a &#8220;yes&#8221; or a &#8220;no.&#8221; The next example shows how to generate
 such a dialog and how to get the user&#8217;s response.</simpara>
-<example>
+<example xml:id="yes-NoDialogExample">
 <title>Yes-No dialog</title>
 <simpara>Consider a program that checks whether a student understands the
 difference between odd and even integers. The program generates a random
 integer <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation>, presents it to the user, and asks the question,
 &#8220;Is <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation> an odd integer?&#8221; The answer given by the user is
 checked for correctness, and the user is informed accordingly.
-Program <xref linkend="program:OddEvenTest"/> shows how to use the <literal>JOptionPane</literal> class
+<xref linkend="OddEvenTestProgram"/> shows how to use the <literal>JOptionPane</literal> class
 to generate a dialog for such an interaction.</simpara>
-<formalpara xml:id="program:OddEvenTest" xreflabel="OddEvenTest">
-<title>Program that tests knowledge of odd and even integers with a Yes-No dialog.</title>
+<formalpara xml:id="OddEvenTestProgram">
+<title>Tests knowledge of odd and even integers with a Yes-No dialog.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.util.*;
 
 public class OddEvenTest {
     public static void main(String [] args) {
-        Random random = new Random();
-		String title = "Odd Even Test";
-        int x = random.nextInt(10); //Random int from 0 to 9
+        String title = "Odd Even Test";
+		Random random = new Random(); <co xml:id="CO6-1"/>
+        int x = random.nextInt(10);
         String question = "Is " + x + " an odd integer?";
-        int response = JOptionPane.showConfirmDialog(null,/*@\label{yes-noDialogLine}@*/
-        		question, title, JOptionPane.YES_NO_OPTION);
+        int response = JOptionPane.showConfirmDialog(null, <co xml:id="CO6-2"/>
+        	question, title, JOptionPane.YES_NO_OPTION);
 		String message;
         // Response is YES_OPTION for Yes, NO_OPTION for No.
-        if((response==JOptionPane.YES_OPTION &amp;&amp; x%2 != 0) ||
-        	(response==JOptionPane.NO_OPTION &amp;&amp; x%2 == 0))
-			message = "You're right!"; /*@\label{correctAnswerLine}@*/
+        if((response == JOptionPane.YES_OPTION &amp;&amp; x%2 != 0) ||
+        	(response == JOptionPane.NO_OPTION &amp;&amp; x%2 == 0))
+			message = "You're right!";
         else
-			message = "Sorry, that's incorrect."; /*@\label{incorrectAnswerLine}@*/
-        JOptionPane.showMessageDialog(null, message, title,
+			message = "Sorry, that's incorrect.";
+        JOptionPane.showMessageDialog(null, message, title, <co xml:id="CO6-3"/>
         	JOptionPane.INFORMATION_MESSAGE);
     }
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Program <xref linkend="program:OddEvenTest"/> begins by declaring a random number
-generator named <literal>random</literal>. It then generates a random number and presents
-it to the user in a dialog created at line <xref linkend="yes-noDialogLine"/>. Note
+<calloutlist>
+<callout arearefs="CO6-1">
+<para>We declare a random number generator named <literal>random</literal> and then use it to generate a random number from 0 to 9.</para>
+</callout>
+<callout arearefs="CO6-2">
+<para>We present the number to the user. Note
 the use of <literal>JOptionPane.YES_NO_OPTION</literal> as the last parameter in the
-<literal>showConfirmDialog()</literal> method at line <xref linkend="yes-noDialogLine"/>. The generated
-dialog is shown in Figure <xref linkend="yes-noDialogFigure"/>(a). A second dialog is
-shown with a message dependent on whether the user gives the correct
-answer. The two different versions of this dialog are shown in
-Figure <xref linkend="yes-noDialogFigure"/>(b) and (c). Note that a call to
-<literal>showConfirmDialog()</literal> at line <xref linkend="yes-noDialogLine"/> returns the
+<literal>showConfirmDialog()</literal>. The generated
+dialog is shown in <xref linkend="yes-noDialogFigure"/>(a). The call to
+<literal>showConfirmDialog()</literal> returns the
 <literal>JOptionPane.YES_OPTION</literal> or the <literal>JOptionPane.NO_OPTION</literal> value
-depending on whether the user clicked the &#8220;Yes&#8221; or &#8220;No&#8221; button.</simpara>
-<figure role="text-center">
+depending on whether the user clicked the &#8220;Yes&#8221; or &#8220;No&#8221; button.</para>
+</callout>
+<callout arearefs="CO6-3">
+<para>A second dialog is shown with a message dependent on whether the user gives the correct answer. The two different versions of this dialog are shown in <xref linkend="yes-noDialogFigure"/>(b) and (c).</para>
+</callout>
+</calloutlist>
+<figure xml:id="yes-noDialogFigure" role="text-center">
 <title>(a) A Yes-No dialog generated using <literal>JOptionPane</literal>. (b) Dialog in response to correct answer. (c) Dialog in response to incorrect answer.</title>
 <mediaobject>
 <imageobject>
@@ -13493,11 +13688,14 @@ depending on whether the user clicked the &#8220;Yes&#8221; or &#8220;No&#8221; 
 </figure>
 </example>
 <simpara>Because we used <literal>YES_NO_OPTION</literal>, the dialog in
-Example <xref linkend="example:Yes-No_dialog"/> automatically generates two buttons
+<xref linkend="yes-NoDialogExample"/> automatically generates two buttons
 labeled &#8220;Yes&#8221; and &#8220;No.&#8221; Dialogs can also use the
 <literal>YES_NO_CANCEL_OPTION</literal> to generate a dialog with &#8220;Yes,&#8221; &#8220;No,&#8221; and
 &#8220;Cancel&#8221; options. The return value from <literal>showConfirmDialog()</literal> is
-<literal>CANCEL_OPTION</literal> if the user presses the &#8220;Cancel&#8221; button. .</simpara>
+<literal>CANCEL_OPTION</literal> if the user presses the &#8220;Cancel&#8221; button.</simpara>
+<sidebar>
+<simpara><link linkend="exercise7.7">Exercise 7.7</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_generating_a_dialog_with_a_list_of_options">
 <title>Generating a dialog with a list of options</title>
@@ -13508,14 +13706,9 @@ options as shown in the next example.</simpara>
 <simpara>Consider a program that asks the user to select the correct capital of a
 country from a given list of capitals. It shows three options and asks
 the user to select one from among the three. It then checks the user
-response for correctness and displays a suitable message.
-Program <xref linkend="program:CapitalQuiz"/> performs these tasks. In this program,
-we call the <literal>showOptionDialog()</literal> method at line <xref linkend="multipleOptionsLine"/>
-to create a dialog with multiple options. In our case, the options are
-three names of capitals, and only one of them is correct.
-Figure <xref linkend="CapitalDialogFigure"/> shows the dialog created.</simpara>
-<formalpara xml:id="program:CapitalQuiz" xreflabel="CapitalQuiz">
-<title>Program to generate a dialog with programmer-defined options.</title>
+response for correctness and displays a suitable message.</simpara>
+<formalpara xml:id="CapitalQuizProgram">
+<title>Generates a dialog with programmer-defined options.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 
@@ -13526,7 +13719,7 @@ public class CapitalQuiz {
         String[] capitals = {"Bujumbura","Baku", "Moroni"};
 		int correct = 1; //Baku is the correct answer
         String question = "Select the capital of " + country;
-        int response = JOptionPane.showOptionDialog(null, /*@\label{multipleOptionsLine}@*/
+        int response = JOptionPane.showOptionDialog(null, <co xml:id="CO7-1"/>
         	question, title, JOptionPane.PLAIN_MESSAGE,
         	JOptionPane.QUESTION_MESSAGE, null, capitals, null);
         // Response is 0, 1, or 2 for the three options
@@ -13536,14 +13729,24 @@ public class CapitalQuiz {
 		else
 			message = "Sorry, the capital of " + country +
 			" is " + capitals[correct];
-        JOptionPane.showMessageDialog(null, message, title,
+        JOptionPane.showMessageDialog(null, message, title, <co xml:id="CO7-2"/>
         	JOptionPane.INFORMATION_MESSAGE);
     }
 }</programlisting>
 </para>
 </formalpara>
-<figure role="text-center">
-<title>A dialog with programmer-defined options generated by Program <xref linkend="program:CapitalQuiz"/>.</title>
+<calloutlist>
+<callout arearefs="CO7-1">
+<para>We call the <literal>showOptionDialog()</literal> method to create a dialog with multiple options. In our case, the options are three names of capitals, and only one of them is correct. <xref linkend="selectCapitalDialogFigure"/> shows the dialog created.<?asciidoc-br?>
+The <literal>showOptionDialog()</literal> method creates an options dialog, which is the most complicated (but also the most flexible) of all the dialogs. The array of <literal>String</literal> values provided as the second to last parameter to <literal>showOptionDialog()</literal> gives the labels for the buttons.<?asciidoc-br?>
+There are three <literal>null</literal> values passed into this method. The first one functions like the <literal>null</literal> used in <xref linkend="OddEvenTestProgram"/>, specifying that the default frame should be used. The second specifies that the default icon should be used. In the next section, we will show how to specify a custom icon. The last parameter indicates the default button, which will have focus when the dialog is created. If the user hits <literal>&lt;enter&gt;</literal> instead of clicking, the button with focus is the button that will be pressed.</para>
+</callout>
+<callout arearefs="CO7-2">
+<para>As in <xref linkend="OddEvenTestProgram"/>, a second dialog is shown with a message dependent on whether the user gives the correct answer.</para>
+</callout>
+</calloutlist>
+<figure xml:id="selectCapitalDialogFigure" role="text-center">
+<title>A dialog with programmer-defined options generated by <xref linkend="CapitalQuizProgram"/>.</title>
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/07-gui-basics/images/selectCapitalDialogFigure.png" width="50%"/>
@@ -13551,20 +13754,13 @@ public class CapitalQuiz {
 <textobject><phrase>selectCapitalDialogFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>The <literal>showOptionDialog()</literal> method creates an options dialog, which is the
-most complicated (but also the most flexible) of all the dialogs. The
-array of <literal>String</literal> values provided as the second to last parameter to
-<literal>showOptionDialog()</literal> gives the labels for the buttons.</simpara>
-<simpara>There are three <literal>null</literal> values passed into the method on
-line <xref linkend="multipleOptionsLine"/> in Program <xref linkend="program:CapitalQuiz"/>. The
-first one functions like the <literal>null</literal> used in
-Program <xref linkend="program:OddEvenTest"/>, specifying that the default frame
-should be used. The second specifies that the default icon should be
-used. In the next section, we will show how to specify a custom icon.
-The last parameter indicates the default button, which will have focus
-when the dialog is created. If the user hits <literal>&lt;enter&gt;</literal> instead of
-clicking, the button with focus is the button that will be pressed.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise7.3">Exercise 7.3</link><?asciidoc-br?>
+<link linkend="exercise7.4">Exercise 7.4</link><?asciidoc-br?>
+<link linkend="exercise7.9">Exercise 7.9</link><?asciidoc-br?>
+<link linkend="exercise7.10">Exercise 7.10</link></simpara>
+</sidebar>
 </section>
 <section xml:id="customIconDialog">
 <title>Generating a dialog with a custom icon</title>
@@ -13573,24 +13769,10 @@ clicking, the button with focus is the button that will be pressed.</simpara>
 next example illustrates how to do so.</simpara>
 <example>
 <title>Custom icon</title>
-<simpara>Program <xref linkend="program:CustomIconDialog"/> shows how to use
-<literal>showMessageDialog()</literal> to generate a message dialog with a custom icon.
-Note the last parameter at line <xref linkend="customIconLine"/>. This parameter
-creates a new <literal>ImageIcon</literal> object from the <literal>file</literal> <literal>String</literal> (<literal>"bat.png"</literal>
-in this case). The resulting dialog appears in
-Figure <xref linkend="customIconDialogFigure"/>. Dialogs illustrated in earlier
-examples can also use an icon parameter to include a custom icon.</simpara>
-<figure role="text-center">
-<title>A dialog with a custom icon generated by Program <xref linkend="program:CustomIconDialog"/>.</title>
-<mediaobject>
-<imageobject>
-<imagedata fileref="chapters/07-gui-basics/images/customIconDialogFigure.png" width="50%"/>
-</imageobject>
-<textobject><phrase>customIconDialogFigure</phrase></textobject>
-</mediaobject>
-</figure>
-<formalpara xml:id="program:CustomIconDialog" xreflabel="CustomIconDialog">
-<title>Program to generate a dialog with a custom icon.</title>
+<simpara><xref linkend="CustomIconDialogProgram"/> shows how to use
+<literal>showMessageDialog()</literal> to generate a message dialog with a custom icon.</simpara>
+<formalpara xml:id="CustomIconDialogProgram">
+<title>Generates a dialog with a custom icon.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 
@@ -13600,47 +13782,46 @@ public class CustomIconDialog{
 		String title = "Custom Icon";
 		String message = "Some bats eat 3,000 mosquitoes a night.";
 		JOptionPane.showMessageDialog(null, message, title,
-			JOptionPane.INFORMATION_MESSAGE, new ImageIcon(file));/*@\label{customIconLine}@*/
+			JOptionPane.INFORMATION_MESSAGE, new ImageIcon(file)); <co xml:id="CO8-1"/>
     }
 }</programlisting>
 </para>
 </formalpara>
+<calloutlist>
+<callout arearefs="CO8-1">
+<para>The last parameter creates a new <literal>ImageIcon</literal> object from the <literal>file</literal> <literal>String</literal> (<literal>"bat.png"</literal> in this case). The resulting dialog appears in <xref linkend="customIconDialogFigure"/>.</para>
+</callout>
+</calloutlist>
+<simpara>Dialogs illustrated in earlier examples can also use an icon parameter to include a custom icon.</simpara>
+<figure xml:id="customIconDialogFigure" role="text-center">
+<title>Dialog with a custom icon generated by <xref linkend="CustomIconDialogProgram"/>.</title>
+<mediaobject>
+<imageobject>
+<imagedata fileref="chapters/07-gui-basics/images/customIconDialogFigure.png" width="50%"/>
+</imageobject>
+<textobject><phrase>customIconDialogFigure</phrase></textobject>
+</mediaobject>
+</figure>
 <simpara>Note that the icon shown above will not appear when you run this code
 unless you have a copy of <literal>bat.png</literal> in the same directory.</simpara>
 </example>
 </section>
-<section xml:id="inputDialog">
+<section xml:id="_generating_an_input_dialog">
 <title>Generating an input dialog</title>
 <simpara>An input dialog can read text data from the user. The
 <literal>showInputDialog()</literal> method in the <literal>JOptionPane</literal> class allows us to
 create such a dialog. We introduced the <literal>showInputDialog()</literal> method in
-Section <xref linkend="syntax:Java_basics"/>, but we give two more examples here to
+<xref linkend="_syntax_java_basics"/>, but we give two more examples here to
 emphasize its similarity to the other <literal>JOptionPane</literal> factory methods and
 to show off some of its additional features.</simpara>
-<example>
+<example xml:id="inputDialogExample">
 <title>Input dialog</title>
 <simpara>We want to write a program that asks a question about basic chemistry.
-Program <xref linkend="program:ChemistryQuizOne"/> shows how to display a question,
+<xref linkend="ChemistryQuizOneProgram"/> shows how to display a question,
 obtain an answer from the user, check for the correctness of the answer,
-and report back to the user. At line <xref linkend="chemistryInputDialogLineOne"/>,
-the <literal>showInputDialog()</literal> method is used to generate the dialog shown in
-Figure <xref linkend="chemistryQuizFigure"/>(a). This method returns a <literal>String</literal> named
-<literal>response</literal> containing the text entered by the user in the dialog box. At
-line <xref linkend="chemistryConvertToIntegerLineOne"/>, this <literal>String</literal> is converted to
-an <literal>int</literal> and saved into variable <literal>answer</literal>. This value is checked against
-the correct answer, and the <literal>showMessageDialog()</literal> method informs the
-user whether or not the answer is correct.</simpara>
-<simpara>It is important to note that the user could type any sequence of
-characters in the dialog box. Try running
-Program <xref linkend="program:ChemistryQuizOne"/> and see what happens when you type
-&#8220;two,&#8221; instead of the number &#8220;2,&#8221; into the dialog box and press the
-&#8220;OK&#8221; button. The program will generate an exception indicating that
-the input <literal>String</literal> cannot be converted to an integer.
-Exercise <xref linkend="exercise:inputDialogExceptionExercise"/> asks you to modify
-Program <xref linkend="program:ChemistryQuizOne"/> so it gracefully handles such
-exceptions.</simpara>
-<formalpara xml:id="program:ChemistryQuizOne" xreflabel="ChemistryQuizOne">
-<title>Program to generate a dialog to input data as text.</title>
+and report back to the user.</simpara>
+<formalpara xml:id="ChemistryQuizOneProgram">
+<title>Generates a dialog to input data as text.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 
@@ -13648,22 +13829,46 @@ public class ChemistryQuizOne {
     public static void main(String [] args) {
         String title = "Atoms in Water";
         String query = "How many atoms are in a molecule of water?";
-        String response = JOptionPane.showInputDialog(null,/*@\label{chemistryInputDialogLineOne}@*/
+        String response = JOptionPane.showInputDialog(null, <co xml:id="CO9-1"/>
         	query, title, JOptionPane.QUESTION_MESSAGE);
-        int answer = Integer.parseInt(response);/*@\label{chemistryConvertToIntegerLineOne}@*/
+        int answer = Integer.parseInt(response); <co xml:id="CO9-2"/>
 		String message;
-        if(answer == 3)
+        if(answer == 3) <co xml:id="CO9-3"/>
 			message = "Good! That's correct!";
 		else
 			message = "Sorry, that's incorrect.";
-        JOptionPane.showMessageDialog(null, message, title,
+        JOptionPane.showMessageDialog(null, message, title, <co xml:id="CO9-4"/>
         	JOptionPane.INFORMATION_MESSAGE);
     }
 }</programlisting>
 </para>
 </formalpara>
-<figure role="text-center">
-<title>(a) A dialog requesting input as text. (b) A dialog requesting a selection from a list of choices. These dialogs are generated by Programs <xref linkend="program:ChemistryQuizOne"/> and <xref linkend="program:ChemistryQuizTwo"/>, respectively.</title>
+<calloutlist>
+<callout arearefs="CO9-1">
+<para>We use the <literal>showInputDialog()</literal> method to generate the dialog shown in <xref linkend="inputDialogFigure"/>(a). This method returns a <literal>String</literal> named <literal>response</literal> containing the text entered by the user in the dialog box.</para>
+</callout>
+<callout arearefs="CO9-2">
+<para>We convert this <literal>String</literal> to an <literal>int</literal> and saved into variable <literal>answer</literal>.</para>
+</callout>
+<callout arearefs="CO9-3">
+<para>We check this value against the correct answer.</para>
+</callout>
+<callout arearefs="CO9-4">
+<para>The <literal>showMessageDialog()</literal> method informs the user whether or not the answer is correct.</para>
+</callout>
+</calloutlist>
+<simpara>It&#8217;s important to note that the user could type any sequence of
+characters in the dialog box. Try running
+<xref linkend="ChemistryQuizOneProgram"/> and see what happens when you type
+&#8220;two,&#8221; instead of the number &#8220;2,&#8221; into the dialog box and press the
+&#8220;OK&#8221; button. The program will generate an exception indicating that
+the input <literal>String</literal> cannot be converted to an integer.
+<link linkend="exercise7.15">Exercise 7.15</link> asks you to modify
+<xref linkend="ChemistryQuizOneProgram"/> so it gracefully handles such
+exceptions.  <xref linkend="inputDialogFigure"/>(a) shows the dialog generated by <xref linkend="ChemistryQuizOneProgram"/>.</simpara>
+</example>
+<figure xml:id="inputDialogFigure" role="text-center">
+<title>(a) A dialog requesting input as text. (b) A dialog requesting a selection from a list of choices.</title>
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/07-gui-basics/images/inputDialogFigure.svg" width="50%"/>
@@ -13671,25 +13876,16 @@ public class ChemistryQuizOne {
 <textobject><phrase>inputDialogFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><anchor xml:id="inputDialogFigure" xreflabel="[inputDialogFigure]"/>[inputDialogFigure]</simpara>
-</example>
-<example>
+<example xml:id="inputDialogWithAListExample">
 <title>Input dialog with a list</title>
-<simpara>In Example <xref linkend="example:Input_dialog"/> the user is required to enter a
+<simpara>In <xref linkend="inputDialogExample"/> the user is required to enter a
 single value. To reduce input errors, we can restrict the user to
 picking from a predefined list. We can create this list by generating an
 array and supplying it as a parameter to the <literal>showInputDialog()</literal> method.</simpara>
-<simpara>Program <xref linkend="program:ChemistryQuizTwo"/> displays a list of chemical
-elements and asks the user to select the heaviest.
-Line <xref linkend="chemistryInputDialogListLineTwo"/> passes an array of four
-<literal>String</literal> values to the <literal>showInputDialog()</literal> method. Note that the last
-parameter to this method is <literal>null</literal> indicating that no specific item on
-the list should be selected by default. (In this case, the first item in
-the list is initially selected.) The generated dialog is shown in
-Figure <xref linkend="chemistryQuizFigure"/>(b). The four elements are contained in a
-drop down list.</simpara>
-<formalpara xml:id="program:ChemistryQuizTwo" xreflabel="ChemistryQuizTwo">
-<title>Program to generate a dialog to input a choice from a list.</title>
+<simpara><xref linkend="ChemistryQuizTwoProgram"/> displays a list of chemical
+elements and asks the user to select the heaviest.</simpara>
+<formalpara xml:id="ChemistryQuizTwoProgram">
+<title>Generates a dialog to input a choice from a list.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 
@@ -13699,34 +13895,37 @@ public class ChemistryQuizTwo {
         String query = "Which is the heaviest element?";
 		String[] elements = {"Iron", "Uranium",	"Copernicium",
 			"Nitrogen"};
-        String response = (String)JOptionPane.showInputDialog(null, /*@\label{chemistryInputDialogListLineTwo}@*/
+        String response = (String)JOptionPane.showInputDialog(null, <co xml:id="CO10-1"/>
         	query, title, JOptionPane.QUESTION_MESSAGE, null,
         	elements, null);
 		String message;
-        if(response.equals("Copernicium"))
+        if(response.equals("Copernicium")) <co xml:id="CO10-2"/>
 			message = "You're right!";
         else
 			message = "Sorry, correct answer: Copernicium.";
-		JOptionPane.showMessageDialog(null, message, title,
+		JOptionPane.showMessageDialog(null, message, title, <co xml:id="CO10-3"/>
 			JOptionPane.INFORMATION_MESSAGE);
     }
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Unlike Example <xref linkend="example:Input_dialog"/>, the return value from
-<literal>showInputDialog()</literal> is now of type <literal>Object</literal>, not of type <literal>String</literal>. The
-type of the list required by the method is <literal>Object</literal> array. (You can pass
-a <literal>String</literal> array to a method that wants an <literal>Object</literal> array due to
-inheritance, which is further discussed in
-Chapters <xref linkend="chapter:Inheritance"/> and <xref linkend="chapter:Polymorphism"/>.) The
-return value is the specific object from the array that was passed in.
-In our case, it <emphasis role="strong">has</emphasis> to be a <literal>String</literal>, but Java is not smart enough to
-figure that out. For this reason, we cast the object to a <literal>String</literal>
-before using the <literal>equals()</literal> method.</simpara>
+<calloutlist>
+<callout arearefs="CO10-1">
+<para>We pass an array of four <literal>String</literal> values to the <literal>showInputDialog()</literal> method. Note that the last parameter to this method is <literal>null</literal> indicating that no specific item on the list should be selected by default. (In this case, the first item in the list is initially selected.) The generated dialog is shown in <xref linkend="inputDialogFigure"/>(b). The four elements are contained in a drop down list.<?asciidoc-br?>
+Unlike <xref linkend="inputDialogExample"/>, the return value from <literal>showInputDialog()</literal> is now of type <literal>Object</literal>, not of type <literal>String</literal>. The type of the list required by the method is <literal>Object</literal> array. (You can pass a <literal>String</literal> array to a method that wants an <literal>Object</literal> array due to inheritance, which is further discussed in
+<xref linkend="_inheritance"/> and <xref linkend="_polymorphism"/>.) The return value is the specific object from the array that was passed in. In our case, it <emphasis role="strong">has</emphasis> to be a <literal>String</literal>, but Java is not smart enough to figure that out. For this reason, we cast the object to a <literal>String</literal> before using the <literal>equals()</literal> method.</para>
+</callout>
+<callout arearefs="CO10-2">
+<para>We check this <literal>String</literal> for correctness.</para>
+</callout>
+<callout arearefs="CO10-3">
+<para>As before, the <literal>showMessageDialog()</literal> method informs the user whether or not the answer is correct.</para>
+</callout>
+</calloutlist>
 </example>
 <example>
 <title>Input dialog with a long list</title>
-<figure role="text-center">
+<figure xml:id="inputDialogListManyItemsFigure" role="text-center">
 <title>A dialog requesting user to select one item from a list of 20 data items. Note the use of a scroll down list to display the items.</title>
 <mediaobject>
 <imageobject>
@@ -13738,9 +13937,9 @@ before using the <literal>equals()</literal> method.</simpara>
 <simpara>When the number of elements in the list supplied to the
 <literal>showInputDialog()</literal> is 20 or more, a <literal>JList</literal> object is automatically
 used to display the items as shown in
-Figure <xref linkend="inputDialogListManyItemsFigure"/>.</simpara>
+<xref linkend="inputDialogListManyItemsFigure"/>.</simpara>
 <simpara>Other than a longer list, the code in this example is virtually
-identical to the code for Example <xref linkend="example:Input_dialog_with_a_list"/>.</simpara>
+identical to the code for <xref linkend="inputDialogWithAListExample"/>.</simpara>
 </example>
 </section>
 </section>
@@ -13754,39 +13953,52 @@ readability, the solution to this problem is divided into methods that
 each do a specific task. We hope that the way a method works is
 intuitively clear to you. If not, the next chapter explains them in
 detail.</simpara>
-<programlisting language="java" linenumbering="numbered">import javax.swing.*;
+<programlisting language="java" linenumbering="unnumbered">import javax.swing.*;
 
 public class CodonExtractor {
 	public static void main(String [] args) {
 		int continueProgram;
-        do {
+        do { <co xml:id="CO11-1"/>
         	// Read DNA sequence
             String input = JOptionPane.showInputDialog(
-            		"Enter a DNA sequence");/*@\label{DNAInputLine}@*/
-            input = input.toUpperCase(); // Make upper case
+            		"Enter a DNA sequence"); <co xml:id="CO11-2"/>
+            input = input.toUpperCase(); <co xml:id="CO11-3"/>
 			String message = "Do you want to continue?";
-            if( isValid(input) ) // Check for validity
-                displayCodons(input); // Find codons
+            if( isValid(input) ) <co xml:id="CO11-4"/>
+                displayCodons(input); <co xml:id="CO11-5"/>
             else
 				message = "Invalid DNA Sequence.\n" + message;
-			continueProgram = JOptionPane.showConfirmDialog(
+			continueProgram = JOptionPane.showConfirmDialog( <co xml:id="CO11-6"/>
 				null, message, "Alert", JOptionPane.YES_NO_OPTION);
         } while(continueProgram == JOptionPane.YES_OPTION);
         JOptionPane.showMessageDialog(null,
         	"Thanks for using the Codon Extractor!");
     }</programlisting>
-<simpara>The <literal>main()</literal> method contains a <literal>do-while</literal> loop that allows the user to
-enter sequences repeatedly. The <literal>showInputDialog()</literal> method makes an
-input dialog and returns the <literal>String</literal> the user enters. The
-<literal>toUpperCase()</literal> method converts the <literal>String</literal> to upper case, allowing us
-to read input in either case.</simpara>
-<simpara>We then call the <literal>isValid()</literal> method to make sure that the user entered a
-valid DNA sequence. If it is valid, we use <literal>displayCodons()</literal> to display
-the codons in the sequence. Either way, we use a <literal>showConfirmDialog()</literal>
-method to creating a confirm dialog, asking the user if he or she wants
-to continue entering sequences. The loop will continue as long as the
-return value is <literal>JOptionPane.YES_OPTION</literal>.</simpara>
-<programlisting language="java" linenumbering="numbered">    public static boolean isValid( String DNA ) {
+<calloutlist>
+<callout arearefs="CO11-1">
+<para>The <literal>main()</literal> method contains a <literal>do-while</literal> loop that allows the user to
+enter sequences repeatedly.</para>
+</callout>
+<callout arearefs="CO11-2">
+<para>The <literal>showInputDialog()</literal> method makes an
+input dialog and returns the <literal>String</literal> the user enters.</para>
+</callout>
+<callout arearefs="CO11-3">
+<para>The <literal>toUpperCase()</literal> method converts the <literal>String</literal> to upper case, allowing us to read input in either case.</para>
+</callout>
+<callout arearefs="CO11-4">
+<para>We then call the <literal>isValid()</literal> method to make sure that the user entered a
+valid DNA sequence.</para>
+</callout>
+<callout arearefs="CO11-5">
+<para>If it is valid, we use <literal>displayCodons()</literal> to display
+the codons in the sequence.</para>
+</callout>
+<callout arearefs="CO11-6">
+<para>Either way, we use a <literal>showConfirmDialog()</literal> method to creating a confirm dialog, asking the user if he or she wants to continue entering sequences. The loop will continue as long as the return value is <literal>JOptionPane.YES_OPTION</literal>.</para>
+</callout>
+</calloutlist>
+<programlisting language="java" linenumbering="unnumbered">    public static boolean isValid( String DNA ) {
         String validBases = "ACGT";
         for( int i = 0; i &lt; DNA.length(); i++) {
 			char base = DNA.charAt(i);
@@ -13800,10 +14012,12 @@ letters representing the four bases. To do this, we use the Java
 <literal>String</literal> library cleverly: We loop through the characters in our input,
 checking to see where they can be found in <literal>"ACGT"</literal>. If the index
 returned is -1, the character was not found, and the DNA is invalid.</simpara>
-<programlisting language="java" linenumbering="numbered">    public static void displayCodons(String DNA) {
+<simpara>In the <literal>displayCodons()</literal> method, we display the individual codons to the
+user.</simpara>
+<programlisting language="java" linenumbering="unnumbered">    public static void displayCodons(String DNA) {
         String message = "";
 		// Get as many complete codons as possible
-        for (int i = 0; i &lt; DNA.length() - 2; i += 3)
+        for (int i = 0; i &lt; DNA.length() - 2; i += 3) <co xml:id="CO12-1"/>
             message += "\n" + DNA.substring(i, i + 3);
 		// 1-2 bases might be left over
         int remaining = DNA.length() % 3;
@@ -13815,16 +14029,18 @@ returned is -1, the character was not found, and the DNA is invalid.</simpara>
             	DNA.length()) + "*";
         message = "DNA length: " + DNA.length() +
         	"\n\nCodons: " + message;
-        JOptionPane.showMessageDialog(null, message,
-        	"Codons in DNA", JOptionPane.INFORMATION_MESSAGE);/*@\label{codonDisplayLine2}@*/
+        JOptionPane.showMessageDialog(null, message, <co xml:id="CO12-2"/>
+        	"Codons in DNA", JOptionPane.INFORMATION_MESSAGE);
     }
 }</programlisting>
-<simpara>In the <literal>displayCodons()</literal> method, we display the individual codons to the
-user. We build a large <literal>String</literal> with newlines separating each codon. To
-do so, we loop through the input, jumping ahead three characters each
-time. If the input length is not a multiple of three, we pad with
-asterisks. Finally, we use the <literal>showMessageDialog()</literal> method to display
-an information dialog with the list of codons.</simpara>
+<calloutlist>
+<callout arearefs="CO12-1">
+<para>We build a large <literal>String</literal> with newlines separating each codon. To do so, we loop through the input, jumping ahead three characters each time. If the input length is not a multiple of three, we pad with asterisks.</para>
+</callout>
+<callout arearefs="CO12-2">
+<para>We use the <literal>showMessageDialog()</literal> method to display an information dialog with the list of codons.</para>
+</callout>
+</calloutlist>
 </section>
 <section xml:id="_concurrency_simple_guis">
 <title>Concurrency: Simple GUIs</title>
@@ -13844,8 +14060,8 @@ clicking on a button) are running at the same time as the thread that
 created the dialog. Since many threads are running, it is possible for
 them to write to the same data at the same time. Doing so can lead to
 inconsistencies such as the ones we will describe in
-Chapter <xref linkend="chapter:Synchronization"/>.</simpara>
-<simpara>The GUIs we will create in Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/>, however, will be more than dialogs. They will be fully
+<xref linkend="_synchronization"/>.</simpara>
+<simpara>The GUIs we will create in <xref linkend="_constructing_graphical_user_interfaces"/>, however, will be more than dialogs. They will be fully
 functional windows, known as frames in Java. Like a non-modal dialog,
 the creation of a frame does not block the thread that created it.</simpara>
 <simpara>Many applications launch a frame and then end their main thread. If no
@@ -13858,7 +14074,7 @@ experienced. The fact that this problem happens so frequently even in
 the latest operating systems should hint at the difficulty of managing
 GUI threads.</simpara>
 <simpara>When we describe how to create fully featured GUIs in
-Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/>, we will also
+<xref linkend="_constructing_graphical_user_interfaces"/>, we will also
 give some techniques to help with avoiding unresponsive GUIs in a
 multi-threaded environment.</simpara>
 </section>
@@ -13869,88 +14085,105 @@ GUIs are created using various methods available in the <literal>JOptionPane</li
 class. While the interfaces created this way are simple in nature, they
 are often adequate for input and output in short Java programs.
 Construction of more complex GUIs is the subject of
-Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/>.</simpara>
+<xref linkend="_constructing_graphical_user_interfaces"/>.</simpara>
 </section>
-<section xml:id="_exercises_6">
+<section xml:id="_exercises_7">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>In which situations would it be better to use a command-line
+<simpara><anchor xml:id="exercise7.1" xreflabel="[exercise7.1]"/> In which situations would it be better to use a command-line
 interface instead of a GUI? When is it better to use a GUI over a
 command-line interface?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:modalNonmodalDialogExercise"/> Explain the difference
+<simpara><anchor xml:id="exercise7.2" xreflabel="[exercise7.2]"/> Explain the difference
 between a modal and a non-modal dialog. Give an example of when you
 would prefer a modal over non-modal dialog, and another example of when
 you would prefer a non-modal to a modal dialog.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:messageTypeConstantsExercise"/> Give one example each when
+<simpara><anchor xml:id="exercise7.3" xreflabel="[exercise7.3]"/> Give one example each when
 you would use the five different message type constants in
 <literal>showMessageDialog()</literal> method (see page  for a listing of the five
 constants).</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:yesNoDialogExercise"/> In Program <xref linkend="program:OddEvenTest"/>,
-we could have coded line <xref linkend="yes-noDialogLine"/> as follows without
-changing the program behavior.</simpara>
-</listitem>
-</orderedlist>
+<simpara><anchor xml:id="exercise7.4" xreflabel="[exercise7.4]"/> In <xref linkend="OddEvenTestProgram"/>,
+we could have coded the line checking to see if the user had correctly determined whether the number was odd or even as follows.</simpara>
 <programlisting language="java" linenumbering="unnumbered">if( (response == 0 &amp;&amp; x % 2 != 0) ||
     (response == 1 &amp;&amp; x % 2 == 0) )</programlisting>
 <simpara>Yet another option is below.</simpara>
 <programlisting language="java" linenumbering="unnumbered">if( response != x % 2 )</programlisting>
 <simpara>Which of these three implementations is best? Why?</simpara>
-<simpara><emphasis role="strong">Programming Practice</emphasis>
-5.  Modify the program in Example <xref linkend="example:Yes-No_dialog"/> such that it
+<simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.5" xreflabel="[exercise7.5]"/> Modify the program in <xref linkend="yes-NoDialogExample"/> such that it
 tests the user several times, say 25 times, whether a randomly generated
 integer is odd or even. The program should keep a score indicating the
 number of correct answers. At the end of the test the score is displayed
-using a suitable dialog.
-6.  Modify the program in Example <xref linkend="example:Yes-No_dialog"/> such that it
+using a suitable dialog.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.6" xreflabel="[exercise7.6]"/> Modify the program in <xref linkend="yes-NoDialogExample"/> such that it
 displays a dialog that asks the user &#8220;Do you wish to continue?&#8221; and
 offers options &#8220;Yes&#8221; and &#8220;No.&#8221; The program exits the loop when the
 &#8220;No&#8221; option is selected and displays the score using a suitable
-dialog.
-7.  <xref linkend="exercise:cancelButtonExercise"/> Rewrite
-Program <xref linkend="program:OddEvenTest"/> so that the confirmatory dialog
+dialog.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.7" xreflabel="[exercise7.7]"/> Rewrite
+<xref linkend="OddEvenTestProgram"/> so that the confirmatory dialog
 generated offers the &#8220;Yes,&#8221; &#8220;No,&#8221; and &#8220;Cancel&#8221; options to the
 user. The program exits with a message dialog saying &#8220;Thank You&#8221; when
-the user selects the &#8220;Cancel&#8221; option.
-8.  <xref linkend="exercise:CapitolDialogExercise"/> Modify
-Program <xref linkend="program:CapitalQuiz"/> to create and administer a test wherein
+the user selects the &#8220;Cancel&#8221; option.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.8" xreflabel="[exercise7.8]"/> Modify
+<xref linkend="CapitalQuizProgram"/> to create and administer a test wherein
 the user is asked capitals of 10 countries in a sequence. The program
 must keep count of the score, i.e., the number of correct answers.
 Inform the user of the score at the end of the test using a suitable
-dialog.
-9.  <xref linkend="exercise:focusOptionExercise"/> Modify line <xref linkend="multipleOptionsLine"/>
-in Program <xref linkend="program:CapitalQuiz"/> so that the button labeled &#8220;Baku&#8221;
-has focus.
-10. <xref linkend="exercise:randomizeCapitalsExercise"/> Section <xref linkend="solution:Three card
-poker"/> gives a method called <literal>shuffle()</literal> that is used to randomize an
+dialog.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.9" xreflabel="[exercise7.9]"/> Modify <xref linkend="CapitalQuizProgram"/> so that the button labeled &#8220;Baku&#8221; has focus when the program begins.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.10" xreflabel="[exercise7.10]"/> <xref linkend="_solution_three_card_poker"/> gives a method called <literal>shuffle()</literal> that is used to randomize an
 array representing a deck of cards. Adapt this code and modify
-Program <xref linkend="program:CapitalQuiz"/> so that the order of the capitals is
+<xref linkend="CapitalQuizProgram"/> so that the order of the capitals is
 randomized. Note that you will have to record which index contains the
-correct answer.
-11. Re-implement the solution to the college cost calculator problem
-given in Section <xref linkend="solution:College_cost_calculator"/> so that it uses
-GUIs constructed with <literal>JOptionPane</literal> for input and output.
-12. Re-implement the solution to the Monty Hall problem given in
-Section <xref linkend="solution:Monty_Hall"/> so that it uses GUIs constructed with
-<literal>JOptionPane</literal> for input and output.
-13. Re-implement the solution to the DNA searching problem given in
-Section <xref linkend="solution:DNA_searching"/> so that it uses GUIs constructed with
-<literal>JOptionPane</literal> for input and output.
-14. Write a program that creates an input dialog that prompts and reads
+correct answer.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.11" xreflabel="[exercise7.11]"/> Re-implement the solution to the college cost calculator problem
+given in <xref linkend="_solution_college_cost_calculator"/> so that it uses
+GUIs constructed with <literal>JOptionPane</literal> for input and output.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.12" xreflabel="[exercise7.12]"/> Re-implement the solution to the Monty Hall problem given in
+<xref linkend="_solution_monty_hall"/> so that it uses GUIs constructed with
+<literal>JOptionPane</literal> for input and output.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.13" xreflabel="[exercise7.13]"/> Re-implement the solution to the DNA searching problem given in
+<xref linkend="_solution_dna_searching"/> so that it uses GUIs constructed with
+<literal>JOptionPane</literal> for input and output.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.14" xreflabel="[exercise7.14]"/> Write a program that creates an input dialog that prompts and reads
 a file name of an image from the user. Then, create an information
 dialog that displays the file as a custom icon. In this way, you can
-construct a simple image viewer.
-15. <xref linkend="exercise:inputDialogExceptionExercise"/> <emphasis role="strong">Note: You should attempt
+construct a simple image viewer.</simpara>
+</listitem>
+<listitem>
+<simpara><anchor xml:id="exercise7.15" xreflabel="[exercise7.15]"/> <emphasis role="strong">Note: You should attempt
 this exercise only if you are familiar with exceptions in Java.
-Exceptions are covered in Chapter <xref linkend="chapter:Exceptions"/>.</emphasis><?asciidoc-br?>
+Exceptions are covered in <xref linkend="_exceptions"/>.</emphasis><?asciidoc-br?>
 Use the <literal>try-catch</literal> block and modify
-Program <xref linkend="program:ChemistryQuizOne"/> so that it handles an exception
+<xref linkend="ChemistryQuizOneProgram"/> so that it handles an exception
 generated when the user enters a string that cannot be converted to an
 integer. In the event such an exception is raised, pop up a message
 dialog box informing the user to try again and type an integer value.
@@ -13962,9 +14195,11 @@ input after an incorrect string has been typed. In another version, your
 program should remain in a loop until the user enters a valid integer
 (note that a valid integer might not be the correct answer to the
 question asked).</simpara>
+</listitem>
+</orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Methods">
+<chapter xml:id="_methods">
 <title>Methods</title>
 <blockquote>
 <attribution>
@@ -13981,7 +14216,7 @@ classic game of both statistics and strategy is poker. The problem we
 want to solve is programming one of the many variations of poker, called
 three card poker. Instead of bluffing, a player competes only with the
 house according to fixed rules without any room for psychology. A player
-is dealt three cards. If the player’s hand contains a pair or better, he
+is dealt three cards. If the player&#8217;s hand contains a pair or better, he
 or she wins a payoff greater than or equal to the money bet. If the
 player does not have a pair or better, he or she loses the money bet.
 Below is a table giving one possible set of payoffs for each possible
@@ -14069,7 +14304,7 @@ problems.</simpara>
 problem you could not solve before. Instead, the tools in this chapter
 and in the next one make solving a problem easier and less susceptible
 to errors. A relatively long, complicated list of Java statements was
-necessary to solve problems like the statistics program or Conway’s Game
+necessary to solve problems like the statistics program or Conway&#8217;s Game
 of Life. Instead of solving those problems as a single monolithic
 segment of code, we can break our solutions into units called <emphasis>static
 methods</emphasis>.</simpara>
@@ -14197,7 +14432,7 @@ input.</simpara>
 <programlisting language="java" linenumbering="unnumbered">int maximum = Math.max(5, 10);</programlisting>
 <simpara>In this case, the value stored into <literal>maximum</literal> is <literal>10</literal>. Despite its
 simplicity, we demonstrated how useful this method could be in our
-solution to Conway’s Game of Life from Chapter <xref linkend="chapter:Arrays"/>. If we
+solution to Conway&#8217;s Game of Life from <xref linkend="_arrays"/>. If we
 wanted to write this method ourselves, the code would be as follows.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public static int max( int a, int b ) {
     if( a &gt;= b )
@@ -14266,7 +14501,7 @@ already been returned.</simpara>
 <simpara>If some of this syntax seems eerily familiar, remember that you have
 been coding static methods since your very first Java program. The
 <literal>main()</literal> method is just another static method, special only because the
-JVM chooses to start execution there. Let’s look at the <literal>main()</literal> method
+JVM chooses to start execution there. Let&#8217;s look at the <literal>main()</literal> method
 from a standard Hello, World! program.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public static void main( String[] args ) {
     System.out.println("Hello, world!");
@@ -14290,7 +14525,7 @@ If Java finds a way that execution could reach the end of a value
 returning method without reaching a <literal>return</literal> statement, it causes a
 compiler error.</simpara>
 </section>
-<section xml:id="subsubsection:Overloaded_methods">
+<section xml:id="_overloaded_methods">
 <title>Overloaded methods</title>
 <simpara>Since this declaration is in another class, it is OK to create a <literal>max()</literal>
 method even though there is already one in the <literal>Math</literal> class. However, it
@@ -14412,7 +14647,7 @@ and objects. Practically, this means that, if a reference to an array is
 passed into a method, you cannot change which array it is pointing at.
 Since references are not values but names pointing at a particular
 location in memory, you can directly change the contents of that memory
-with a method, even if you can’t change which locations are being
+with a method, even if you can&#8217;t change which locations are being
 referenced. For example, the following method does <emphasis role="strong">not</emphasis> reverse the
 order of an array.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public static void badReverseArray( int[] array ) {
@@ -14446,7 +14681,7 @@ array in reverse order, but it is less efficient to create the extra
 array and perform two copies.</simpara>
 </section>
 </section>
-<section xml:id="subsection:class_variables">
+<section xml:id="_class_variables">
 <title>Class variables</title>
 <simpara>According to the rules we have given so far, the only legal variables in
 the scope of a static method are the parameters and any other <emphasis>local</emphasis>
@@ -14459,8 +14694,8 @@ is to declare it outside of all methods (but inside the class) with an
 access modifier such as <literal>public</literal> or <literal>private</literal>, and the keyword <literal>static</literal>.
 For example, the following class includes a method called <literal>record()</literal>
 that increases the class variable <literal>counter</literal> every time it is called.</simpara>
-<formalpara xml:id="program:Bookkeeper" xreflabel="Bookkeeper">
-<title>A program that keeps track of the number of times the <literal>record()</literal> method is called.</title>
+<formalpara xml:id="BookkeeperProgram">
+<title>Keeps track of the number of times the <literal>record()</literal> method is called.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class Bookkeeper {
 	public static int counter = 0;
@@ -14512,8 +14747,8 @@ object, <inlineequation><alt><![CDATA[m_2]]></alt><mathphrase><![CDATA[m_2]]></m
 distance between their centers, and <inlineequation><alt><![CDATA[G]]></alt><mathphrase><![CDATA[G]]></mathphrase></inlineequation> is the gravitational
 constant,
 <inlineequation><alt><![CDATA[6.673 \times 10^{-11}\mbox{ N}\cdot\mbox{m}^2\cdot\mbox{kg}^{-2}]]></alt><mathphrase><![CDATA[6.673 \times 10^{-11}\mbox{ N}\cdot\mbox{m}^2\cdot\mbox{kg}^{-2}]]></mathphrase></inlineequation>.</simpara>
-<formalpara xml:id="program:Gravity" xreflabel="Gravity">
-<title>A program that calculates the attraction due to gravity between two masses.</title>
+<formalpara xml:id="GravityProgram">
+<title>Calculates the attraction due to gravity between two masses.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class Gravity {
 	public static final double G = 6.673e-11;
@@ -14578,10 +14813,10 @@ equation: <inlineequation><alt><![CDATA[d = \sqrt{(x_1 - x_2)^2 + (y_1 - y_2)^2 
 necessary to do this calculation many times and it does not depend on
 any other variables or program state.</simpara>
 </example>
-<example>
+<example xml:id="palindromeTestingExample">
 <title>Palindrome testing</title>
 <simpara>A palindrome is a word or phrase (or even a number) that is the same
-spelled forwards and backwards. &#8220;Racecar,&#8221; &#8220;Madam, I’m Adam,&#8221; and
+spelled forwards and backwards. &#8220;Racecar,&#8221; &#8220;Madam, I&#8217;m Adam,&#8221; and
 &#8220;Satan, oscillate my metallic sonatas&#8221; are examples in English.
 Typically, spaces and punctuation are ignored. We are going to write a
 function that, given a <literal>String</literal>, returns <literal>true</literal> if it is a palindrome
@@ -14605,13 +14840,16 @@ case <literal>String</literal>. On the outside of this function, the <literal>St
 does not change because the name <literal>text</literal> is passed by value.</simpara>
 <simpara>The loop iterates through the first half of <literal>text</literal>, comparing it to the
 second half. This loop reflects the asymmetry of these kinds of tests:
-You can’t be sure that <literal>text</literal> is a palindrome until you have checked the
+You can&#8217;t be sure that <literal>text</literal> is a palindrome until you have checked the
 entire thing, but you immediately know that it is not if even a single
 pair of characters does not match. If the test in that <literal>if</literal> statement
 ever shows that the two <literal>char</literal> values are not equal, the <literal>return false</literal>
 statement jumps out of the method without completing the loop.</simpara>
 </example>
-<example>
+<sidebar>
+<simpara><link linkend="exercise8.11">Exercise 8.11</link></simpara>
+</sidebar>
+<example xml:id="parsingANumberExample">
 <title>Parsing a number</title>
 <simpara>When you read in a number using an object of the <literal>Scanner</literal> class, it
 converts (or <emphasis>parses</emphasis>) the text entered by the user into the appropriate
@@ -14851,13 +15089,13 @@ arrow that then executes the corresponding <literal>run()</literal> method and a
 methods it calls. Note that we are talking about a method called on a
 <literal>Thread</literal> object, not a static method called on the class as a whole.
 Calling <literal>start()</literal> is an instance method, which we discuss in
-Chapter <xref linkend="chapter:Classes"/>. Unlike the static methods we have discussed
+<xref linkend="_classes"/>. Unlike the static methods we have discussed
 in this chapter, an instance method is tied to a particular object, but
 most of what you have learned about methods still applies.</simpara>
 <simpara>Methods are supposed to make programming easier by breaking programs
 into chunks small enough to think about. One of the only real dangers of
 methods is using class variables, as discussed in
-Section <xref linkend="subsection:class_variables"/>. This problem becomes worse with
+<xref linkend="_class_variables"/>. This problem becomes worse with
 multiple threads. With a single thread, two or more different methods
 can all affect the same class variable, perhaps in conflicting ways.
 With multiple threads, even the <emphasis role="strong">same</emphasis> method can interfere with itself.</simpara>
@@ -14867,8 +15105,8 @@ With multiple threads, even the <emphasis role="strong">same</emphasis> method c
 pseudorandom numbers using the equation
 <inlineequation><alt><![CDATA[x_i=(ax_{i-1}+b)\mod m]]></alt><mathphrase><![CDATA[x_i=(ax_{i-1}+b)\mod m]]></mathphrase></inlineequation>, deriving the next number from the
 previous one, and so on.</simpara>
-<formalpara xml:id="program:UnsafeRandom" xreflabel="UnsafeRandom">
-<title>This program implements an LCG similar to one sometimes used in the function <literal>rand()</literal> used in the C language.</title>
+<formalpara xml:id="UnsafeRandomProgram">
+<title>Implements an LCG similar to one sometimes used in the function <literal>rand()</literal> used in the C language.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class UnsafeRandom {
 	private static int next = 1;
@@ -14892,8 +15130,8 @@ should be rewritten so that it takes in the previous number in the
 sequence. In that way, there is no shared state. Remember that using a
 (non-final) static field (class variable) should be avoided whenever
 possible.</simpara>
-<formalpara xml:id="program:SafeRandom" xreflabel="SafeRandom">
-<title>This program implements the same LCG safely by requiring the caller to supply the previous random number.</title>
+<formalpara xml:id="SafeRandomProgram">
+<title>Implements the same LCG safely by requiring the caller to supply the previous random number.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class SafeRandom {
 	private final static int A = 1103515245;
@@ -14910,11 +15148,11 @@ possible.</simpara>
 <example>
 <title>Unpredictable methods</title>
 <simpara>By forcing each thread to carry its own state, we fixed the previous
-problem. In Chapter <xref linkend="chapter:Synchronization"/> we talk about the much
+problem. In <xref linkend="_synchronization"/> we talk about the much
 nastier problem of two threads executing a method at exactly the same
 time. When that happens, very curious effects are possible. Consider the
 following program:</simpara>
-<formalpara xml:id="program:AlwaysEven" xreflabel="AlwaysEven">
+<formalpara xml:id="AlwaysEvenProgram">
 <title>The <literal>print()</literal> method always prints <literal>"Even"</literal> when run with a single thread but can sometimes print <literal>"Odd"</literal> if called repeatedly with multiple threads.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class AlwaysEven {
@@ -14937,24 +15175,25 @@ If two or more threads are calling the <literal>print()</literal> method, <liter
 be changed by one right before the other executes the <literal>if</literal> statements.</simpara>
 </example>
 </section>
-<section xml:id="_exercises_7">
+<section xml:id="_exercises_8">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>Describe three advantages of dividing long segments of code into
+<simpara><anchor xml:id="exercise8.1" xreflabel="[exercise8.1]"/> Describe three advantages of dividing long segments of code into
 static methods.</simpara>
 </listitem>
 <listitem>
-<simpara>Can you think of any disadvantages of dividing code into methods?
+<simpara><anchor xml:id="exercise8.2" xreflabel="[exercise8.2]"/> Can you think of any disadvantages of dividing code into methods?
 Are there situations where using a method is unwise?</simpara>
 </listitem>
 <listitem>
-<simpara>If you wanted to declare a static method that would compute the
+<simpara><anchor xml:id="exercise8.3" xreflabel="[exercise8.3]"/> If you wanted to declare a static method that would compute the
 mean, median, and standard deviation of an input array of <literal>double</literal>
 values, how would you return those three answers?</simpara>
 </listitem>
 <listitem>
-<simpara>Consider the following method definition.</simpara>
+<simpara><anchor xml:id="exercise8.4" xreflabel="[exercise8.4]"/> Consider the following method definition.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public static void twice( int i ) {
     i = 2 * i;
 }</programlisting>
@@ -14964,7 +15203,7 @@ while( x &lt; 128 )
     twice(x);</programlisting>
 </listitem>
 <listitem>
-<simpara>Consider the following signatures of two overloaded methods.</simpara>
+<simpara><anchor xml:id="exercise8.5" xreflabel="[exercise8.5]"/> Consider the following signatures of two overloaded methods.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public static int magic( int rabbit, double hat )
 public static int magic( double wand, int spell )</programlisting>
 <simpara>Which method would be invoked by the following call?</simpara>
@@ -14974,7 +15213,7 @@ public static int magic( double wand, int spell )</programlisting>
 <simpara>Use a compiler to check your answers.</simpara>
 </listitem>
 <listitem>
-<simpara>The following class generates a sequence of even numbers. Each time
+<simpara><anchor xml:id="exercise8.6" xreflabel="[exercise8.6]"/> The following class generates a sequence of even numbers. Each time
 the <literal>next()</literal> method is called, the next even number in the sequence is
 returned. What is the design problem with using a static field to keep
 track of the next value in the sequence?</simpara>
@@ -14989,12 +15228,12 @@ track of the next value in the sequence?</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Write a static method called <literal>cube()</literal> that takes a single <literal>double</literal>
+<simpara><anchor xml:id="exercise8.7" xreflabel="[exercise8.7]"/> Write a static method called <literal>cube()</literal> that takes a single <literal>double</literal>
 value as a parameter and returns its value cubed. Do not use the
 <literal>Math.pow()</literal> method.</simpara>
 </listitem>
 <listitem>
-<simpara>Implement a static method that takes a single <literal>int</literal> value as a
+<simpara><anchor xml:id="exercise8.8" xreflabel="[exercise8.8]"/> Implement a static method that takes a single <literal>int</literal> value as a
 parameter and prints its digits in reverse. For example, if <literal>103</literal> was
 passed into this method, it would print <literal>301</literal> to the screen.</simpara>
 <simpara>You can find out what digit is in the ones place of a number by taking
@@ -15002,7 +15241,7 @@ its remainder modulus 10. Then, you can remove the digit in the ones
 place by dividing by 10. Do not convert the <literal>int</literal> value into a <literal>String</literal>.</simpara>
 </listitem>
 <listitem>
-<simpara>Write a static method that takes an array of <literal>int</literal> values as a
+<simpara><anchor xml:id="exercise8.9" xreflabel="[exercise8.9]"/> Write a static method that takes an array of <literal>int</literal> values as a
 parameter and returns <literal>true</literal> if the array is in ascending order and
 <literal>false</literal> otherwise. Compare each element of the array to the next element
 of the array. If the current element is ever larger than the next
@@ -15011,7 +15250,7 @@ only be sure that the array is in ascending order after you have checked
 all neighboring pairs.</simpara>
 </listitem>
 <listitem>
-<simpara>Write a static method that finds the
+<simpara><anchor xml:id="exercise8.10" xreflabel="[exercise8.10]"/> Write a static method that finds the
 <inlineequation><alt><![CDATA[\lfloor\log_2(n)\rfloor]]></alt><mathphrase><![CDATA[\lfloor\log_2(n)\rfloor]]></mathphrase></inlineequation> of an integer <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>.
 Note that if <inlineequation><alt><![CDATA[\log_2 n = x]]></alt><mathphrase><![CDATA[\log_2 n = x]]></mathphrase></inlineequation>, it is also true that
 <inlineequation><alt><![CDATA[n = 2^x]]></alt><mathphrase><![CDATA[n = 2^x]]></mathphrase></inlineequation>. In other words, the <inlineequation><alt><![CDATA[\log_2]]></alt><mathphrase><![CDATA[\log_2]]></mathphrase></inlineequation> operator
@@ -15072,22 +15311,22 @@ various input values of <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![C
 </informaltable>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:palindromes"/> Write a method that tests palindromes like
-the method from Example <xref linkend="example:Palindrome_testing"/> but also ignores
+<simpara><anchor xml:id="exercise8.11" xreflabel="[exercise8.11]"/> Write a method that tests palindromes like
+the method from <xref linkend="palindromeTestingExample"/> but also ignores
 punctuation and spaces. Thus, <literal>"A man, a plan, a canal: Panama"</literal> should
 be counted as a palindrome by this new method.</simpara>
 </listitem>
 <listitem>
-<simpara>Re-implement the solution from Section <xref linkend="solution:Three_card_poker"/>
+<simpara><anchor xml:id="exercise8.12" xreflabel="[exercise8.12]"/> Re-implement the solution from <xref linkend="_solution_three_card_poker"/>
 so that it uses a GUI constructed with <literal>JOptionPane</literal> to display the hand
 and the winnings.</simpara>
 </listitem>
 <listitem>
-<simpara>Five card poker is a much more common version of poker than the
-three card version we discussed in Section <xref linkend="problem:Three_card_poker"/>.
+<simpara><anchor xml:id="exercise8.13" xreflabel="[exercise8.13]"/> Five card poker is a much more common version of poker than the
+three card version we discussed in <xref linkend="_problem_three_card_poker"/>.
 Using static methods, implement a two-player game of poker in which the
 deck is shuffled and then dealt into two hands of five cards each. Then,
-state which player’s hand wins. With five cards, determining which hand
+state which player&#8217;s hand wins. With five cards, determining which hand
 wins is a more complicated process. The rankings of the various possible
 hands from best to worst are as follows.</simpara>
 <orderedlist numeration="loweralpha">
@@ -15143,7 +15382,7 @@ cards in each hand are used as tiebreakers, in descending rank order.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>In terms of time, there is a small overhead associated with calling
+<simpara><anchor xml:id="exercise8.14" xreflabel="[exercise8.14]"/> In terms of time, there is a small overhead associated with calling
 a method and returning a value, but it is very hard to measure. Write a
 program with two <literal>int</literal> variables, <literal>a</literal> and <literal>b</literal>, where <literal>a</literal> starts with a
 value of <literal>1</literal> and <literal>b</literal> starts with a value of <literal>2</literal>. Run a <literal>for</literal> loop
@@ -15162,7 +15401,7 @@ following method.</simpara>
 <simpara>Again, run your program repeatedly with this modification. What is the
 difference in running time between the version that uses a method and
 the version that does addition directly?</simpara>
-<simpara>Depending on your JVM, it’s quite possible that there’s almost no
+<simpara>Depending on your JVM, it&#8217;s quite possible that there&#8217;s almost no
 difference. The JVM does a lot of optimizations including <emphasis>inlining</emphasis>,
 which replaces a call to a method with the actual code inside the
 method.</simpara>
@@ -15170,7 +15409,7 @@ method.</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Classes">
+<chapter xml:id="_classes">
 <title>Classes</title>
 <blockquote>
 <attribution>
@@ -15197,8 +15436,7 @@ left and right square brackets must be balanced, and left and right
 curly braces must be balanced. Furthermore, a correctly balanced set of
 parentheses can be nested inside of a correctly balanced set of square
 brackets or curly braces (and vice versa), but they cannot intersect as
-they do at the end of the previous paragraph. Table <xref linkend="table:nested
-expressions"/> shows more examples of correctly and incorrectly nested
+they do at the end of the previous paragraph. The table below shows more examples of correctly and incorrectly nested
 expressions.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
 <tgroup cols="2">
@@ -15258,19 +15496,19 @@ brace, put it on the stack.</simpara>
 <listitem>
 <simpara>If it is a right parenthesis, right square bracket, or right curly
 brace, check that the top of the stack is its matching left half. If it
-is, pop the left half off the stack. If it isn’t (or if the stack is
+is, pop the left half off the stack. If it isn&#8217;t (or if the stack is
 empty), the grouping symbols are either unbalanced or intersecting.
 Print an error and quit.</simpara>
 </listitem>
 <listitem>
-<simpara>For any character that isn’t a grouping symbol, ignore it and move
+<simpara>For any character that isn&#8217;t a grouping symbol, ignore it and move
 on.</simpara>
 </listitem>
 </orderedlist>
 <simpara>If you reach the end of input without an error, check to see if the
 stack is empty. If it is, then all of the left grouping symbols have
 been matched up with right grouping symbols. If not, there are left
-symbols left on the stack, and the expression isn’t correctly nested.</simpara>
+symbols left on the stack, and the expression isn&#8217;t correctly nested.</simpara>
 </section>
 <section xml:id="_concepts_object_oriented_programming">
 <title>Concepts: Object-oriented programming</title>
@@ -15349,7 +15587,7 @@ the object is hidden.</simpara>
 not need an object in order to be called. Regular (instance) methods
 should be thought of as an action performed on (or by) a specific
 object. This action could be asking a question, such as inquiring what
-the name of an object of type Human is. This action could be telling the
+the name of an object of type <literal>Human</literal> is. This action could be telling the
 object to change itself, such as the case of pushing something onto a
 stack.</simpara>
 <simpara>One of the broadest definitions of an object is a collection of data and
@@ -15366,7 +15604,7 @@ the object or get information from it.</simpara>
 <simpara>OOP concepts such as encapsulation may seem esoteric until you see them
 in practice. Remember, we just want to create some private data and then
 define a few carefully controlled ways that the data can be manipulated.
-First, we’ll describe how to declare fields, then explain how to write
+First, we&#8217;ll describe how to declare fields, then explain how to write
 instance methods to manipulate that data, and finally give more details
 about protecting its privacy.</simpara>
 <section xml:id="_fields">
@@ -15374,7 +15612,7 @@ about protecting its privacy.</simpara>
 <simpara>Fields in an object must be declared like any other data in Java. The
 type of a piece of data can be a primitive or reference type. Fields are
 also sometimes called member variables. You declare fields just like you
-would class variables, except without the <literal>static</literal> keyword. Here’s an
+would class variables, except without the <literal>static</literal> keyword. Here&#8217;s an
 example with the <literal>Human</literal> class.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class Human {
     private String name;
@@ -15386,7 +15624,7 @@ example with the <literal>Human</literal> class.</simpara>
 <literal>private</literal>, code outside of this class cannot change or even read the
 values. Note that this class cannot do anything yet. Also, note that
 this class does not contain a <literal>main()</literal> method. There is no way to run
-this class, but that’s fine. We can add a <literal>main()</literal> method, of course.</simpara>
+this class, but that&#8217;s fine. We can add a <literal>main()</literal> method, of course.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class Human {
     private String name;
     private String DOB;
@@ -15402,9 +15640,9 @@ this class, but that’s fine. We can add a <literal>main()</literal> method, of
 Since the <literal>main()</literal> method is a static method, it is not associated with
 any particular object. When we tell the <literal>main()</literal> method to change the
 fields, it does not know what object we are talking about. If we
-actually want to use an object, we’ll have to create one.</simpara>
-<formalpara xml:id="program:Human" xreflabel="Human">
-<title>Example of a class encapsulating the attributes of a human being.</title>
+actually want to use an object, we&#8217;ll have to create one.</simpara>
+<formalpara xml:id="HumanProgram">
+<title>Class encapsulating the attributes of a human being.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class Human {
 	private String name;
@@ -15436,7 +15674,7 @@ seems to stem from the fact that the class (such as <literal>Human</literal>) is
 template for objects but it is also a place to house other related code,
 such as static methods, including <literal>main()</literal>.</simpara>
 <simpara>Although the practice is discouraged, we mentioned in
-Section <xref linkend="subsection:class_variables"/> that class variables can be
+<xref linkend="_class_variables"/> that class variables can be
 stored in the class itself. Every object has a distinct copy of each
 field, but there is only a single copy of each class variable that they
 all share. By using the keyword <literal>static</literal>, we could add a class variable
@@ -15448,7 +15686,7 @@ connected to humans as a whole, not to any individual human being.</simpara>
     private int height; //in cm
     private static double population = 7.023E9;
 }</programlisting>
-<simpara>We are using a <literal>double</literal> to represent the world’s population since the
+<simpara>We are using a <literal>double</literal> to represent the world&#8217;s population since the
 value is too big to fit in an <literal>int</literal> and is easily expressed in
 scientific notation. If several <literal>Human</literal> objects were created, they would
 have their own <literal>name</literal>, <literal>DOB</literal>, and <literal>height</literal> values, but the value for
@@ -15467,7 +15705,7 @@ have their own <literal>name</literal>, <literal>DOB</literal>, and <literal>hei
 <title>Constructors</title>
 <simpara>To create a new object, you have to invoke a <emphasis>constructor</emphasis>, a special
 kind of method that can initialize the object. A constructor allows sets
-up the values inside an object when it is first created. Let’s consider
+up the values inside an object when it is first created. Let&#8217;s consider
 a simple <literal>Rectangle</literal> class with only two fields: <literal>length</literal> and <literal>width</literal>,
 both of type <literal>int</literal>.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class Rectangle {
@@ -15490,14 +15728,14 @@ constructor does not have a return type. A constructors is the only kind
 of method that does not have a return type. It is possible to have more
 than one constructor as well, just as other methods can be overloaded.
 For more information about overloaded methods, refer back to
-Section <xref linkend="subsubsection:Overloaded_methods"/>.</simpara>
+<xref linkend="_overloaded_methods"/>.</simpara>
 <programlisting language="java" linenumbering="unnumbered">    public Rectangle( int value ) {
         length = value;
         width = value;
     }</programlisting>
 <simpara>In the very same class, we could have this second constructor, allowing
 us to quickly and easily create a square. All classes have constructors,
-but some are not written explicitly. If you don’t type out a constructor
+but some are not written explicitly. If you don&#8217;t type out a constructor
 for a class, a default one is automatically created. The default
 constructor takes no parameters and sets all the values inside the new
 object to defaults such as <literal>null</literal> and <literal>0</literal>. Once you do create a
@@ -15520,8 +15758,8 @@ into themselves for no reason. The designers of Java anticipated that it
 would be useful to refer to fields even in the presence of other
 variables with the same name. To do so, the <literal>this</literal> keyword can be used.
 Any field (or method) can be referred to by its object name, followed by
-a dot, followed by the name of that field or method. Since you don’t
-have a variable name to reference the object when you’re inside of it,
+a dot, followed by the name of that field or method. Since you don&#8217;t
+have a variable name to reference the object when you&#8217;re inside of it,
 the <literal>this</literal> keyword acts as a reference to the object.</simpara>
 <programlisting language="java" linenumbering="unnumbered">    public Rectangle( int length, int width ) {
         this.length = length;
@@ -15531,7 +15769,7 @@ the <literal>this</literal> keyword acts as a reference to the object.</simpara>
 told Java to store the argument <literal>length</literal> into the field <literal>length</literal> inside
 the object pointed at by <literal>this</literal> and to do similarly for <literal>width</literal>.</simpara>
 </section>
-<section xml:id="_methods">
+<section xml:id="_methods_2">
 <title>Methods</title>
 <simpara>Objects do not really come to life until you add instance methods. With
 the <literal>Rectangle</literal> class described above, any <literal>Rectangle</literal> objects created
@@ -15610,7 +15848,7 @@ and set the <literal>length</literal> field, for example. Perhaps doing so seems
 needlessly complex. After all, if the <literal>length</literal> variable had been
 declared with the <literal>public</literal> modifier instead of the <literal>private</literal> modifier,
 we could get and set its value directly, without using methods. In
-response, let’s improve the mutators that set <literal>length</literal> and <literal>width</literal>.</simpara>
+response, let&#8217;s improve the mutators that set <literal>length</literal> and <literal>width</literal>.</simpara>
 <programlisting language="java" linenumbering="unnumbered">    public void setLength( int length ) {
         if( length &gt; 0 )
             this.length = length;
@@ -15622,12 +15860,12 @@ response, let’s improve the mutators that set <literal>length</literal> and <l
     }</programlisting>
 <simpara>With these better mutators, we can prevent a user from setting the
 values of <literal>length</literal> and <literal>width</literal> to negative numbers or zero, values that
-don’t make sense for dimensions of a rectangle. For more complicated
+don&#8217;t make sense for dimensions of a rectangle. For more complicated
 objects, it becomes even more important to protect the values of the
 fields from malicious or mistaken users.</simpara>
 </section>
 </section>
-<section xml:id="subsection:Access_modifiers">
+<section xml:id="_access_modifiers">
 <title>Access modifiers</title>
 <simpara>Hiding data is at the heart of the Java OOP model. There are four
 different levels of access that can be applied to fields and methods,
@@ -15670,7 +15908,7 @@ code unless the code is contained in the same class, a subclass, or is
 in the same package. This level of access is more restrictive than
 <literal>public</literal> but less restrictive than <literal>private</literal> or default access. We
 discuss it further in the context of subclasses and inheritance in
-Chapter <xref linkend="chapter:Inheritance"/>.</simpara>
+<xref linkend="_inheritance"/>.</simpara>
 </listitem>
 </varlistentry>
 <varlistentry>
@@ -15685,7 +15923,7 @@ organization that Java provides to group classes together. When you use
 an <literal>import</literal> statement, you can import an entire package of classes.
 There is no keyword for this access modifier. It is useful if you are
 designing a package containing classes that must be able to access each
-other’s fields or methods. For now, you should always give your fields
+other&#8217;s fields or methods. For now, you should always give your fields
 and methods an explicit <literal>public</literal> or <literal>private</literal> (or sometimes <literal>protected</literal>)
 modifier.</simpara>
 </listitem>
@@ -15751,7 +15989,7 @@ of an expression in postfix notation.</simpara>
 <example>
 <title>Student roster</title>
 <simpara>We are going to create a <literal>Student</literal> class so that we can store objects
-containing student roster information. Then, we’re going to create a
+containing student roster information. Then, we&#8217;re going to create a
 client program that reads data from a user to create <literal>Student</literal> objects,
 sort them by GPA, and then print them out.</simpara>
 <programlisting language="java" linenumbering="numbered">public class Student {
@@ -16012,8 +16250,7 @@ is only referred to in the method. Such a class is called a <emphasis>local
 class</emphasis>. It is possible to create an unnamed local class on the fly as
 well. Such a class is called an <emphasis>anonymous class</emphasis>. Both local and
 anonymous classes are special kinds of inner classes. Because of the way
-they are created and used, we discuss them in Section <xref linkend="advanced:Local
-and anonymous classes"/></simpara>
+they are created and used, we discuss them in <xref linkend="_advanced_local_and_anonymous_classes"/></simpara>
 <example>
 <title>Inner class objects as iterators</title>
 <simpara>If you create a data structure for other programmers to use, a useful
@@ -16024,7 +16261,7 @@ class object called an <emphasis>iterator</emphasis> that can repeatedly get the
 in the data structure. Since instances of an inner class can read
 private data of the outer class, iterators can keep track of where they
 are inside the data structure. If outside code were allowed access to
-the data structure’s internals, it would violate encapsulation.
+the data structure&#8217;s internals, it would violate encapsulation.
 Iterators are a very common application of inner classes.</simpara>
 <simpara>We can create a <literal>SafeArray</literal> class that only allows data to be written to
 its internal array if it falls in the legal range of indexes.</simpara>
@@ -16043,7 +16280,7 @@ its internal array if it falls in the legal range of indexes.</simpara>
 <simpara>We could add an inner class called <literal>Iterator</literal> to <literal>SafeArray</literal> that allows
 us to process all the array values without knowing how many there are.
 This kind of behavior is useful for many dynamic data structures, as
-discussed in Chapter <xref linkend="chapter:Dynamic_Data_Structures"/>.</simpara>
+discussed in <xref linkend="_dynamic_data_structures"/>.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class SafeArray {
     private double[] data;
 
@@ -16091,7 +16328,7 @@ of the values in a <literal>SafeArray</literal> object.</simpara>
 from the beginning of the chapter. Classes help us divide up the work of
 solving the problem. First, we need a stack class that can hold <literal>char</literal>
 values.</simpara>
-<formalpara xml:id="program:SymbolStack" xreflabel="SymbolStack">
+<formalpara xml:id="SymbolStackProgram">
 <title>Simple stack class to hold symbols from an input expression.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class SymbolStack {
@@ -16185,20 +16422,24 @@ efficiency, the loop stops early if <literal>correct</literal> is no longer <lit
 	}
 }</programlisting>
 <simpara>After the input has been examined, we check to see if the stack is
-empty. If it isn’t, there must be some left symbols that were not
+empty. If it isn&#8217;t, there must be some left symbols that were not
 matched with right symbols. In that case, we set <literal>correct</literal> to <literal>false</literal>.
 Finally, we print out whether the input is correctly or incorrectly
 nested based on the value of <literal>correct</literal>.</simpara>
+<sidebar>
+<simpara><link linkend="exercise9.9">Exercise 9.9</link><?asciidoc-br?>
+<link linkend="exercise9.14">Exercise 9.14</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_concurrency_objects">
 <title>Concurrency: Objects</title>
 <simpara>Nearly everything in Java is an object: arrays, lists, <literal>String</literal> values,
-colors, and even exceptions, which form Java’s error-handling system and
-is discussed in Chapter <xref linkend="chapter:Exceptions"/>. Some critics of Java
+colors, and even exceptions, which form Java&#8217;s error-handling system and
+is discussed in <xref linkend="_exceptions"/>. Some critics of Java
 point out that <literal>int</literal>, <literal>double</literal>, and the other primitive types are not
 objects, forcing the programmer to adopt two different programming
 models. Regardless, threads are stored as objects as well. In
-Chapter <xref linkend="chapter:Concurrent_Programming"/>, we discuss how to create
+<xref linkend="_concurrent_programming"/>, we discuss how to create
 threads and the various methods that can be used to interact with them.</simpara>
 <simpara>However, objects of type <literal>Thread</literal> are not the only ones you deal with
 when writing concurrent programs. As we have just noted, most data in
@@ -16211,14 +16452,22 @@ the cat. Consider the class below that keeps track of the lives a cat
 has, losing one every time it becomes curious.</simpara>
 <example>
 <title>Thread safety</title>
-<formalpara xml:id="program:Cat" xreflabel="Cat">
-<title>Program to record the number of lives a cat has left. Each <literal>Cat</literal> object starts with 9, but loses one each time it uses its curiosity. If no more lives remain, an error message is output.</title>
+<simpara>If the relationship between curiosity and mortality is the only feature
+of a cat you are trying to model, the class below appears to function well.
+If the <literal>useCuriosity()</literal> method is invoked, it removes a life or prints
+an error message if the cat has run out of lives. In a single-threaded
+situation, this object would work perfectly. No cat would be able to
+lose more than 9 lives.</simpara>
+<simpara>In a multi-threaded situation, there is no telling when a thread might
+pause in executing the <literal>useCuriosity()</literal> method.</simpara>
+<formalpara xml:id="CatProgram">
+<title>Records the number of lives a cat has left. Each <literal>Cat</literal> object starts with 9, but loses one each time it uses its curiosity. If no more lives remain, an error message is output.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class Cat {
 	private int lives = 9;
 
 	public boolean useCuriosity() {
-		if( lives &gt; 1 ) { /*@\label{life check}@*/
+		if( lives &gt; 1 ) { <co xml:id="CO13-1"/>
 			lives--;
 			System.out.println("Down to life " + lives);
 			return true;
@@ -16231,20 +16480,12 @@ has, losing one every time it becomes curious.</simpara>
 }</programlisting>
 </para>
 </formalpara>
-<simpara>If the relationship between curiosity and mortality is the only feature
-of a cat you are trying to model, this class appears to function well.
-If the <literal>useCuriosity()</literal> method is invoked, it removes a life or prints
-an error message if the cat has run out of lives. In a single-threaded
-situation, this object would work perfectly. No cat would be able to
-lose more than 9 lives.</simpara>
-<simpara>In a multi-threaded situation, there is no telling when a thread might
-pause in executing the <literal>useCuriosity()</literal> method. If 100 threads all
-called <literal>useCuriosity()</literal>, each one might successfully pass the <literal>if</literal>
-statement on line <xref linkend="life_check"/> before any had decremented <literal>lives</literal>.
-Once past the check, nothing would prevent them from continuing on and
-decrementing <literal>lives</literal>, resulting in a cat who lost 100 lives, resulting
-in a total of -91 lives. Such a scenario makes no sense.</simpara>
-<simpara>In Chapter <xref linkend="chapter:Synchronization"/>, we discuss how to prevent this
+<calloutlist>
+<callout arearefs="CO13-1">
+<para>If 100 threads all called <literal>useCuriosity()</literal>, each one might successfully pass the <literal>if</literal> on this line before any had decremented <literal>lives</literal>. Once past the check, nothing would prevent them from continuing on and decrementing <literal>lives</literal>, resulting in a cat who lost 100 lives, resulting in a total of -91 lives. Such a scenario makes no sense.</para>
+</callout>
+</calloutlist>
+<simpara>In <xref linkend="_synchronization"/>, we discuss how to prevent this
 problem, using the <literal>synchronized</literal> keyword to allow only a single thread
 at a time to execute the body of a method. The goal is to make
 <literal>useCuriosity()</literal> <emphasis>thread-safe</emphasis>, meaning that its behavior is consistent
@@ -16256,8 +16497,7 @@ programs, we discuss ways to make them thread-safe. However, you are
 also a consumer of code written by other people. In multi-threaded
 environments, you may need to use library classes that are thread-safe.
 For example, <literal>AtomicInteger</literal> is a thread-safe class designed to store
-and manipulate <literal>int</literal> values. In Chapter <xref linkend="chapter:Dynamic Data
-Structures"/>, we talk about the <literal>ArrayList</literal> and <literal>Vector</literal> classes, which
+and manipulate <literal>int</literal> values. In <xref linkend="_dynamic_data_structures"/>, we talk about the <literal>ArrayList</literal> and <literal>Vector</literal> classes, which
 are both used to hold variable length lists of objects. One of the few
 differences between them is that <literal>ArrayList</literal> is not thread-safe while
 <literal>Vector</literal> is. There is even the <literal>Collections.synchronizedCollection()</literal>
@@ -16277,39 +16517,40 @@ with the <literal>synchronized</literal> keyword. The JVM is relatively efficien
 how it enforces that keyword, but the computational expense is not zero.
 Learn the libraries well, and use the right tools for the right job.</simpara>
 </section>
-<section xml:id="_exercises_8">
+<section xml:id="_exercises_9">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>Explain the relationship between a class and an object.</simpara>
+<simpara><anchor xml:id="exercise9.1" xreflabel="[exercise9.1]"/> Explain the relationship between a class and an object.</simpara>
 </listitem>
 <listitem>
-<simpara>What is the difference between a static method and an instance
+<simpara><anchor xml:id="exercise9.2" xreflabel="[exercise9.2]"/> What is the difference between a static method and an instance
 method?</simpara>
 </listitem>
 <listitem>
-<simpara>What is the purpose of a constructor? Why is it impossible for a
+<simpara><anchor xml:id="exercise9.3" xreflabel="[exercise9.3]"/> What is the purpose of a constructor? Why is it impossible for a
 constructor to return a value? Why is it impossible for a constructor to
 be called multiple times on the same object?</simpara>
 </listitem>
 <listitem>
-<simpara>A static method can be called directly from a instance method, but
+<simpara><anchor xml:id="exercise9.4" xreflabel="[exercise9.4]"/> A static method can be called directly from a instance method, but
 an instance method cannot be called directly from a static method. Why?</simpara>
 </listitem>
 <listitem>
-<simpara>Describe the uses of accessor and mutator methods. Is it possible to
+<simpara><anchor xml:id="exercise9.5" xreflabel="[exercise9.5]"/> Describe the uses of accessor and mutator methods. Is it possible to
 create a method that is both an accessor and a mutator? Why or why not?</simpara>
 </listitem>
 <listitem>
-<simpara>Why do we usually mark fields with the <literal>private</literal> keyword when it
+<simpara><anchor xml:id="exercise9.6" xreflabel="[exercise9.6]"/> Why do we usually mark fields with the <literal>private</literal> keyword when it
 would be easier to make all fields <literal>public</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara>What is the meaning of the <literal>this</literal> keyword? When is it necessary to
+<simpara><anchor xml:id="exercise9.7" xreflabel="[exercise9.7]"/> What is the meaning of the <literal>this</literal> keyword? When is it necessary to
 use it? When can it be ignored?</simpara>
 </listitem>
 <listitem>
-<simpara>Consider the following class definitions.</simpara>
+<simpara><anchor xml:id="exercise9.8" xreflabel="[exercise9.8]"/> Consider the following class definitions.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class A {
     private int a;
 
@@ -16338,7 +16579,7 @@ public class B {
 uses cause a compiler error and why?</simpara>
 </listitem>
 <listitem>
-<simpara>In Section <xref linkend="solution:Nested_expressions"/>, we gave a definition of
+<simpara><anchor xml:id="exercise9.9" xreflabel="[exercise9.9]"/> In <xref linkend="_solution_nested_expressions"/>, we gave a definition of
 <literal>SymbolStack</literal> that implements a simple stack using two fields, defined
 as followed:</simpara>
 <programlisting language="java" linenumbering="unnumbered">private char[] symbols;
@@ -16349,7 +16590,7 @@ happen if <literal>symbols</literal> and <literal>size</literal> were declared <
 poorly written code had access to the object?</simpara>
 </listitem>
 <listitem>
-<simpara>Consider the following class definition.</simpara>
+<simpara><anchor xml:id="exercise9.10" xreflabel="[exercise9.10]"/> Consider the following class definition.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class GroceryItem {
     private String name;
     private double price;
@@ -16367,7 +16608,7 @@ not?</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>OOP is often used when the data inside the object must maintain
+<simpara><anchor xml:id="exercise9.11" xreflabel="[exercise9.11]"/> OOP is often used when the data inside the object must maintain
 special relationships. Consider a clock with hours, minutes, and
 seconds. When the number of seconds reaches 60, the number of minutes is
 increased by 1, and the number of seconds is reset to 0. When the number
@@ -16385,7 +16626,7 @@ be returned as <literal>"12:00:00 AM"</literal>. Make sure you pad the output fo
 <literal>seconds</literal> and <literal>minutes</literal> with an extra <literal>"0"</literal> if they are less than <literal>10</literal>.</simpara>
 </listitem>
 <listitem>
-<simpara>Draw on any of your hobbies to come up with a collection of items,
+<simpara><anchor xml:id="exercise9.12" xreflabel="[exercise9.12]"/> Draw on any of your hobbies to come up with a collection of items,
 whether those items are books you like to read, athletes you follow,
 music you collect, or anything else that is easy to classify. First
 create a class that can describe one of these items with three to five
@@ -16401,7 +16642,7 @@ that he or she is looking for all books whose author is
 not have to enter data about your objects repetitively.</simpara>
 </listitem>
 <listitem>
-<simpara>The <literal>java.awt</literal> package defines a class called <literal>Point</literal> that can be
+<simpara><anchor xml:id="exercise9.13" xreflabel="[exercise9.13]"/> The <literal>java.awt</literal> package defines a class called <literal>Point</literal> that can be
 used to manipulate an <inlineequation><alt><![CDATA[(x,y)]]></alt><mathphrase><![CDATA[(x,y)]]></mathphrase></inlineequation> pair in programs involving the
 Cartesian coordinate system. Create your own <literal>Point</literal> class with <literal>int</literal>
 values <literal>x</literal> and <literal>y</literal> as fields.</simpara>
@@ -16417,13 +16658,12 @@ as an argument.</simpara>
 if the <literal>distance()</literal> method gives the right answer.</simpara>
 </listitem>
 <listitem>
-<simpara>Re-implement the solution from Section <xref linkend="solution:Nested
-expressions"/> so that it performs its input and output with GUIs created
+<simpara><anchor xml:id="exercise9.14" xreflabel="[exercise9.14]"/> Re-implement the solution from <xref linkend="_solution_nested_expressions"/> so that it performs its input and output with GUIs created
 using <literal>JOptionPane</literal>.</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Objects are great tools for solving problems, but there is some
+<simpara><anchor xml:id="exercise9.15" xreflabel="[exercise9.15]"/> Objects are great tools for solving problems, but there is some
 additional overhead associated with creating objects and calling
 methods.</simpara>
 <simpara>Write a piece of code that allocates an array of 10,000,000 <literal>int</literal>
@@ -16441,7 +16681,7 @@ it takes to call a constructor and allocate a new object?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Interfaces">
+<chapter xml:id="_interfaces">
 <title>Interfaces</title>
 <blockquote>
 <attribution>
@@ -16451,13 +16691,13 @@ Edward Gibbon
 </blockquote>
 <section xml:id="_problem_sort_it_out">
 <title>Problem: Sort it out</title>
-<simpara>Defining classes as we did in Chapter <xref linkend="chapter:Classes"/> provides us
+<simpara>Defining classes as we did in <xref linkend="_classes"/> provides us
 with useful tools. First, we can group related data together. Then, we
 can encapsulate that data so that it can only be changed in carefully
 controlled ways. But these ideas are only a fraction of the true power
 of object orientation that becomes apparent when we exploit
 relationships between different classes. Eventually, in
-Chapter <xref linkend="chapter:Inheritance"/>, we will talk about hierarchical
+<xref linkend="_inheritance"/>, we will talk about hierarchical
 relationships, in which one class can be the parent of many other child
 classes. However, there is a simpler relationship that classes can
 share, the ability to do some specific action or answer some specific
@@ -16472,7 +16712,7 @@ age. Naturally, the age we are interested for a <literal>Dog</literal> is 7 time
 calendar age. At the same time, because a cat has nine lives, we will
 use <inlineequation><alt><![CDATA[\frac{1}{9}]]></alt><mathphrase><![CDATA[\frac{1}{9}]]></mathphrase></inlineequation> of its calendar age. The age we use for
 <literal>Person</literal> and <literal>Cheese</literal> objects is simply their calendar age.</simpara>
-<simpara>As we discussed in Example <xref linkend="example:Selection_sort"/>, sorting is one of
+<simpara>As we discussed in <xref linkend="selectionSortExample"/>, sorting is one of
 the most fundamental things that computer scientists do. In that
 example, we introduced selection sort. Here we are going to use another
 sort called bubble sort. We are introducing bubble sort to expose you to
@@ -16543,7 +16783,7 @@ each method with <literal>public</literal>, and it is illegal to mark them with 
 or <literal>protected</literal>.</simpara>
 <simpara>Here is an interface for a guitar player that defines two abstract
 methods.</simpara>
-<programlisting xml:id="program:Guitarist" xreflabel="Guitarist" language="java" linenumbering="numbered">public interface Guitarist {
+<programlisting xml:id="GuitaristProgram" language="java" linenumbering="numbered">public interface Guitarist {
 	void strumChord( Chord chord );
 	void playMelody( Melody notes );
 }</programlisting>
@@ -16551,7 +16791,7 @@ methods.</simpara>
 methods, declared with the access modifier <literal>public</literal>, the same return
 types, and the same parameters. We could create a <literal>RockGuitarist</literal> class
 that implements <literal>Guitarist</literal> as follows.</simpara>
-<programlisting xml:id="program:RockGuitarist" xreflabel="RockGuitarist" language="java" linenumbering="numbered">public class RockGuitarist implements Guitarist {
+<programlisting xml:id="RockGuitaristProgram" language="java" linenumbering="numbered">public class RockGuitarist implements Guitarist {
 	public void strumChord( Chord chord ) {
 		System.out.print("Totally wails on that " + chord.getName()
 				+ " chord!");
@@ -16566,7 +16806,7 @@ that implements <literal>Guitarist</literal> as follows.</simpara>
 going to approach playing a chord or a melody differently from a rock
 guitarist. Java only requires that all the methods in the interface are
 implemented.</simpara>
-<programlisting xml:id="program:ClassicalGuitarist" xreflabel="ClassicalGuitarist" language="java" linenumbering="numbered">public class ClassicalGuitarist implements Guitarist {
+<programlisting xml:id="ClassicalGuitaristProgram" language="java" linenumbering="numbered">public class ClassicalGuitarist implements Guitarist {
 	public void strumChord( Chord chord ) {
 		System.out.print( "Delicately voices a " + chord.getName()
 				+ " chord." );
@@ -16633,7 +16873,7 @@ Whether or not a method is <literal>static</literal> is considered by Java to be
 implementation detail that is not suitable to specify in an interface.
 For example, even with <literal>Chord</literal> and <literal>Melody</literal> defined, the following
 interface fails to compile.</simpara>
-<programlisting xml:id="program:StaticGuitarist" xreflabel="StaticGuitarist" language="java" linenumbering="numbered">public interface StaticGuitarist {
+<programlisting xml:id="StaticGuitaristProgram" language="java" linenumbering="numbered">public interface StaticGuitarist {
 	void strumChord( Chord chord );
 	void playMelody( Melody notes );
 	static int getStrings();
@@ -16645,7 +16885,7 @@ static methods in interfaces.</simpara>
 class constants are allowed. Thus, we could define <literal>static</literal> <literal>final</literal>
 values that might be useful to any class implementing an interface. With
 <literal>Chord</literal> and <literal>Melody</literal> defined, the following interface <emphasis role="strong">will</emphasis> compile.</simpara>
-<programlisting xml:id="program:ConstantGuitarist" xreflabel="ConstantGuitarist" language="java" linenumbering="numbered">public interface ConstantGuitarist {
+<programlisting xml:id="ConstantGuitaristProgram" language="java" linenumbering="numbered">public interface ConstantGuitarist {
 	static final int MAJOR = 1;
 	static final int NATURAL_MINOR = 2;
 	static final int HARMONIC_MINOR = 3;
@@ -16661,7 +16901,7 @@ since the purpose of an interface is to define a list of a requirements
 for what a class does rather than dealing with data values.
 Nevertheless, constants are allowed in interfaces, and the Java API does
 so in many cases.</simpara>
-<example>
+<example xml:id="supermarketPricingExample">
 <title>Supermarket pricing</title>
 <simpara>Interface names often include the suffix <emphasis>-able</emphasis>, for example,
 <literal>Runnable</literal>, <literal>Callable</literal>, and <literal>Comparable</literal>. This suffix is typical because
@@ -16669,12 +16909,12 @@ it reminds us that a class implementing an interface has some specific
 ability. Let’s consider an example in a supermarket in which the items
 could have very little in common with each other but they all have a
 price. We could define the interface <literal>Priceable</literal> as follows.</simpara>
-<programlisting xml:id="program:Priceable" xreflabel="Priceable" language="java" linenumbering="numbered">interface Priceable {
+<programlisting xml:id="PriceableProgram" language="java" linenumbering="numbered">interface Priceable {
 	double getPrice();
 }</programlisting>
 <simpara>If bananas cost $0.49 a pound, we can define the <literal>Bananas</literal> class as
 follows.</simpara>
-<programlisting xml:id="program:Bananas" xreflabel="Bananas" language="java" linenumbering="numbered">public class Bananas implements Priceable {
+<programlisting xml:id="BananasProgram" language="java" linenumbering="numbered">public class Bananas implements Priceable {
 	public static final double PRICE_PER_POUND = 0.49;
 	private double weight;
 
@@ -16686,7 +16926,7 @@ follows.</simpara>
 }</programlisting>
 <simpara>If eggs are $1.50 for a dozen large eggs and $1.75 for a dozen extra
 large eggs, we can define the <literal>Eggs</literal> class as follows.</simpara>
-<programlisting xml:id="program:Eggs" xreflabel="Eggs" language="java" linenumbering="numbered">public class Eggs implements Priceable {
+<programlisting xml:id="EggsProgram" language="java" linenumbering="numbered">public class Eggs implements Priceable {
 	public static final double PRICE_PER_DOZEN_LARGE = 1.5;
 	public static final double PRICE_PER_DOZEN_EXTRA_LARGE = 1.75;
 	private int dozens;
@@ -16706,7 +16946,7 @@ large eggs, we can define the <literal>Eggs</literal> class as follows.</simpara
 }</programlisting>
 <simpara>Finally, if water is $0.99 a gallon, we can define the <literal>Water</literal> class as
 follows.</simpara>
-<programlisting xml:id="program:Water" xreflabel="Water" language="java" linenumbering="numbered">public class Water implements Priceable {
+<programlisting xml:id="WaterProgram" language="java" linenumbering="numbered">public class Water implements Priceable {
     public static final double PRICE_PER_GALLON = 0.99;
     private int gallons;
 
@@ -16737,7 +16977,7 @@ interface type, we can make as many references to it as we want.</simpara>
 </section>
 <section xml:id="_advanced_local_and_anonymous_classes">
 <title>Advanced: Local and anonymous classes</title>
-<simpara>If you have not read Section <xref linkend="advanced:Nested_classes"/>, you may want
+<simpara>If you have not read <xref linkend="_advanced_nested_classes"/>, you may want
 to look over that material to be sure that you understand what nested
 classes and inner classes are. Recall that a normal inner class is
 declared inside of another class, but it is also legal to declare a
@@ -16799,7 +17039,7 @@ classes are not commonly used.</simpara>
 <simpara>However, we can make local classes more useful if they implement
 interfaces. Consider the following interface which can be implemented by
 any shape that returns its area.</simpara>
-<programlisting xml:id="program:AreaGettable" xreflabel="AreaGettable" language="java" linenumbering="numbered">public interface AreaGettable {
+<programlisting xml:id="AreaGettableProgram" language="java" linenumbering="numbered">public interface AreaGettable {
 	double getArea();
 }</programlisting>
 <simpara>The method below takes an array of <literal>AreaGettable</literal> objects and sums their
@@ -16842,7 +17082,7 @@ will expand the local <literal>Ellipse</literal> class in this way and fill an a
 <simpara>Even though the <literal>Ellipse</literal> class had the <literal>getArea()</literal> method before, the
 compiler would not have allowed us to store <literal>Ellipse</literal> references in an
 <literal>AreaGettable</literal> array until we marked the <literal>Ellipse</literal> class as implementing
-<literal>AreaGettable</literal>. As in Example <xref linkend="example:Supermarket_pricing"/>, we used
+<literal>AreaGettable</literal>. As in <xref linkend="supermarketPricingExample"/>, we used
 an array of the interface type.</simpara>
 </section>
 <section xml:id="subsection:_Anonymous_classes">
@@ -16907,13 +17147,13 @@ when a particular event happens. If you need many different listeners in
 one program, it can be convenient to create anonymous classes that can
 handle each event rather than defining many named classes which each
 have a single, narrow purpose. We will use this technique in
-Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/>.</simpara>
+<xref linkend="_constructing_graphical_user_interfaces"/>.</simpara>
 </section>
 </section>
 <section xml:id="_solution_sort_it_out">
 <title>Solution: Sort it out</title>
 <simpara>It is not difficult to move from totaling the value of items as we did
-in Example <xref linkend="example:Supermarket_pricing"/> to sorting them. Refer to the
+in <xref linkend="supermarketPricingExample"/> to sorting them. Refer to the
 following class diagram as we explain our solution to the sorting
 problem posed at the beginning of the chapter. Dotted lines are used to
 show the implements relationship.</simpara>
@@ -16928,21 +17168,21 @@ show the implements relationship.</simpara>
 </figure>
 <simpara>We will start with the definitions of the two interfaces we will use to
 compare objects.</simpara>
-<programlisting xml:id="program:Ageable" xreflabel="Ageable" language="java" linenumbering="numbered">public interface Ageable {
+<programlisting xml:id="AgeableProgram" language="java" linenumbering="numbered">public interface Ageable {
 	int getAge();
 }</programlisting>
-<programlisting xml:id="program:Weighable" xreflabel="Weighable" language="java" linenumbering="numbered">public interface Weighable {
+<programlisting xml:id="WeighableProgram" language="java" linenumbering="numbered">public interface Weighable {
 	double getWeight();
 }</programlisting>
 <simpara>Classes implementing these two interfaces will be able to give their age
 and weight independently. The next step is to create the <literal>Dog</literal>, <literal>Cat</literal>,
 <literal>Person</literal>, and <literal>Cheese</literal> classes which can do so.</simpara>
-<simpara>We’ll see in Chapter <xref linkend="chapter:Inheritance"/> that the <literal>Dog</literal>, <literal>Cat</literal>, and
+<simpara>We’ll see in <xref linkend="_inheritance"/> that the <literal>Dog</literal>, <literal>Cat</literal>, and
 <literal>Person</literal> classes could inherit from a common ancestor (such as
 <literal>Creature</literal> or <literal>Mammal</literal>) which implements the <literal>Ageable</literal> and <literal>Weighable</literal>
 interfaces. That design could reduce the total amount of code needed.
 For now, each class will have to implement both interfaces directly.</simpara>
-<programlisting xml:id="program:Dog" xreflabel="Dog" language="java" linenumbering="numbered">public class Dog implements Ageable, Weighable {
+<programlisting xml:id="DogProgram" language="java" linenumbering="numbered">public class Dog implements Ageable, Weighable {
 	private int age;
 	private double weight;
 
@@ -16968,7 +17208,7 @@ For now, each class will have to implement both interfaces directly.</simpara>
 
 	public int getWeight() { return weight; }
 }</programlisting>
-<programlisting xml:id="program:Person" xreflabel="Person" language="java" linenumbering="numbered">public class Person implements Ageable, Weighable {
+<programlisting xml:id="PersonProgram" language="java" linenumbering="numbered">public class Person implements Ageable, Weighable {
 	private int age;
 	private double weight;
 
@@ -16981,7 +17221,7 @@ For now, each class will have to implement both interfaces directly.</simpara>
 
 	public int getWeight() { return weight; }
 }</programlisting>
-<programlisting xml:id="program:Cheese" xreflabel="Cheese" language="java" linenumbering="numbered">public class Cheese implements Ageable, Weighable {
+<programlisting xml:id="CheeseProgram" language="java" linenumbering="numbered">public class Cheese implements Ageable, Weighable {
 	private int age;
 	private double weight;
 	private String type;
@@ -17045,11 +17285,11 @@ universal sorting methods, the Java API defines a <literal>Comparable</literal> 
 which can be implemented by any class which requires sorting. With Java
 5 and higher, the <literal>Comparable</literal> interface uses generics to be more
 type-safe, so we will not discuss how to use this interface until we
-cover generics in Chapter <xref linkend="chapter:Dynamic_Data_Structures"/>.</simpara>
+cover generics in <xref linkend="_dynamic_data_structures"/>.</simpara>
 </section>
 <section xml:id="_concurrency_interfaces">
 <title>Concurrency: Interfaces</title>
-<simpara>As we discussed in Section <xref linkend="concepts:Making_a_promise"/>, implementing
+<simpara>As we discussed in <xref linkend="_concepts_making_a_promise"/>, implementing
 an interface means making a promise to have public methods with the
 signatures specified in the interface definition. Making a promise seems
 only tangentially related to having multiple threads of execution.
@@ -17064,14 +17304,14 @@ makes intuitive sense. A regular program has a single starting place,
 the <literal>main()</literal> method. If we want to run additional threads, some method
 needs to be marked as a starting place for each one. For more
 information about using the <literal>Runnable</literal> interface, refer to
-Section <xref linkend="subsection:runnable"/>.</simpara>
+<xref linkend="_the_literal_runnable_literal_interface"/>.</simpara>
 <simpara>The second connection between interfaces and concurrency is more
 philosophical. What can you specify in an interface? The rules for
 interfaces in Java are relatively limited: You can require a class to
 have a public instance method with specific parameters and a specific
 return type. Java interfaces do not allow you to require a static
 method.</simpara>
-<simpara>In Chapter <xref linkend="chapter:Synchronization"/>, we will discuss a key way to
+<simpara>In <xref linkend="_synchronization"/>, we will discuss a key way to
 make classes thread-safe by using the<?asciidoc-br?>
 <literal>synchronized</literal> keyword. Like static, Java does not allow an interface to
 specify whether a method is synchronized. Thus, it is impossible to use
@@ -17086,29 +17326,30 @@ you read (or write) the documentation carefully. Since there is no way
 to force programmers to use the <literal>synchronized</literal> keyword, the
 documentation may be the only guide.</simpara>
 </section>
-<section xml:id="_exercises_9">
+<section xml:id="_exercises_10">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>What is the purpose of an interface?</simpara>
+<simpara><anchor xml:id="exercise10.1" xreflabel="[exercise10.1]"/> What is the purpose of an interface?</simpara>
 </listitem>
 <listitem>
-<simpara>Why implement an interface when it puts additional requirements on a
+<simpara><anchor xml:id="exercise10.2" xreflabel="[exercise10.2]"/> Why implement an interface when it puts additional requirements on a
 class yet adds no functionality?</simpara>
 </listitem>
 <listitem>
-<simpara>Is it legal to have methods marked <literal>private</literal> or <literal>protected</literal> in an
+<simpara><anchor xml:id="exercise10.3" xreflabel="[exercise10.3]"/> Is it legal to have methods marked <literal>private</literal> or <literal>protected</literal> in an
 interface? Why did the designers of Java make this choice?</simpara>
 </listitem>
 <listitem>
-<simpara>What is the <literal>instanceof</literal> keyword used for? Why is it useful in the
+<simpara><anchor xml:id="exercise10.4" xreflabel="[exercise10.4]"/> What is the <literal>instanceof</literal> keyword used for? Why is it useful in the
 context of interfaces?</simpara>
 </listitem>
 <listitem>
-<simpara>What kind of programming error causes a <literal>ClassCastException</literal>?</simpara>
+<simpara><anchor xml:id="exercise10.5" xreflabel="[exercise10.5]"/> What kind of programming error causes a <literal>ClassCastException</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara>Create an interface called <literal>ColorWavelengths</literal> that only contains
+<simpara><anchor xml:id="exercise10.6" xreflabel="[exercise10.6]"/> Create an interface called <literal>ColorWavelengths</literal> that only contains
 constants storing the wavelengths in nanometers for each of the seven
 colors of light, as given below.</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
@@ -17155,14 +17396,14 @@ colors of light, as given below.</simpara>
 </informaltable>
 </listitem>
 <listitem>
-<simpara>Write an interface called <literal>Clock</literal> that specifies the functionality a
+<simpara><anchor xml:id="exercise10.7" xreflabel="[exercise10.7]"/> Write an interface called <literal>Clock</literal> that specifies the functionality a
 clock should have. Remember that the classes that implement the clock
 may tell time in different ways (hourglass, water clock, mechanical
 movement, atomic clock), but they must share the basic functionality
 that you specify.</simpara>
 </listitem>
 <listitem>
-<simpara>There are four compiler errors in the following interface. Name each
+<simpara><anchor xml:id="exercise10.8" xreflabel="[exercise10.8]"/> There are four compiler errors in the following interface. Name each
 one and explain why it is an error.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public interface Singable {
     public int SOPRANO = 1;
@@ -17178,7 +17419,7 @@ one and explain why it is an error.</simpara>
 }</programlisting>
 </listitem>
 <listitem>
-<simpara>Consider the interface defined below.</simpara>
+<simpara><anchor xml:id="exercise10.9" xreflabel="[exercise10.9]"/> Consider the interface defined below.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public interface Explodable {
     boolean explode( double megatons );
 }</programlisting>
@@ -17211,7 +17452,7 @@ public class Firecracker implements Explodable {
 }</programlisting>
 </listitem>
 <listitem>
-<simpara>Write a single class that correctly implements the following three
+<simpara><anchor xml:id="exercise10.10" xreflabel="[exercise10.10]"/> Write a single class that correctly implements the following three
 interfaces.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public interface Laughable {
     boolean laugh( int times );
@@ -17220,35 +17461,34 @@ interfaces.</simpara>
     void cry( int tears, boolean moaning );
 }</programlisting>
 <programlisting language="java" linenumbering="unnumbered">public interface Shoutable {
-    void laugh( double volume, String words );
+    void shout( double volume, String words );
 }</programlisting>
 </listitem>
 <listitem>
-<simpara>If you are sorting a list of items <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> elements long
+<simpara><anchor xml:id="exercise10.11" xreflabel="[exercise10.11]"/> If you are sorting a list of items <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> elements long
 using bubble sort, what is the minimum number of passes you would need
 to be sure the list is sorted, assuming the worst possible ordering of
 items to start with? (Hint: Imagine the list is in backwards order.)
-What is the minimum number of passes if the list is already sorted?
-<emphasis role="strong">Programming Practice</emphasis></simpara>
+What is the minimum number of passes if the list is already sorted?</simpara>
+<simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Add client code that randomly creates the objects needing sorting in
-the solution from Section <xref linkend="solution:Sort_it_out"/>. Design and include
+<simpara><anchor xml:id="exercise10.12" xreflabel="[exercise10.12]"/> Add client code that randomly creates the objects needing sorting in
+the solution from <xref linkend="_solution_sort_it_out"/>. Design and include
 additional classes <literal>Wine</literal> and <literal>Tortoise</literal> that both implement <literal>Ageable</literal>
 and <literal>Weighable</literal>. Add <literal>toString()</literal> methods to each class so that their
 contents can be easily output. Make sure that you print out the list of
 objects after sorting to test your implementation.</simpara>
 </listitem>
 <listitem>
-<simpara>Refer to the sort given as a solution in Section <xref linkend="solution:Sort it
-out"/>. Add another <literal>boolean</literal> to the parameters of the sort which
+<simpara><anchor xml:id="exercise10.13" xreflabel="[exercise10.13]"/> Refer to the sort given as a solution in <xref linkend="_solution_sort_it_out"/>. Add another <literal>boolean</literal> to the parameters of the sort which
 specifies whether the sort is ascending or descending. Make the needed
 changes throughout the code to add this functionality.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:parallelBubbleSort"/> After learning about threads in
-Chapter <xref linkend="chapter:Concurrent_Programming"/>, refer to the simple bubble
-sort from Section <xref linkend="problem:Sort_it_out"/>. The goal is now to
+<simpara><anchor xml:id="exercise10.14" xreflabel="[exercise10.14]"/> After learning about threads in
+<xref linkend="_concurrent_programming"/>, refer to the simple bubble
+sort from <xref linkend="_problem_sort_it_out"/>. The goal is now to
 parallelize the sort. Write some code which will generate an array of
 random <literal>int</literal> values. Design your code so that you can spawn
 <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> threads. Partition the single array into <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>
@@ -17267,8 +17507,8 @@ arrays which are being merged.</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Once you have implemented the sort in parallel from
-Exercise <xref linkend="exercise:parallelBubbleSort"/>, time it against the sequential
+<simpara><anchor xml:id="exercise10.15" xreflabel="[exercise10.15]"/> Once you have implemented the sort in parallel from
+<link linkend="exercise10.14">Exercise 10.14</link>, time it against the sequential
 version. Try two, four, and eight different threads. Be sure to create
 one random array and use copies of the same array for both the parallel
 and sequential versions. Be careful not to sort an array that is already
@@ -17278,7 +17518,7 @@ performance increase? Was it as much as you expected?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Inheritance">
+<chapter xml:id="_inheritance">
 <title>Inheritance</title>
 <blockquote>
 <attribution>
@@ -17291,7 +17531,7 @@ And though they are with you yet they belong not to you.</simpara>
 </blockquote>
 <section xml:id="_problem_boolean_circuits">
 <title>Problem: Boolean circuits</title>
-<simpara>In Chapter <xref linkend="chapter:Selection"/>, we talked extensively about Boolean
+<simpara>In <xref linkend="_selection"/>, we talked extensively about Boolean
 algebra and how it can be applied to <literal>if</literal> statements in order to control
 the flow of execution in your program. The commands that we give in
 software must be executed by hardware in order to have an effect. It
@@ -17391,7 +17631,7 @@ sections.</simpara>
 <title>Concepts: Refining classes</title>
 <simpara>Here we give a brief overview of inheritance that will give us enough
 information to continue onward. We cover some of the deeper areas of the
-subject in Chapter <xref linkend="chapter:Polymorphism"/>.</simpara>
+subject in <xref linkend="_polymorphism"/>.</simpara>
 <section xml:id="_basic_inheritance">
 <title>Basic inheritance</title>
 <simpara>The process of creating an inherited class out of an existing class is
@@ -17459,7 +17699,7 @@ Let&#8217;s give an example using the <literal>Fish</literal> class defined belo
 creates a basic fish that can swim, feed, and die. We can check its
 color, location, and whether or not it is alive. When it runs out of
 energy, it dies.</simpara>
-<programlisting xml:id="program:Fish" xreflabel="Fish" language="java" linenumbering="numbered">import java.awt.*;
+<programlisting xml:id="FishProgram" language="java" linenumbering="numbered">import java.awt.*;
 
 public class Fish {
 	protected Color color = Color.GRAY;
@@ -17493,7 +17733,7 @@ the new class name, followed by the parent class name (in this case
 <simpara>Just as we are allowed to make an empty class, we are allowed to make an
 inherited class and add nothing, but doing so is pointless. Instead, we
 can make a <literal>Flounder</literal> class that can change its color.</simpara>
-<programlisting xml:id="program:Flounder" xreflabel="Flounder" language="java" linenumbering="numbered">public class Flounder extends Fish {
+<programlisting xml:id="FlounderProgram" language="java" linenumbering="numbered">public class Flounder extends Fish {
 	public void setColor( Color newColor ) { color = newColor; }
 }</programlisting>
 <simpara>The <literal>Flounder</literal> class can do everything a <literal>Fish</literal> can: It can swim, feed,
@@ -17504,7 +17744,7 @@ swim over. Note that the <literal>color</literal> field in the <literal>Fish</li
 point.</simpara>
 <simpara>Here is a <literal>Shark</literal> class that extends <literal>Fish</literal> in another ways, by adding
 the capability of eating other <literal>Fish</literal>.</simpara>
-<programlisting xml:id="program:Shark" xreflabel="Shark" language="java" linenumbering="numbered">public class Shark extends Fish {
+<programlisting xml:id="SharkProgram" language="java" linenumbering="numbered">public class Shark extends Fish {
 	public void eat( Fish fish ) {
 		fish.die();
 		feed();
@@ -17524,7 +17764,7 @@ In multiple inheritance, a single class can have many different parents.
 Since C supports multiple inheritance, you can have a
 <literal>SharkAlligatorMan</literal> class in that language that inherits from the
 <literal>Shark</literal>, <literal>Alligator</literal>, and <literal>Human</literal> classes. If you go back to the sorting
-problem from Chapter <xref linkend="chapter:Interfaces"/>, multiple inheritance would
+problem from <xref linkend="_interfaces"/>, multiple inheritance would
 allow us to solve the problem with an <literal>Age</literal> class and a <literal>Weight</literal> class
 from which <literal>Dog</literal>, <literal>Cat</literal>, <literal>Person</literal>, and <literal>Cheese</literal> all inherit.</simpara>
 <simpara>However, the designers of Java decided not to allow multiple
@@ -17554,7 +17794,7 @@ interfaces, each interface in an extends list is separated by commas.</simpara>
 (and constants) they define. If a class implements an interface that
 extends other interfaces, it must contain versions of all the methods
 specified by <emphasis role="strong">all</emphasis> the interfaces. Recall the <literal>Ageable</literal> and <literal>Weighable</literal>
-interfaces from Chapter <xref linkend="chapter:Interfaces"/>, which specified the
+interfaces from <xref linkend="_interfaces"/>, which specified the
 <literal>getAge()</literal> and <literal>getWeight()</literal> methods, respectively. We could create an
 interface that required both of these methods by extending <literal>Ageable</literal> and
 <literal>Weighable</literal>.</simpara>
@@ -17585,7 +17825,7 @@ since there was no mutator to change it.</simpara>
 so it might be good design to prevent outside code from changing the
 <literal>color</literal> field with such a mutator. There are no absolute rules for
 making these kinds of decisions.</simpara>
-<simpara>We introduced access modifiers in Section <xref linkend="subsection:Access_modifiers"/>, but inheritance gives them new meaning. Recall that the
+<simpara>We introduced access modifiers in <xref linkend="_access_modifiers"/>, but inheritance gives them new meaning. Recall that the
 access modifier for the <literal>color</literal> field of <literal>Fish</literal> was <literal>protected</literal>. A field
 or method with the <literal>protected</literal> modifier can be accessed by all child
 classes (as well as classes in the same package). If the modifier for
@@ -17603,7 +17843,7 @@ are not inadvertently corrupted.</simpara>
 parent class exists inside of the child. When you create an object from
 a child class, how do you properly initialize the fields inside the
 parent class?</simpara>
-<simpara>As we discussed in Chapter <xref linkend="chapter:Classes"/>, every class has a
+<simpara>As we discussed in <xref linkend="_classes"/>, every class has a
 constructor, even if it is a default one created for you. Whenever the
 constructor for a child class is invoked, the constructor for the parent
 class is invoked as well. If the parent class is also the child of some
@@ -17616,12 +17856,12 @@ call the parent constructor, its default (no parameter) constructor will
 be called. If the parent class does not have a default constructor, then
 leaving off an appropriate call to a parent constructor will result in a
 compiler error. Consider the following two classes.</simpara>
-<programlisting xml:id="program:Parent" xreflabel="Parent" language="java" linenumbering="numbered">public class Parent {
+<programlisting xml:id="ParentProgram" language="java" linenumbering="numbered">public class Parent {
 	private String name;
 	public Parent( String name ) { this.name = name; }
 	public String getName() { return name; }
 }</programlisting>
-<programlisting xml:id="program:Child" xreflabel="Child" language="java" linenumbering="numbered">public class Child extends Parent {
+<programlisting xml:id="ChildProgram" language="java" linenumbering="numbered">public class Child extends Parent {
 	public Child( String name ) {
 		super( "Baby " + name );
 	}
@@ -17652,7 +17892,7 @@ The return type must be either exactly the same or a child class of the
 original return type.</simpara>
 <simpara>We can return to the <literal>Fish</literal> class example and make a new kind of fish
 that never moves.</simpara>
-<programlisting xml:id="program:LazyFish" xreflabel="LazyFish" language="java" linenumbering="numbered">public class LazyFish extends Fish {
+<programlisting xml:id="LazyFishProgram" language="java" linenumbering="numbered">public class LazyFish extends Fish {
 	public void swim() {
 		System.out.println("I think I'll just sit here.");
 	}
@@ -17662,7 +17902,7 @@ will just announce that it is going to sit where it is. Its location is
 not updated and its energy does not change.</simpara>
 <simpara>On the other hand, we could create another child class that swims twice
 as fast as the original <literal>Fish</literal>.</simpara>
-<programlisting xml:id="program:FastFish" xreflabel="FastFish" language="java" linenumbering="numbered">public class FastFish extends Fish {
+<programlisting xml:id="FastFishProgram" language="java" linenumbering="numbered">public class FastFish extends Fish {
 	public void swim() {
 		super.swim();
 		super.swim();
@@ -17685,12 +17925,12 @@ other words, there is no way to call something like a
 <simpara>Just as methods are overridden, fields are <emphasis>hidden</emphasis>. It is perfectly
 legal to declare a field with the same name as a field from a parent
 class, but the new field will then be used instead of the old one.</simpara>
-<programlisting xml:id="program:A" xreflabel="A" language="java" linenumbering="numbered">public class A {
+<programlisting xml:id="AProgram" language="java" linenumbering="numbered">public class A {
 	protected int a;
 	public int getA() { return a; }
 	public void setA( int value ) { a = value; }
 }</programlisting>
-<programlisting xml:id="program:B" xreflabel="B" language="java" linenumbering="numbered">public class B extends A {
+<programlisting xml:id="BProgram" language="java" linenumbering="numbered">public class B extends A {
 	protected int a;
 	public void setA( int value ) { a = value; }
 }</programlisting>
@@ -17759,7 +17999,7 @@ tables of objects.</simpara></entry>
 <row>
 <entry align="left" valign="top"><simpara><literal>notify()</literal></simpara></entry>
 <entry align="left" valign="top"><simpara>Used for synchronization with threaded programs. More in
-Chapter <xref linkend="chapter:Synchronization"/>.</simpara></entry>
+<xref linkend="_synchronization"/>.</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara><literal>notifyAll()</literal></simpara></entry>
@@ -17785,24 +18025,24 @@ methods. Aside from making a few useful methods available, having a
 common ancestor for all classes means that you can store any object in
 an <literal>Object</literal> reference. An array of type <literal>Object</literal> can hold anything,
 provided that you know how to retrieve it. We discuss the finer points
-of inheritance and polymorphism in Chapter <xref linkend="chapter:Polymorphism"/> and
+of inheritance and polymorphism in <xref linkend="_polymorphism"/> and
 how to build lists and other data structures using <literal>Object</literal> references
-in Chapter <xref linkend="chapter:Dynamic_Data_Structures"/>.</simpara>
+in <xref linkend="_dynamic_data_structures"/>.</simpara>
 </section>
 </section>
 <section xml:id="_examples_problem_solving_with_inheritance">
 <title>Examples: Problem solving with inheritance</title>
 <simpara>Here are two extended examples showing how we can use inheritance to
 solve problems. First, we revisit the student roster example from
-Chapter <xref linkend="chapter:Classes"/> and then move onto an inheritance hierarchy
+<xref linkend="_classes"/> and then move onto an inheritance hierarchy
 of polygons.</simpara>
 <example>
 <title>Graduate student roster</title>
-<simpara>The <literal>Student</literal> class we create in Chapter <xref linkend="chapter:Classes"/> is useful
+<simpara>The <literal>Student</literal> class we create in <xref linkend="_classes"/> is useful
 but works only for undergraduate students. With only a few additions, we
 can make it suitable for graduate students as well. First, lets take
 another look at the <literal>Student</literal> class.</simpara>
-<formalpara xml:id="program:Student" xreflabel="Student">
+<formalpara xml:id="StudentProgram">
 <title>Basic student class, designed for undergraduates.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class Student {
@@ -17843,7 +18083,7 @@ another look at the <literal>Student</literal> class.</simpara>
 <literal>Student</literal>. We need to add a thesis topic for each graduate student.
 Likewise, we need to update the <literal>toString()</literal> method so that outputs the
 appropriate data. We use <literal>4</literal> as the year value for graduate students.</simpara>
-<formalpara xml:id="program:GraduateStudent" xreflabel="GraduateStudent">
+<formalpara xml:id="GraduateStudentProgram">
 <title>Class extending <literal>Student</literal> to add graduate student capabilities.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class GraduateStudent extends Student {
@@ -17917,7 +18157,7 @@ of the perimeter by adding the lengths of the segments connecting the
 vertices. It is possible to determine the area enclosed by a list of
 vertices, but the algorithm is complex. The <literal>draw()</literal> method draws the
 polygon by drawing each line segment that connects adjacent vertices. We
-discuss the <literal>Graphics</literal> class in Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/>. If you compile and run this code, please note that in
+discuss the <literal>Graphics</literal> class in <xref linkend="_constructing_graphical_user_interfaces"/>. If you compile and run this code, please note that in
 Java graphics, like many computer graphics environments, the upper left
 hand corner of the screen or window is considered (0,0), and
 <inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation> values <emphasis role="strong">increase</emphasis> going downward, not upward.</simpara>
@@ -17965,7 +18205,7 @@ we can determine whether the triangle represented is equilateral,
 isosceles, or scalene. Of course, computing the perimeter and drawing
 the triangle are already taken care of by the <literal>Polygon</literal> class.</simpara>
 <simpara>We can easily make a <literal>Rectangle</literal> class along the same lines.</simpara>
-<programlisting xml:id="program:Rectangle" xreflabel="Rectangle" language="java" linenumbering="numbered">import java.awt.*;
+<programlisting xml:id="RectangleProgram" language="java" linenumbering="numbered">import java.awt.*;
 
 public class Rectangle extends Polygon {
 	public Rectangle( int x, int y, int length, int width ) {
@@ -17993,7 +18233,7 @@ values is generated. The rectangle-specific code that we add is the
 rectangle by examining the <literal>points</literal> array and then calculates area.</simpara>
 <simpara>Using inheritance as form of specialization, we can go one step further
 and make a <literal>Square</literal> class.</simpara>
-<programlisting xml:id="program:Square" xreflabel="Square" language="java" linenumbering="numbered">public class Square extends Rectangle {
+<programlisting xml:id="SquareProgram" language="java" linenumbering="numbered">public class Square extends Rectangle {
 	public Square(int x, int y, int size ) {
 		super( x, y, size, size );
 	}
@@ -18007,7 +18247,7 @@ enter both length and width.</simpara>
 <title>Solution: Boolean circuits</title>
 <simpara>Here we present our solution to the Boolean Circuits problem. First, we
 define a parent class for all circuit components, called <literal>Gate</literal>.</simpara>
-<programlisting xml:id="program:Gate" xreflabel="Gate" language="java" linenumbering="numbered">public class Gate {
+<programlisting xml:id="GateProgram" language="java" linenumbering="numbered">public class Gate {
 	private String name;
 
 	public Gate( String name ) { this.name = name; }
@@ -18022,11 +18262,11 @@ and to get a value. From <literal>Gate</literal>, we can define the most basic c
 components: gates whose value is either always true or always false. It
 doesn&#8217;t really matter what <literal>getValue()</literal> gives back for <literal>Gate</literal>, but we
 can say that it is <literal>false</literal>.</simpara>
-<programlisting xml:id="program:True" xreflabel="True" language="java" linenumbering="numbered">public class True extends Gate {
+<programlisting xml:id="TrueProgram" language="java" linenumbering="numbered">public class True extends Gate {
 	public True() { super("true"); }
 	public boolean getValue() { return true; }
 }</programlisting>
-<programlisting xml:id="program:False" xreflabel="False" language="java" linenumbering="numbered">public class False extends Gate {
+<programlisting xml:id="FalseProgram" language="java" linenumbering="numbered">public class False extends Gate {
 	public False() { super("false"); }
 	public boolean getValue() { return false; }
 }</programlisting>
@@ -18034,7 +18274,7 @@ can say that it is <literal>false</literal>.</simpara>
 a <literal>String</literal> giving their name to the <literal>super</literal> constructor. The values
 returned by the <literal>getValue()</literal> method are clear. Next, we want to create a
 class that can be used for general unary operators.</simpara>
-<programlisting xml:id="program:UnaryOperator" xreflabel="UnaryOperator" language="java" linenumbering="numbered">public class UnaryOperator extends Gate {
+<programlisting xml:id="UnaryOperatorProgram" language="java" linenumbering="numbered">public class UnaryOperator extends Gate {
 	private Gate input;
 
 	public UnaryOperator( String name ) { super( name ); }
@@ -18046,11 +18286,11 @@ field. Any unary operator must have a single input gate that it operates
 on. This class provides a mutator and accessor for <literal>input</literal>, as well as
 an appropriate constructor. From <literal>UnaryOperator</literal>, we can derive two
 specific operators.</simpara>
-<programlisting xml:id="program:Output" xreflabel="Output" language="java" linenumbering="numbered">public class Output extends UnaryOperator {
+<programlisting xml:id="OutputProgram" language="java" linenumbering="numbered">public class Output extends UnaryOperator {
 	public Output( int i ) { super( "OUTPUT " + i ); }
 	public boolean getValue() { return getInput().getValue(); }
 }</programlisting>
-<programlisting xml:id="program:Not" xreflabel="Not" language="java" linenumbering="numbered">public class Not extends UnaryOperator {
+<programlisting xml:id="NotProgram" language="java" linenumbering="numbered">public class Not extends UnaryOperator {
 	public Not() { super("NOT"); }
 	public boolean getValue() { return !(getInput().getValue()); }
 }</programlisting>
@@ -18062,7 +18302,7 @@ the <literal>super</literal> constructor and returns the logical NOT of the valu
 input.</simpara>
 <simpara>Just as we did for unary operators, we also need a base class for binary
 operators.</simpara>
-<programlisting xml:id="program:BinaryOperator" xreflabel="BinaryOperator" language="java" linenumbering="numbered">public class BinaryOperator extends Gate {
+<programlisting xml:id="BinaryOperatorProgram" language="java" linenumbering="numbered">public class BinaryOperator extends Gate {
 	private Gate operand1;
 	private Gate operand2;
 
@@ -18077,7 +18317,7 @@ representing the inputs to the operator. The <literal>BinaryOperator</literal> c
 an appropriate constructor and then accessors and mutators for the
 operands. With <literal>BinaryOperator</literal> as a parent, only a few lines of code
 are necessary to define any logical binary operator.</simpara>
-<programlisting xml:id="program:And" xreflabel="And" language="java" linenumbering="numbered">public class And extends BinaryOperator {
+<programlisting xml:id="AndProgram" language="java" linenumbering="numbered">public class And extends BinaryOperator {
 	public And() { super("AND"); }
 
 	public boolean getValue() {
@@ -18085,7 +18325,7 @@ are necessary to define any logical binary operator.</simpara>
 			getOperand1().getValue();
 	}
 }</programlisting>
-<programlisting xml:id="program:Or" xreflabel="Or" language="java" linenumbering="numbered">public class Or extends BinaryOperator {
+<programlisting xml:id="OrProgram" language="java" linenumbering="numbered">public class Or extends BinaryOperator {
 	public Or() { super("OR"); }
 
 	public boolean getValue() {
@@ -18093,7 +18333,7 @@ are necessary to define any logical binary operator.</simpara>
 			getOperand1().getValue();
 	}
 }</programlisting>
-<programlisting xml:id="program:Xor" xreflabel="Xor" language="java" linenumbering="numbered">public class Xor extends BinaryOperator {
+<programlisting xml:id="XorProgram" language="java" linenumbering="numbered">public class Xor extends BinaryOperator {
 	public Xor() { super("XOR"); }
 
 	public boolean getValue() {
@@ -18191,11 +18431,11 @@ concurrency deserve attention.</simpara>
 whose type inherits from <literal>Thread</literal>. Creating such types is done by
 extending <literal>Thread</literal>, just as you would extend any other class. Further
 information about extending <literal>Thread</literal> for concurrency is given in
-Section <xref linkend="syntax:Threads_in_Java"/>. Extending the <literal>Thread</literal> class to make
+<xref linkend="_syntax_threads_in_java"/>. Extending the <literal>Thread</literal> class to make
 your own customized threads of execution is an alternative to
 implementing the <literal>Runnable</literal> interface mentioned in
-Section <xref linkend="concurrency:Interfaces"/> and is discussed in greater detail in
-Section <xref linkend="subsection:runnable"/>.</simpara>
+<xref linkend="_concurrency_interfaces"/> and is discussed in greater detail in
+<xref linkend="_the_literal_runnable_literal_interface"/>.</simpara>
 <simpara>The second interaction between inheritance and concurrency is again very
 similar to the problem with interfaces and concurrency: There is no way
 to specify that a method is thread-safe. Recall that it is not allowed
@@ -18206,7 +18446,7 @@ synchronized method with a non-synchronized method or vice versa.</simpara>
 child class is usable anywhere that an object of the parent class is
 usable. Thus, you cannot override a public method with a private one,
 reducing the visibility of a method. We discuss a similar restriction
-with exceptions in Section <xref linkend="subsection:Inheritance_and_exceptions"/>.</simpara>
+with exceptions in <xref linkend="_inheritance_and_exceptions"/>.</simpara>
 <simpara>If it has these restrictions, why doesn&#8217;t Java prevent a synchronized
 method from being overridden by a non-synchronized method? In the first
 place, a non-synchronized method can be used anywhere a synchronized one
@@ -18218,16 +18458,17 @@ others (even child classes) do not. However, if you override a class
 with a synchronized method, it is safest to mark your method
 synchronized as well.</simpara>
 </section>
-<section xml:id="_exercises_10">
+<section xml:id="_exercises_11">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>Give three advantages of using inheritance instead of copying and
+<simpara><anchor xml:id="exercise11.1" xreflabel="[exercise11.1]"/> Give three advantages of using inheritance instead of copying and
 pasting code from a parent class. Are there any disadvantages to using
 inheritance?</simpara>
 </listitem>
 <listitem>
-<simpara>Consider classes <literal>Radish</literal> and <literal>Carrot</literal> which both extend class
+<simpara><anchor xml:id="exercise11.2" xreflabel="[exercise11.2]"/> Consider classes <literal>Radish</literal> and <literal>Carrot</literal> which both extend class
 <literal>Vegetable</literal> and implement interface <literal>Crunchable</literal>. Which of the following
 sets of assignments are legal and why?</simpara>
 <orderedlist numeration="loweralpha">
@@ -18249,11 +18490,11 @@ sets of assignments are legal and why?</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>In the context of inheritance, the keyword <literal>super</literal> can be used for
+<simpara><anchor xml:id="exercise11.3" xreflabel="[exercise11.3]"/> In the context of inheritance, the keyword <literal>super</literal> can be used for
 two different purposes. What are they?</simpara>
 </listitem>
 <listitem>
-<simpara>Consider the following class definitions.</simpara>
+<simpara><anchor xml:id="exercise11.4" xreflabel="[exercise11.4]"/> Consider the following class definitions.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class A {
     private String value;
     public A(String s) { value = "A" + s + "A"; }
@@ -18272,38 +18513,38 @@ public class C extends B {
 System.out.println(c);</programlisting>
 </listitem>
 <listitem>
-<simpara>Beginning Java programmers often confuse package-private access (no
+<simpara><anchor xml:id="exercise11.5" xreflabel="[exercise11.5]"/> Beginning Java programmers often confuse package-private access (no
 explicit specifier) with <literal>public</literal> access. How is this confusion possible
 when default access is more constrained than both <literal>public</literal> and
 <literal>protected</literal> access? (Hint: The file system plays a role.)</simpara>
 </listitem>
 <listitem>
-<simpara>What are the similarities and differences between overloading a
+<simpara><anchor xml:id="exercise11.6" xreflabel="[exercise11.6]"/> What are the similarities and differences between overloading a
 method and overriding a method?</simpara>
 </listitem>
 <listitem>
-<simpara>What is field hiding? How can software bugs arise from this
+<simpara><anchor xml:id="exercise11.7" xreflabel="[exercise11.7]"/> What is field hiding? How can software bugs arise from this
 functionality in Java?</simpara>
 </listitem>
 <listitem>
-<simpara>Give reasons why the designers of Java decided not to allow multiple
+<simpara><anchor xml:id="exercise11.8" xreflabel="[exercise11.8]"/> Give reasons why the designers of Java decided not to allow multiple
 inheritance. Would you have made the same decision? Why or why not?</simpara>
 </listitem>
 <listitem>
-<simpara>Draw a class hierarchy establishing a sensible relationship between
+<simpara><anchor xml:id="exercise11.9" xreflabel="[exercise11.9]"/> Draw a class hierarchy establishing a sensible relationship between
 the <literal>Human</literal>, <literal>Soldier</literal>, <literal>Sailor</literal>, <literal>Marine</literal>, <literal>General</literal>, and <literal>Admiral</literal>
 classes. For this class hierarchy, refer to the U.S. military structure
 in which the U.S. Marine Corps is a part of the U.S. Navy.</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Create an <literal>InternationalStudent</literal> class that extends <literal>Student</literal>. It
+<simpara><anchor xml:id="exercise11.10" xreflabel="[exercise11.10]"/> Create an <literal>InternationalStudent</literal> class that extends <literal>Student</literal>. It
 should include <literal>String</literal> fields for country of origin and also visa
 status. It should include mutator and accessor methods for these two new
 fields.</simpara>
 </listitem>
 <listitem>
-<simpara>Add <literal>Pentagon</literal> and <literal>Hexagon</literal> classes that extend the <literal>Polygon</literal>
+<simpara><anchor xml:id="exercise11.11" xreflabel="[exercise11.11]"/> Add <literal>Pentagon</literal> and <literal>Hexagon</literal> classes that extend the <literal>Polygon</literal>
 class. The constructor for each class should take an <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation>,
 <inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation> and radius value, each of <literal>int</literal> type. Both classes
 should be implemented to create <emphasis>regular</emphasis> polygons, that is, polygons in
@@ -18319,17 +18560,17 @@ trigonometry to determine their locations. As a result, the final
 pentagons and hexagons stored and displayed will be slightly irregular.</simpara>
 </listitem>
 <listitem>
-<simpara>The inheritance design of our solution to the Boolean circuits
-problem given in Section <xref linkend="solution:Boolean_circuits"/> makes adding new
+<simpara><anchor xml:id="exercise11.12" xreflabel="[exercise11.12]"/> The inheritance design of our solution to the Boolean circuits
+problem given in <xref linkend="_solution_boolean_circuits"/> makes adding new
 gates easy. Add classes that implement a NAND gate and a NOR gate. Then,
 rewrite the <literal>main()</literal> method of <literal>BooleanCircuit</literal> to accommodate these two
 extra classes.</simpara>
 </listitem>
 <listitem>
-<simpara>Re-implement the object hierarchy in the solution to the sort it out
-problem from Chapter <xref linkend="chapter:Interfaces"/>. This time, let the <literal>Cat</literal>,
+<simpara><anchor xml:id="exercise11.13" xreflabel="[exercise11.13]"/> Re-implement the object hierarchy in the solution to the sort it out
+problem from <xref linkend="_interfaces"/>. This time, let the <literal>Cat</literal>,
 <literal>Dog</literal>, and <literal>Person</literal> classes extend the <literal>Creature</literal> class defined below.</simpara>
-<programlisting xml:id="program:Creature" xreflabel="Creature" language="java" linenumbering="numbered">public class Creature implements Ageable, Weighable {
+<programlisting xml:id="CreatureProgram" language="java" linenumbering="numbered">public class Creature implements Ageable, Weighable {
 	protected int age;
 	protected double weight;
 
@@ -18346,7 +18587,7 @@ problem from Chapter <xref linkend="chapter:Interfaces"/>. This time, let the <
 short as possible. How many lines of code do you save?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:celestial"/> Design a celestial body simulator. You will
+<simpara><anchor xml:id="exercise11.14" xreflabel="[exercise11.14]"/> Design a celestial body simulator. You will
 need to create a class containing fields for the <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation>,
 <inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation>, and <inlineequation><alt><![CDATA[z]]></alt><mathphrase><![CDATA[z]]></mathphrase></inlineequation> locations, <inlineequation><alt><![CDATA[x]]></alt><mathphrase><![CDATA[x]]></mathphrase></inlineequation>,
 <inlineequation><alt><![CDATA[y]]></alt><mathphrase><![CDATA[y]]></mathphrase></inlineequation>, and <inlineequation><alt><![CDATA[z]]></alt><mathphrase><![CDATA[z]]></mathphrase></inlineequation> velocities, radii, and masses of
@@ -18381,7 +18622,7 @@ object using the equation
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Inheritance is a powerful technique, but it comes with some overhead
+<simpara><anchor xml:id="exercise11.15" xreflabel="[exercise11.15]"/> Inheritance is a powerful technique, but it comes with some overhead
 costs. Create a class called <literal>A</literal> with the following implementation.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class A {
     protected int a;
@@ -18394,7 +18635,7 @@ you create an object of type <literal>Z</literal>, it will contain, through inhe
 26 <literal>int</literal> fields named <literal>a</literal> through <literal>z</literal>. But, for a single <literal>Z</literal> object to
 be created, it must call 27 (<literal>Z</literal> back through <literal>A</literal> plus <literal>Object</literal>)
 constructors. You may wish to use the file I/O material in
-Chapter <xref linkend="chapter:File_I/O"/> to write a program to create all these
+<xref linkend="_file_i_o"/> to write a program to create all these
 classes so that you do not have to do so by hand.</simpara>
 <simpara>Finally, create a new class called <literal>All</literal> which contains 26 <literal>protected</literal>
 fields of <literal>int</literal> type named <literal>a</literal> through <literal>z</literal>. Now, the purpose of doing
@@ -18405,13 +18646,13 @@ fields named <literal>a</literal> through <literal>z</literal>.</simpara>
 with 100,000 <literal>Z</literal> objects. Time this process. Create an array of 100,000
 elements of type <literal>All</literal> and then populate that array with 100,000 <literal>All</literal>
 objects. You may wish to use the <literal>System.nanoTime()</literal> method described in
-Chapter <xref linkend="chapter:Concurrent_Programming"/> to accurately time these
+<xref linkend="_concurrent_programming"/> to accurately time these
 processes. Is there a significant difference in the times you found?</simpara>
 </listitem>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Exceptions">
+<chapter xml:id="_exceptions">
 <title>Exceptions</title>
 <blockquote>
 <attribution>
@@ -18553,8 +18794,11 @@ mixed in with normal code. Doing so reduces code readability and makes
 it difficult to centralize error handling. Likewise, a numerical value
 can be difficult to deal with. A user may have to look it up to find out
 what kind of error it is.</simpara>
+<sidebar>
+<simpara><link linkend="exercise12.1">Exercise 12.1</link></simpara>
+</sidebar>
 </section>
-<section xml:id="exceptions">
+<section xml:id="_exceptions_2">
 <title>Exceptions</title>
 <simpara>Java adopts a different error handling strategy called exceptions.
 Whenever a specified error state or unusual situation is reached, an
@@ -18689,13 +18933,16 @@ legal variable name. Usually, the kind of exception is all you need to
 know, but every exception is an object and has fields and methods.
 Particularly useful is the <literal>getMessage()</literal> method which can give
 additional information about the exception.</simpara>
+<sidebar>
+<simpara><link linkend="exercise12.10">Exercise 12.10</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_catch_or_specify">
 <title>Catch or specify</title>
 <simpara>Despite the examples given above, you will rarely write code to catch a
 <literal>NullPointerException</literal> or an <literal>ArithmeticException</literal>. Both of these
 exceptions are called <emphasis>unchecked</emphasis> exceptions. In
-Chapter <xref linkend="chapter:Arrays"/>, we used the <literal>Thread.sleep()</literal> method to put
+<xref linkend="_arrays"/>, we used the <literal>Thread.sleep()</literal> method to put
 the execution of our program to sleep for a short period of time. We
 were forced to enclose this method call in a <literal>try</literal> block with a <literal>catch</literal>
 block for <literal>InterruptedException</literal>.</simpara>
@@ -18717,10 +18964,17 @@ with that name exists or that the user might not have permission to
 access it. A program should catch the corresponding exceptions and
 recover rather than crashing. Perhaps the program should prompt the user
 for a new name or explain that the required permission is not set.</simpara>
-<simpara>In Chapter <xref linkend="chapter:Arrays"/>, there were no executable statements in
+<sidebar>
+<simpara><link linkend="exercise12.5">Exercise 12.5</link><?asciidoc-br?>
+<link linkend="exercise12.8">Exercise 12.8</link></simpara>
+</sidebar>
+<simpara>In <xref linkend="_arrays"/>, there were no executable statements in
 the <literal>catch</literal> block used with the<?asciidoc-br?>
 <literal>Thread.sleep()</literal> method. You should <emphasis role="strong">never</emphasis> write an empty <literal>catch</literal>
 block. Doing so allows errors to fail silently.</simpara>
+<sidebar>
+<simpara><link linkend="exercise12.6">Exercise 12.6</link></simpara>
+</sidebar>
 <simpara>We are allowed to put code that can throw a checked exception into a
 <literal>try</literal>-<literal>catch</literal> block, but there is another possibility. Java has a catch
 or specify requirement, meaning that your code is required either to
@@ -18728,6 +18982,10 @@ catch a checked exception or to specify that it has the potential for
 causing that exception. To specify that a method can throw certain
 exceptions, we use the <literal>throws</literal> keyword. Note that this is <emphasis role="strong">not</emphasis> the
 same as the <literal>throw</literal> keyword.</simpara>
+<sidebar>
+<simpara><link linkend="exercise12.3">Exercise 12.3</link><?asciidoc-br?>
+<link linkend="exercise12.4">Exercise 12.4</link></simpara>
+</sidebar>
 <programlisting language="java" linenumbering="unnumbered">public static void sleepWithoutTry( int milliseconds ) throws InterruptedException {
     Thread.sleep( milliseconds );
 }</programlisting>
@@ -18757,7 +19015,7 @@ following a <literal>try</literal> block. The code inside the <literal>finally</
 executed <emphasis role="strong">whether or not</emphasis> any exception was thrown. A <literal>finally</literal> block is
 often used with file I/O to close the file, which should be closed
 whether or not something went wrong in the process of reading it as we
-demonstrate in Chapter <xref linkend="chapter:File_I/O"/></simpara>
+demonstrate in <xref linkend="_file_i_o"/></simpara>
 <simpara>The <literal>finally</literal> keyword is unusually powerful. If an exception is not
 caught and propagates up another level, the <literal>finally</literal> block will be
 executed before propagating the exception. Even a <literal>return</literal> statement
@@ -18778,6 +19036,11 @@ unusual semantics. Use them sparingly and only for careful cleanup
 operations when necessary to guarantee that some event occurs.</simpara>
 <simpara>Code in a <literal>finally</literal> block will execute <emphasis role="strong">no matter what</emphasis> unless the JVM
 exits or the thread in question terminates.</simpara>
+<sidebar>
+<simpara><link linkend="exercise12.2">Exercise 12.2</link><?asciidoc-br?>
+<link linkend="exercise12.9">Exercise 12.9</link><?asciidoc-br?>
+<link linkend="exercise12.11">Exercise 12.11</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_customized_exceptions">
 <title>Customized exceptions</title>
@@ -18810,6 +19073,11 @@ considered good style to end the name of any exception class with
 add other fields or methods to give your exception the functionality it
 needs, go ahead. However, the main value of an exception is simply in
 its existence as a named error, not in any tricks it can perform.</simpara>
+<sidebar>
+<simpara><link linkend="exercise12.12">Exercise 12.12</link><?asciidoc-br?>
+<link linkend="exercise12.13">Exercise 12.13</link><?asciidoc-br?>
+<link linkend="exercise12.14">Exercise 12.14</link></simpara>
+</sidebar>
 <simpara>Here we will give a few examples of exception handling, although
 exceptions are more useful in large systems with heavy API use. We will
 start with an example of a simple calculator that detects division by
@@ -18904,24 +19172,27 @@ real exceptions that are generated because of real errors. Third, the
 code becomes difficult to read and unintuitive. Finally, excessive use
 of exceptions can negatively impact performance.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise12.15">Exercise 12.15</link></simpara>
+</sidebar>
 <example>
 <title>Color ranges</title>
 <simpara>The <literal>Color</literal> class provided by Java allows us to represent a color as a
 triple of red, green, and blue values with each value in the range
-<inlineequation><alt><![CDATA[[0,255]]></alt><mathphrase><![CDATA[[0,255]]></mathphrase></inlineequation>]. Using these three components, we can produce
-<inlineequation><alt><![CDATA[256^3 = 16,777,216]]></alt><mathphrase><![CDATA[256^3 = 16,777,216]]></mathphrase></inlineequation> colors. If we were programming some
+[0,255]. Using these three components, we can produce
+256<superscript>3</superscript> = 16,777,216 colors. If we were programming some
 image manipulation software, we might want to be able to increase the
 red, green, or blue values separately. If changing a value makes it
 larger than 255, we could throw an exception. Likewise, if changing a
 value makes it less than 0, we could throw a different exception. Let&#8217;s
 give two custom exceptions that could serve in these roles.</simpara>
-<programlisting xml:id="program:ColorUnderflowException" xreflabel="ColorUnderflowException" language="java" linenumbering="numbered">public class ColorUnderflowException extends Exception {
+<programlisting xml:id="ColorUnderflowExceptionProgram" language="java" linenumbering="numbered">public class ColorUnderflowException extends Exception {
 	public ColorUnderflowException( String message ) {
 		super( message );
 	}
 	public ColorComponentTooSmallException() { super(); }
 }</programlisting>
-<programlisting xml:id="program:ColorOverflowException" xreflabel="ColorOverflowException" language="java" linenumbering="numbered">public class ColorOverflowException extends Exception {
+<programlisting xml:id="ColorOverflowExceptionProgram" language="java" linenumbering="numbered">public class ColorOverflowException extends Exception {
 	public ColorOverflowException( String message ) {
 		super( message );
 	}
@@ -19030,25 +19301,25 @@ assignment could happen.</simpara>
 <simpara>Here is our solution to the bank burglary problem. Although somewhat
 fanciful, the process could be expanded into a more serious simulation.
 We begin by defining each of the exceptions.</simpara>
-<programlisting xml:id="program:BurglarAlarmException" xreflabel="BurglarAlarmException" language="java" linenumbering="numbered">public class BurglarAlarmException extends Exception {
+<programlisting xml:id="BurglarAlarmExceptionProgram" language="java" linenumbering="numbered">public class BurglarAlarmException extends Exception {
 	public BurglarAlarmException( String message ) {
 		super( message );
 	}
 	public BurglarAlarmException() { super(); }
 }</programlisting>
-<programlisting xml:id="program:WatchmanException" xreflabel="WatchmanException" language="java" linenumbering="numbered">public class WatchmanException extends Exception {
+<programlisting xml:id="WatchmanExceptionProgram" language="java" linenumbering="numbered">public class WatchmanException extends Exception {
 	public WatchmanException( String message ) {
 		super( message );
 	}
 	public WatchmanException() { super(); }
 }</programlisting>
-<programlisting xml:id="program:LockPickFailException" xreflabel="LockPickFailException" language="java" linenumbering="numbered">public class LockPickFailException extends Exception {
+<programlisting xml:id="LockPickFailExceptionProgram" language="java" linenumbering="numbered">public class LockPickFailException extends Exception {
 	public LockPickFailException( String message ) {
 		super( message );
 	}
 	public LockPickFailException() { super(); }
 }</programlisting>
-<programlisting xml:id="program:LootTooHeavyException" xreflabel="LootTooHeavyException" language="java" linenumbering="numbered">public class LootTooHeavyException extends Exception {
+<programlisting xml:id="LootTooHeavyExceptionProgram" language="java" linenumbering="numbered">public class LootTooHeavyException extends Exception {
 	public LootTooHeavyException( String message ) {
 		super( message );
 	}
@@ -19144,8 +19415,8 @@ method will crash the program, completely halting execution. In a
 multi-threaded program, execution will continue on all threads that have
 not thrown exceptions. If even a single thread is executing, the program
 will run to completion before the JVM shuts down.</simpara>
-<formalpara xml:id="program:CrazyThread" xreflabel="CrazyThread">
-<title>This program spawns 10 threads. 9 out of 10 spawned threads as well as the main thread throw an exception and die. The remaining thread outputs the sum of the sines of 1 through 1,000,000.</title>
+<formalpara xml:id="CrazyThreadProgram">
+<title>Spawns 10 threads. 9 out of 10 spawned threads as well as the main thread throw an exception and die. The remaining thread outputs the sum of the sines of 1 through 1,000,000.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class CrazyThread extends Thread {
 	private int value;
@@ -19179,7 +19450,7 @@ because of the<?asciidoc-br?>
 <literal>catch</literal> blocks. The thread with a <literal>value</literal> of 7 will complete its
 calculation and print it to the screen even though the main thread has
 died. For more information on how to spawn threads, refer to
-Chapter <xref linkend="chapter:Concurrent_Programming"/>.</simpara>
+<xref linkend="_concurrent_programming"/>.</simpara>
 </example>
 <simpara>This behavior can cause a program that never seems to finish. You might
 write a program that spawns a number of threads and does some work. Even
@@ -19211,48 +19482,49 @@ causing such an exception. Although we will generally leave the
 for production code should always handle interruptions gracefully.</simpara>
 </section>
 </section>
-<section xml:id="_exercises_11">
+<section xml:id="_exercises_12">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara><xref linkend="exercise:exceptions_vs._error_codes"/> What are the advantages of
+<simpara><anchor xml:id="exercise12.1" xreflabel="[exercise12.1]"/> What are the advantages of
 using exceptions instead of returning error codes?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:final_and_finally"/> The keywords <literal>final</literal> and <literal>finally</literal>,
+<simpara><anchor xml:id="exercise12.2" xreflabel="[exercise12.2]"/> The keywords <literal>final</literal> and <literal>finally</literal>,
 as well as the <literal>Object</literal> method <literal>finalize()</literal>, are sometimes confused.
 What is the purpose of each one?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:throws_keyword"/> What is the difference between the
+<simpara><anchor xml:id="exercise12.3" xreflabel="[exercise12.3]"/> What is the difference between the
 <literal>throw</literal> keyword and the <literal>throws</literal> keyword?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:catch_or_specify"/> Explain the catch or specify
+<simpara><anchor xml:id="exercise12.4" xreflabel="[exercise12.4]"/> Explain the catch or specify
 requirement of Java.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:checked_vs._unchecked"/> What must be done differently
+<simpara><anchor xml:id="exercise12.5" xreflabel="[exercise12.5]"/> What must be done differently
 when using methods that throw checked exceptions as compared to
 unchecked exceptions? How do the classes <literal>Exception</literal>,<?asciidoc-br?>
 <literal>RuntimeException</literal>, and <literal>Error</literal> play a role?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:whole_program_in_try"/> For every program you write, you
+<simpara><anchor xml:id="exercise12.6" xreflabel="[exercise12.6]"/> For every program you write, you
 could choose to put the entire body of your <literal>main()</literal> method in a large
 <literal>try</literal> block with a <literal>catch</literal> block at the end that catches <literal>Exception</literal>. In
 this way, no exception would cause your program to crash. Why is this
 approach a bad programming decision?</simpara>
 </listitem>
 <listitem>
-<simpara>Why did the designers of Java choose to make <literal>NullPointerException</literal>
+<simpara><anchor xml:id="exercise12.7" xreflabel="[exercise12.7]"/> Why did the designers of Java choose to make <literal>NullPointerException</literal>
 and<?asciidoc-br?>
 <literal>ArithmeticException</literal> unchecked exceptions even though this choice means
 that a program that unintentionally dereferences a <literal>null</literal> pointer or
 divides by zero will often crash.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:checked_example"/> Consider the following two classes.</simpara>
+<simpara><anchor xml:id="exercise12.8" xreflabel="[exercise12.8]"/> Consider the following two classes.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class Trouble {
     public makeTrouble() {
         throw new ArithmeticException();
@@ -19268,7 +19540,7 @@ public class Hazard {
 and what could be done to make <literal>Hazard</literal> compile.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:finally_returns"/> What value will the following method
+<simpara><anchor xml:id="exercise12.9" xreflabel="[exercise12.9]"/> What value will the following method
 always return and why?</simpara>
 <programlisting language="java" linenumbering="unnumbered">public static int magic( String value ) {
     try {
@@ -19285,7 +19557,7 @@ always return and why?</simpara>
 }</programlisting>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:specific_exceptions_first"/> Why will the following
+<simpara><anchor xml:id="exercise12.10" xreflabel="[exercise12.10]"/> Why will the following
 segment of code fail to compile?</simpara>
 <programlisting language="java" linenumbering="unnumbered">try{
     Thread.sleep(1000);
@@ -19298,7 +19570,7 @@ catch( InterruptedException e ) {
 }</programlisting>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:multiple_exceptions"/> Consider the following fragment of
+<simpara><anchor xml:id="exercise12.11" xreflabel="[exercise12.11]"/> Consider the following fragment of
 Java.</simpara>
 <programlisting language="java" linenumbering="unnumbered">try {
     throw new NullPointerException();
@@ -19313,22 +19585,18 @@ up from this code and why?</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>The <xref linkend="exercise:calculator_exceptions"/> <literal>NumberFormatException</literal>
-exception is thrown whenever the<?asciidoc-br?>
-<literal>Integer.parseInt()</literal> method receives a poorly formatted <literal>String</literal>
-representation of an integer. Re-implement <literal>QuickCalculator</literal> to catch
-any <literal>NumberFormatException</literal> and give an appropriate message to the user.</simpara>
+<simpara><anchor xml:id="exercise12.12" xreflabel="[exercise12.12]"/> The <literal>NumberFormatException</literal>
+exception is thrown whenever the <literal>Integer.parseInt()</literal> method receives a poorly formatted <literal>String</literal> representation of an integer. Re-implement <literal>QuickCalculator</literal> to catch any <literal>NumberFormatException</literal> and give an appropriate message to the user.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:celestial_exceptions"/> Refer to
-Exercise <xref linkend="exercise:celestial"/> from Chapter <xref linkend="chapter:Inheritance"/>.
-Add to the basic mechanics of the simulation by designing two custom
+<simpara><anchor xml:id="exercise12.13" xreflabel="[exercise12.13]"/> Refer to
+<link linkend="exercise11.14">Exercise 11.14</link> and add to the basic mechanics of the simulation by designing two custom
 exceptions, <literal>CollisionException</literal> and <literal>LightSpeedException</literal>. These
 exceptions should be thrown, respectively, if two bodies collide or if
 the total magnitude of a body&#8217;s velocity exceeds the speed of light.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:password_checker"/> Users often log onto systems by
+<simpara><anchor xml:id="exercise12.14" xreflabel="[exercise12.14]"/> Users often log onto systems by
 entering their user name and a password. Unfortunately, human beings are
 notoriously bad at picking passwords. In computer security, a tool
 called a <emphasis>proactive password checker</emphasis> allows a user to pick a password
@@ -19379,7 +19647,7 @@ you will need to define each of the four exceptions as well.</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Throwing <xref linkend="exercise:exception_performance"/> and catching exceptions
+<simpara><anchor xml:id="exercise12.15" xreflabel="[exercise12.15]"/> Throwing and catching exceptions
 is a useful tool for making robust programs in Java. However, the JVM
 machinery needed to implement such a powerful tool is complex. Create an
 array containing 100,000 random <literal>int</literal> values. First, sum all these
@@ -19395,7 +19663,7 @@ implications for code that routinely throws thousands of exceptions?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Concurrent_Programming">
+<chapter xml:id="_concurrent_programming">
 <title>Concurrent Programming</title>
 <blockquote>
 <attribution>
@@ -19455,14 +19723,17 @@ some care to coordinate these workers. First of all, we still need to
 get the right answer. A concurrent solution is worthless if it is
 incorrect, and by reading and writing to the same shared memory, answers
 found by one core can corrupt answers found by other cores. Preventing
-that problem will be addressed in Chapter <xref linkend="chapter:Synchronization"/>.
+that problem will be addressed in <xref linkend="_synchronization"/>.
 If we are sure the concurrent solution is correct, we also want to
 improve performance in some way. Perhaps we want the task to finish more
 quickly. Perhaps we have an interactive system that should continue to
 handle user requests even though it is working on a solution in the
 background. Again, if the overhead of coordinating our workers takes
 more time than a sequential solution or makes the system less
-responsive, it is not useful.</simpara>
+responsive, it&#8217;s not useful.</simpara>
+<sidebar>
+<simpara><link linkend="exercise13.10">Exercise 13.10</link></simpara>
+</sidebar>
 <simpara>There are two main ways to split up work. The first is called <emphasis>task
 decomposition</emphasis>. In this approach, each worker is given a different job
 to do. The second is called <emphasis>domain decomposition</emphasis>. In this approach,
@@ -19487,10 +19758,13 @@ the dinner couldn&#8217;t finish until certain supplies had been bought.</simpar
 many tasks have natural divisions. Unfortunately, it is not always an
 effective way to use multiple cores on a computer. If one task finishes
 long before the others, a core might sit idle.</simpara>
+<sidebar>
+<simpara><link linkend="exercise13.9">Exercise 13.9</link></simpara>
+</sidebar>
 <simpara>The next two examples give simple illustrations of the process of
 splitting a task into smaller subtasks in the context of multicore
 programming.</simpara>
-<example>
+<example xml:id="videoGameTasksExample">
 <title>Video game tasks</title>
 <simpara>Consider a simple video game that consists of the following tasks.</simpara>
 <orderedlist numeration="arabic">
@@ -19510,7 +19784,7 @@ programming.</simpara>
 <simpara>end game</simpara>
 </listitem>
 </orderedlist>
-<figure role="text-center">
+<figure xml:id="figure-video_game_tasks" role="text-center">
 <title>Execution of tasks in a video game. (a) Sequential execution on a single core. (b) Concurrent execution on two cores. Arrows show the flow of execution and data transfer.</title>
 <mediaobject>
 <imageobject>
@@ -19522,7 +19796,7 @@ programming.</simpara>
 <simpara>Suppose that tasks B and D are independent and can be executed
 concurrently if two cores are available. Task D continually updates the
 screen with the old data until task C updates the information.</simpara>
-<simpara>Figure <xref linkend="figure:video_game_tasks"/>(a) and (b) show how the tasks in this
+<simpara><xref linkend="figure-video_game_tasks"/>(a) and (b) show how the tasks in this
 video game can be sequenced, respectively, on a single core or on two
 cores. All tasks are executed sequentially on a single-core processor.
 In a dual-core processor tasks B and C can execute on one core while
@@ -19532,7 +19806,7 @@ continuously updating the screen. Having two cores can allow a faster
 refresh of the display as the processor does not have to wait for tasks
 B or C to complete.</simpara>
 </example>
-<example>
+<example xml:id="mathExpressionTasksExample">
 <title>Math expression tasks</title>
 <simpara>Suppose that the following mathematical expression is to be evaluated
 for parameters <inlineequation><alt><![CDATA[a]]></alt><mathphrase><![CDATA[a]]></mathphrase></inlineequation> and <inlineequation><alt><![CDATA[K]]></alt><mathphrase><![CDATA[K]]></mathphrase></inlineequation> at a given value of
@@ -19544,7 +19818,7 @@ Each of these terms can be assigned to a different task for evaluation.
 On a dual-core processor, these two tasks can be executed on separate
 cores and the results from each combined to generate the value of the
 expression by the main task.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-math_evaluation" role="text-center">
 <title>Evaluation of a mathematical expression (a) sequentially on a single core and (b) concurrently on two cores. Arrows show the flow of execution and data transfer. Bold typeface indicates the operation being performed.</title>
 <mediaobject>
 <imageobject>
@@ -19553,13 +19827,17 @@ expression by the main task.</simpara>
 <textobject><phrase>mathematical expression evaluation</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>Figure <xref linkend="figure:math_evaluation"/> shows how this expression can be
+<simpara><xref linkend="figure-math_evaluation"/> shows how this expression can be
 evaluated on single core and dual-core processors. Sometimes, using
 multiple cores to evaluate an expression like this will take less time
 than a single core. However, there is no guarantee that using multiple
 cores will always be faster, because tasks take time to set up and to
 communicate with each other.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise13.4">Exercise 13.4</link><?asciidoc-br?>
+<link linkend="exercise13.5">Exercise 13.5</link></simpara>
+</sidebar>
 <simpara>These examples illustrate how a task can be divided into two or more
 subtasks executed by different cores of a processor. We use a dual-core
 processor for our examples, but the same ideas can be expanded to a
@@ -19592,7 +19870,7 @@ is called the <emphasis>map</emphasis> step. Combining the partial answers into 
 answer is called the <emphasis>reduce</emphasis> step.</simpara>
 <simpara>We illustrate the domain decomposition strategy in the next two
 examples.</simpara>
-<example>
+<example xml:id="arraySummationPreviewExample">
 <title>Array summation preview</title>
 <simpara>Suppose that we want to apply function <inlineequation><alt><![CDATA[f()]]></alt><mathphrase><![CDATA[f()]]></mathphrase></inlineequation> to each element
 of an array <inlineequation><alt><![CDATA[A]]></alt><mathphrase><![CDATA[A]]></mathphrase></inlineequation> and sum the results. Mathematically, we want
@@ -19611,7 +19889,7 @@ S_2 =\sum_{i=\lfloor \frac{N}{2} \rfloor +1}^{N} f\left(a(i)\right)]]></mathphra
 <simpara>Assuming that <inlineequation><alt><![CDATA[N]]></alt><mathphrase><![CDATA[N]]></mathphrase></inlineequation> is even, both cores process exactly the
 same amount of data. For odd <inlineequation><alt><![CDATA[N]]></alt><mathphrase><![CDATA[N]]></mathphrase></inlineequation>, one of the cores processes
 one more data item than the other.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-array_decomposition" role="text-center">
 <title>Computing the sum of a function of each element of an array.</title>
 <mediaobject>
 <imageobject>
@@ -19622,11 +19900,11 @@ one more data item than the other.</simpara>
 </figure>
 <simpara>After <inlineequation><alt><![CDATA[S_1]]></alt><mathphrase><![CDATA[S_1]]></mathphrase></inlineequation> and <inlineequation><alt><![CDATA[S_2]]></alt><mathphrase><![CDATA[S_2]]></mathphrase></inlineequation> have been computed, one of
 the cores can add these two numbers together to get <inlineequation><alt><![CDATA[S]]></alt><mathphrase><![CDATA[S]]></mathphrase></inlineequation>.
-This strategy is illustrated in Figure <xref linkend="figure:array_decomposition"/>.
+This strategy is illustrated in <xref linkend="figure-array_decomposition"/>.
 After the two cores have completed their work on each half of the array,
 the individual sums are added together to produce the final sum.</simpara>
 </example>
-<example>
+<example xml:id="matrixMultiplicationPreviewExample">
 <title>Matrix multiplication preview</title>
 <simpara>The need to multiply matrices arises in many mathematical, scientific,
 and engineering applications. Suppose we are asked to write a program to
@@ -19636,7 +19914,7 @@ are both <inlineequation><alt><![CDATA[n\times n]]></alt><mathphrase><![CDATA[n\
 program will compute each element of matrix <inlineequation><alt><![CDATA[C]]></alt><mathphrase><![CDATA[C]]></mathphrase></inlineequation> one at a
 time. However, a concurrent program can compute more than one element of
 <inlineequation><alt><![CDATA[C]]></alt><mathphrase><![CDATA[C]]></mathphrase></inlineequation> simultaneously using multiple cores.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-matrix_decomposition" role="text-center">
 <title>Data decomposition to multiply two <inlineequation><alt><![CDATA[4\times 4]]></alt><mathphrase><![CDATA[4\times 4]]></mathphrase></inlineequation> matrices. The two cores perform the same multiplication tasks but on different data from matrix <inlineequation><alt><![CDATA[A]]></alt><mathphrase><![CDATA[A]]></mathphrase></inlineequation>. The two cores compute the top and bottom two rows of <inlineequation><alt><![CDATA[C]]></alt><mathphrase><![CDATA[C]]></mathphrase></inlineequation>, respectively.</title>
 <mediaobject>
 <imageobject>
@@ -19647,7 +19925,7 @@ time. However, a concurrent program can compute more than one element of
 </figure>
 <simpara>In this problem, the task is to multiply matrices <inlineequation><alt><![CDATA[A]]></alt><mathphrase><![CDATA[A]]></mathphrase></inlineequation> and
 <inlineequation><alt><![CDATA[B]]></alt><mathphrase><![CDATA[B]]></mathphrase></inlineequation>. Through domain decomposition, we can replicate this
-task on each core. As shown in Figure <xref linkend="figure:matrix_decomposition"/>,
+task on each core. As shown in <xref linkend="figure-matrix_decomposition"/>,
 each core computes only a portion of <inlineequation><alt><![CDATA[C]]></alt><mathphrase><![CDATA[C]]></mathphrase></inlineequation>. For example, if
 <inlineequation><alt><![CDATA[A]]></alt><mathphrase><![CDATA[A]]></mathphrase></inlineequation> and <inlineequation><alt><![CDATA[B]]></alt><mathphrase><![CDATA[B]]></mathphrase></inlineequation> are <inlineequation><alt><![CDATA[4\times 4]]></alt><mathphrase><![CDATA[4\times 4]]></mathphrase></inlineequation>
 matrices, we can ask one core to compute the product of the first two
@@ -19678,13 +19956,12 @@ tell which core a given thread is using.</simpara>
 it takes care to package up the right set of tasks into a single thread
 of execution. Recall the previous examples of concurrent programming in
 this chapter.</simpara>
-<simpara>Consider dividing the tasks in Example <xref linkend="example:Video_game_tasks"/> into
+<simpara>Consider dividing the tasks in <xref linkend="videoGameTasksExample"/> into
 two threads. Tasks B and C in can be packaged into thread 1, and task D
 can be packaged into thread 2. This division is shown in
-Figure <xref linkend="figure:tasks_in_threads"/>(a).</simpara>
-<simpara>Tasks to evaluate different subexpressions in Example <xref linkend="example:Math
-expression tasks"/> can also be divided into two threads as shown in
-Figure <xref linkend="figure:tasks_in_threads"/>(b). In many problems there are
+<xref linkend="figure-tasks_in_threads"/>(a).</simpara>
+<simpara>Tasks to evaluate different subexpressions in <xref linkend="mathExpressionTasksExample"/> can also be divided into two threads as shown in
+<xref linkend="figure-tasks_in_threads"/>(b). In many problems there are
 several reasonable ways of dividing a set of subtasks into threads.</simpara>
 <simpara>Note that these figures look exactly like the earlier figures, except
 that the tasks are grouped as threads instead of cores. This grouping is
@@ -19694,18 +19971,16 @@ into threads but not how they are assigned to cores.</simpara>
 thread started these threads running. Every Java program, concurrent or
 sequential, starts with one thread. We will refer to this thread as the
 <emphasis>main</emphasis> thread since it contains the <literal>main()</literal> method.</simpara>
-<simpara>Examples <xref linkend="example:Array_summation_preview"/> and <xref linkend="example:Matrix
-multiplication preview"/> use multiple identical tasks. But these tasks
-operate on different data. Nevertheless, in Example <xref linkend="example:Array
-summation preview"/>, the two tasks can be assigned two threads that
+<simpara><xref linkend="arraySummationPreviewExample"/> and <xref linkend="matrixMultiplicationPreviewExample"/> use multiple identical tasks. But these tasks
+operate on different data. Nevertheless, in <xref linkend="arraySummationPreviewExample"/>, the two tasks can be assigned two threads that
 operate on different portions of the input array. The task of summing
 the results from the two threads can either be a separate thread or a
 subtask included in one of the other threads. In
-Example <xref linkend="example:Matrix_multiplication_preview"/>, the two tasks can
+<xref linkend="matrixMultiplicationPreviewExample"/>, the two tasks can
 again be assigned to two distinct threads that operate on different
 parts of the input matrix <inlineequation><alt><![CDATA[A]]></alt><mathphrase><![CDATA[A]]></mathphrase></inlineequation> to generate the corresponding
 portions of the output matrix <inlineequation><alt><![CDATA[C]]></alt><mathphrase><![CDATA[C]]></mathphrase></inlineequation>.</simpara>
-<figure>
+<figure xml:id="figure-tasks_in_threads">
 <title>(a) Tasks in a video game shown packaged into two threads. (b) Tasks to evaluate a mathematical expression shown packaged into two threads. Each thread may or may not run on the same core as the other.</title>
 <mediaobject>
 <imageobject>
@@ -19784,15 +20059,14 @@ applications begin with a single main thread which starts in a <literal>main()</
 method. Additional threads must start somewhere, and that place is the
 <literal>run()</literal> method. A Java application will continue to run as long as at
 least one thread is active. The following example shows two threads,
-each evaluating a separate subexpression as in Figure <xref linkend="figure:tasks in
-threads"/>(b).</simpara>
-<example>
+each evaluating a separate subexpression as in <xref linkend="figure-tasks_in_threads"/>(b).</simpara>
+<example xml:id="threadSamplesExample">
 <title>Thread samples</title>
 <simpara>We will create <literal>Thread1</literal> and <literal>Thread2</literal> classes. The threads of execution
 created by instances of these classes compute, respectively, the two
-subexpressions in Figure <xref linkend="figure:tasks_in_threads"/>(b) and save the
+subexpressions in <xref linkend="figure-tasks_in_threads"/>(b) and save the
 computed values.</simpara>
-<programlisting xml:id="program:Thread1" xreflabel="Thread1" language="java" linenumbering="numbered">public class Thread1 extends Thread {
+<programlisting xml:id="Thread1Program" language="java" linenumbering="numbered">public class Thread1 extends Thread {
 	private double K, a, t, value;
 
 	public Thread1(double K, double a, double t) {
@@ -19803,7 +20077,7 @@ computed values.</simpara>
 	public void run() { value = 2*K*a*t; }
 	public double getValue() { return value; }
 }</programlisting>
-<programlisting xml:id="program:Thread2" xreflabel="Thread2" language="java" linenumbering="numbered">public class Thread2 extends Thread {
+<programlisting xml:id="Thread2Program" language="java" linenumbering="numbered">public class Thread2 extends Thread {
 	private double a, t, value;
 
 	public  Thread2(double a, double t) {
@@ -19815,7 +20089,7 @@ computed values.</simpara>
 }</programlisting>
 <simpara>The <literal>run()</literal> method in each thread above computes a subexpression and
 saves its value. We show how these threads can be executed to solve the
-math expression problem in Example <xref linkend="example:Math_expression_threads"/>.</simpara>
+math expression problem in <xref linkend="mathExpressionThreadsExample"/>.</simpara>
 </example>
 </section>
 <section xml:id="_creating_a_thread_object">
@@ -19868,17 +20142,19 @@ interrupted the main thread, forcing it to stop waiting for <literal>thread1</li
 <simpara>In earlier versions of Java, there was a <literal>stop()</literal> method which would
 stop an executing thread. Although this method still exists, it has been
 deprecated and should not be used.</simpara>
-<example>
+<sidebar>
+<simpara><link linkend="exercise13.1">Exercise 13.1</link></simpara>
+</sidebar>
+<example xml:id="mathExpressionThreadsExample">
 <title>Math expression threads</title>
 <simpara>Now that we have the syntax to start threads and wait for them to
-finish, we can use the threads defined in Example <xref linkend="example:Thread
-samples"/> with a main thread to make our first complete concurrent
+finish, we can use the threads defined in <xref linkend="threadSamplesExample"/> with a main thread to make our first complete concurrent
 program. The main thread in class <literal>MathExpression</literal> creates and starts
 the worker threads <literal>thread1</literal> and <literal>thread2</literal> and waits for their
 completion. When the two threads complete their execution, we can ask
 each for its computed value. The main thread then prints the product of
 these values, which is the result of the expression we want to evaluate.</simpara>
-<programlisting xml:id="program:MathExpression" xreflabel="MathExpression" language="java" linenumbering="numbered">public class MathExpression {
+<programlisting xml:id="MathExpressionProgram" language="java" linenumbering="numbered">public class MathExpression {
     public static void main (String[] args) {
         double K = 120, a = 1.2, t = 2;
         Thread1 thread1 = new Thread1(K, a, t);
@@ -19898,7 +20174,7 @@ these values, which is the result of the expression we want to evaluate.</simpar
 }</programlisting>
 <simpara>We want to make it absolutely clear when threads are created, start
 executing, and finish. These details are crucial for the finer points of
-concurrent Java programming. In Figure <xref linkend="figure:tasks_in_threads"/>, it
+concurrent Java programming. In <xref linkend="figure-tasks_in_threads"/>, it
 appears as if execution of the concurrent math expression evaluation
 begins with Thread 1 which spawns Thread 2. Although that figure
 explains the basics of task decomposition well, the details are messier
@@ -19908,12 +20184,12 @@ for real Java code.</simpara>
 for them to finish. Then, it reads the values from the objects after
 they have stopped executing. We could have put the <literal>main()</literal> method in
 the <literal>Thread1</literal> class, omitting the <literal>MathExpression</literal> class entirely. Doing
-so would make the execution match Figure <xref linkend="figure:tasks_in_threads"/>
+so would make the execution match <xref linkend="figure-tasks_in_threads"/>
 more closely, but it would make the two <literal>Thread</literal> subclasses less
 symmetrical: The main thread and <literal>thread1</literal> would both independently
 execute code inside the <literal>Thread1</literal> class while only <literal>thread2</literal> would
 execute code inside the <literal>Thread2</literal> class.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-thread_execution" role="text-center">
 <title>Creation, starting, and joining of threads in <literal>MathExpression</literal>, <literal>Thread1</literal>, and <literal>Thread2</literal>.</title>
 <mediaobject>
 <imageobject>
@@ -19922,7 +20198,7 @@ execute code inside the <literal>Thread2</literal> class.</simpara>
 <textobject><phrase>thread lifecycle</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>Figure <xref linkend="figure:thread_execution"/> shows the execution of <literal>thread1</literal> and
+<simpara><xref linkend="figure-thread_execution"/> shows the execution of <literal>thread1</literal> and
 <literal>thread2</literal> and the main thread. Note that the creation and start of the
 main thread is done implicitly by the JVM while <literal>thread1</literal> and <literal>thread2</literal>
 are created explicitly and started by the main thread. Even after the
@@ -19931,7 +20207,7 @@ the objects continue to exist. Methods and fields can continue to be
 accessed.</simpara>
 </example>
 </section>
-<section xml:id="subsection:runnable">
+<section xml:id="_the_literal_runnable_literal_interface">
 <title>The <literal>Runnable</literal> interface</title>
 <simpara>Although it is possible to create Java threads by inheriting from the
 <literal>Thread</literal> class directly, the Java API allows the programmer to use an
@@ -19985,12 +20261,15 @@ to design classes that implement <literal>Runnable</literal> instead of inheriti
 <literal>Thread</literal>. Why? Java only allows for single inheritance. If your class
 implements <literal>Runnable</literal>, it is free to inherit from another parent class
 with the features you want.</simpara>
-<example>
+<sidebar>
+<simpara><link linkend="exercise13.2">Exercise 13.2</link></simpara>
+</sidebar>
+<example xml:id="arrayOfThreadsExample">
 <title>Array of threads</title>
 <simpara>In domain decomposition, we often need to create multiple threads, all
 from the same class. As an example, consider the following thread
 declaration.</simpara>
-<programlisting xml:id="program:NumberedThread" xreflabel="NumberedThread" language="java" linenumbering="numbered">public class NumberedThread extends Thread {
+<programlisting xml:id="NumberedThreadProgram" language="java" linenumbering="numbered">public class NumberedThread extends Thread {
 	private int value;
 
 	public NumberedThread( int input ) { value = input; }
@@ -20052,6 +20331,10 @@ relative to the sequential program. Ideally, we expect
 <inlineequation><alt><![CDATA[t_c<t_s]]></alt><mathphrase><![CDATA[t_c<t_s]]></mathphrase></inlineequation>, making the speedup greater than 1. However,
 simply writing a concurrent program does not necessarily make it faster
 than the sequential version.</simpara>
+<sidebar>
+<simpara><link linkend="exercise13.6">Exercise 13.6</link><?asciidoc-br?>
+<link linkend="exercise13.8">Exercise 13.8</link></simpara>
+</sidebar>
 <simpara>To determine speedup, we need to measure <inlineequation><alt><![CDATA[t_s]]></alt><mathphrase><![CDATA[t_s]]></mathphrase></inlineequation> and
 <inlineequation><alt><![CDATA[t_c]]></alt><mathphrase><![CDATA[t_c]]></mathphrase></inlineequation>. Time in a Java program can easily be measured with
 the following two static methods in the <literal>System</literal> class.</simpara>
@@ -20084,13 +20367,16 @@ System.out.println("Elapsed time: " + (end - start) + " ms");</programlisting>
 milliseconds. To get the execution time in nanoseconds, use the
 <literal>System.nanoTime()</literal> method instead.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise13.15">Exercise 13.15</link><?asciidoc-br?>
+<link linkend="exercise13.16">Exercise 13.16</link></simpara>
+</sidebar>
 <simpara>Now that we have the tools to measure execution time, we can measure
 speedup. The next few examples show the speedup (or lack of it) that we
 can achieve using a concurrent solution to a few simple problems.</simpara>
 <example>
 <title>Math expression speedup</title>
-<simpara>Recall the concurrent program in Example <xref linkend="example:Math expression
-threads"/> to evaluate a simple mathematical expression. This program
+<simpara>Recall the concurrent program in <xref linkend="mathExpressionThreadsExample"/> to evaluate a simple mathematical expression. This program
 uses two threads. We executed this multi-threaded program on an iMac
 computer with an Intel Core 2 Duo running at 2.16 Ghz. The execution
 time was measured at 1,660,000 nanoseconds. We also wrote a simple
@@ -20105,9 +20391,12 @@ sequential program. In this example, the cost of creating, running, and
 joining threads outweighed the benefits of concurrent calculation on two
 cores.</simpara>
 </example>
-<example>
+<sidebar>
+<simpara><link linkend="exercise13.7">Exercise 13.7</link></simpara>
+</sidebar>
+<example xml:id="arraySummationExample">
 <title>Array summation</title>
-<simpara>In Example <xref linkend="example:Array_summation_preview"/>, we introduced the
+<simpara>In <xref linkend="arraySummationPreviewExample"/>, we introduced the
 problem of applying a function to every value in an array and then
 summing the results. Let&#8217;s say that we want to apply the sine function
 to each value. To solve this problem concurrently, we partition the
@@ -20173,7 +20462,7 @@ be shared by all instances of <literal>SumThread</literal>. Then each thread is 
 with lower and upper bounds that mark its array partition. If the
 process using the array length and the number of threads to determine
 upper and lower bounds doesn&#8217;t make sense, refer to
-Section <xref linkend="concurrency:Arrays"/> which describes the fair division of work
+<xref linkend="_concurrency_arrays"/> which describes the fair division of work
 to threads. If the length of the array is not divisible by the number of
 threads, simple division isn&#8217;t enough. After creating each thread, its
 <literal>start()</literal> method is called.</simpara>
@@ -20197,17 +20486,22 @@ the running total. If the main thread is interrupted while waiting for a
 thread to complete, the stack trace is printed. Otherwise, the final sum
 is printed out.</simpara>
 </example>
-<example>
+<sidebar>
+<simpara><link linkend="exercise13.12">Exercise 13.12</link><?asciidoc-br?>
+<link linkend="exercise13.19">Exercise 13.19</link><?asciidoc-br?>
+<link linkend="exercise13.20">Exercise 13.20</link></simpara>
+</sidebar>
+<example xml:id="matrixMultiplicationExample">
 <title>Matrix multiplication</title>
-<simpara>In Example <xref linkend="example:Matrix_multiplication_preview"/>, we discussed the
+<simpara>In <xref linkend="matrixMultiplicationPreviewExample"/>, we discussed the
 importance of matrix operations in many applications. Now that we know
 the necessary Java syntax, we can write a concurrent program to multiply
 two square matrices <inlineequation><alt><![CDATA[A]]></alt><mathphrase><![CDATA[A]]></mathphrase></inlineequation> and <inlineequation><alt><![CDATA[B]]></alt><mathphrase><![CDATA[B]]></mathphrase></inlineequation> and compute the
 resultant matrix <inlineequation><alt><![CDATA[C]]></alt><mathphrase><![CDATA[C]]></mathphrase></inlineequation>. If these matrices have <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>
 rows and <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> columns, the value at the <inlineequation><alt><![CDATA[i]]></alt><mathphrase><![CDATA[i]]></mathphrase></inlineequation><superscript>th</superscript>
 row and <inlineequation><alt><![CDATA[j]]></alt><mathphrase><![CDATA[j]]></mathphrase></inlineequation><superscript>th</superscript> column of <inlineequation><alt><![CDATA[C]]></alt><mathphrase><![CDATA[C]]></mathphrase></inlineequation> is</simpara>
-<simpara><inlineequation><alt><![CDATA[C_{ij} = \sum_{k = 1}^n A_{ik}B_{kj} = A_{i1}B_{1j} + A_{i2}B_{2j} + \hdots +
-A_{in}B_{nj}]]></alt><mathphrase><![CDATA[C_{ij} = \sum_{k = 1}^n A_{ik}B_{kj} = A_{i1}B_{1j} + A_{i2}B_{2j} + \hdots +
+<simpara><inlineequation><alt><![CDATA[C_{ij} = \sum_{k = 1}^n A_{ik}B_{kj} = A_{i1}B_{1j} + A_{i2}B_{2j} + \ldots +
+A_{in}B_{nj}]]></alt><mathphrase><![CDATA[C_{ij} = \sum_{k = 1}^n A_{ik}B_{kj} = A_{i1}B_{1j} + A_{i2}B_{2j} + \ldots +
 A_{in}B_{nj}]]></mathphrase></inlineequation></simpara>
 <simpara>In Java, it is natural for us to store matrices as 2-dimensional arrays.
 To do this multiplication sequentially, the simplest approach uses three
@@ -20224,7 +20518,7 @@ names with lowercase letters.</simpara>
 create a <literal>Thread</literal> subclass which will do some part of the matrix
 multiplication. Below is the <literal>MatrixThread</literal> class which will compute a
 number of rows in the answer matrix <literal>c</literal>.</simpara>
-<programlisting xml:id="program:MatrixThread" xreflabel="MatrixThread" language="java" linenumbering="numbered">public class MatrixThread extends Thread {
+<programlisting xml:id="MatrixThreadProgram" language="java" linenumbering="numbered">public class MatrixThread extends Thread {
 	private double[][] a;
 	private double[][] b;
 	private double[][] c;
@@ -20257,7 +20551,7 @@ critical that each thread is assigned a set of rows that does not
 overlap with the rows another thread has. Not only would having multiple
 threads compute the same row be inefficient, it could very likely lead
 to an incorrect result, as we will see in
-Chapter <xref linkend="chapter:Synchronization"/>.</simpara>
+<xref linkend="_synchronization"/>.</simpara>
 <simpara>The following client code uses an array of <literal>MatrixThread</literal> objects to
 perform a matrix multiplication. We assume that an <literal>int</literal> constant named
 <literal>THREADS</literal> has been defined which gives the number of threads we want to
@@ -20283,7 +20577,7 @@ catch( InterruptedException e ) {
 }</programlisting>
 <simpara>We loop through the array, creating a <literal>MatrixThread</literal> object for each
 location. As in the previous example, we use the approach described in
-Section <xref linkend="concurrency:Arrays"/> to allocate rows to each thread fairly.
+<xref linkend="_concurrency_arrays"/> to allocate rows to each thread fairly.
 Each new <literal>MatrixThread</literal> object is given a reference to each of the three
 matrices as well as an inclusive starting and an exclusive ending row.
 After the <literal>MatrixThread</literal> objects are created, we start them running with
@@ -20340,6 +20634,10 @@ performance when using two threads. In that case, we achieved a speedup
 of 1.45, marked with an asterisk. In the other two cases, performance
 became worse.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise13.14">Exercise 13.14</link><?asciidoc-br?>
+<link linkend="exercise13.17">Exercise 13.17</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_concepts_thread_scheduling">
 <title>Concepts: Thread scheduling</title>
@@ -20369,8 +20667,8 @@ information about when they will and will not need processor time. A
 thread may need to wait for a specific event and will not need to run
 until then. Java allows threads to interact with the scheduler through
 <literal>Thread.sleep()</literal> and <literal>Thread.yield()</literal>, which we will discuss in
-Section <xref linkend="syntax:Thread_states"/>, and through the <literal>wait()</literal>, method which
-we will discuss in Chapter <xref linkend="chapter:Synchronization"/>.</simpara>
+<xref linkend="_syntax_thread_states"/>, and through the <literal>wait()</literal>, method which
+we will discuss in <xref linkend="_synchronization"/>.</simpara>
 <section xml:id="_nondeterminism">
 <title>Nondeterminism</title>
 <simpara>In Java, the mapping of a thread inside the JVM to a thread in the OS
@@ -20388,8 +20686,11 @@ threads, and both programs are complex mountains of code which try to
 balance many factors. If you create three threads, there is no guarantee
 that the first will run first, the second second, and the third third,
 not even if it happens that way the first 10 times you run the program.
-Exercise <xref linkend="exercise:NumberedThread"/> shows that the pattern of thread
+<link linkend="exercise13.18">Exercise 13.18</link> shows that the pattern of thread
 execution can vary a lot.</simpara>
+<sidebar>
+<simpara><link linkend="exercise13.18">Exercise 13.18</link></simpara>
+</sidebar>
 <simpara>In all the programs before this chapter, the same sequence of input
 would always produce the same sequence of output. Perhaps the biggest
 hurdle created by this nondeterminism is that programmers must shift
@@ -20432,6 +20733,9 @@ other thread when it has the correct value.</simpara>
 parallel programming, partly because it can be useful in solving some
 problems in this chapter, and partly because we want you to understand
 the reasons why we need better techniques for thread communication.</simpara>
+<sidebar>
+<simpara><link linkend="exercise13.11">Exercise 13.11</link></simpara>
+</sidebar>
 </section>
 </section>
 <section xml:id="_syntax_thread_states">
@@ -20452,7 +20756,11 @@ anything when a <literal>Thread.yield()</literal> call happens. The Java specifi
 does not demand a particular implementation. A JVM could ignore a
 <literal>Thread.yield()</literal> call completely, but most JVMs will move on to the next
 thread in the schedule.</simpara>
-<figure role="text-center">
+<sidebar>
+<simpara><link linkend="exercise13.3">Exercise 13.3</link><?asciidoc-br?>
+<link linkend="exercise13.13">Exercise 13.13</link></simpara>
+</sidebar>
+<figure xml:id="figure-thread_states" role="text-center">
 <title>Thread states and transitions.</title>
 <mediaobject>
 <imageobject>
@@ -20461,7 +20769,7 @@ thread in the schedule.</simpara>
 <textobject><phrase>thread states</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>Figure <xref linkend="figure:thread_states"/> shows the lifecycle of a thread. A
+<simpara><xref linkend="figure-thread_states"/> shows the lifecycle of a thread. A
 thread begins its life in the New Thread state, after the constructor is
 called. When the <literal>start()</literal> method is called, the thread begins to run
 and transitions to the Runnable state. Being Runnable doesn&#8217;t
@@ -20505,7 +20813,7 @@ sequence for marching and loop the whole thing 10 times so that we can
 see how accurately place the words. We want to use the scheduling tools
 discussed above to get the timing right. Let&#8217;s try <literal>Thread.sleep()</literal>
 first.</simpara>
-<programlisting xml:id="program:LeftThread" xreflabel="LeftThread" language="java" linenumbering="numbered">public class LeftThread extends Thread {
+<programlisting xml:id="LeftThreadProgram" language="java" linenumbering="numbered">public class LeftThread extends Thread {
 	public void run() {
 		for( int i = 0; i &lt; 10; i++ ) {
 			System.out.print("Left ");
@@ -20521,7 +20829,7 @@ first.</simpara>
 }</programlisting>
 <simpara>Class <literal>LeftThread</literal> has a <literal>for</literal> loop which prints out <literal>Left</literal> three times,
 waits for 10 milliseconds, prints out <literal>Left</literal> again, then repeats.</simpara>
-<programlisting xml:id="program:RightThread" xreflabel="RightThread" language="java" linenumbering="numbered">public class RightThread extends Thread {
+<programlisting xml:id="RightThreadProgram" language="java" linenumbering="numbered">public class RightThread extends Thread {
 	public void run() {
 		try { Thread.sleep(5); }
 		catch( InterruptedException e ) {
@@ -20541,7 +20849,7 @@ has a <literal>for</literal> loop which prints out <literal>Right</literal>, wai
 and repeats. The driver program below creates a thread for each of these
 classes and then starts them. If you run this program, you should see 10
 lines of <literal>Left Left Left Right Left</literal>, but there are a few problems.</simpara>
-<programlisting xml:id="program:MilitaryMarching" xreflabel="MilitaryMarching" language="java" linenumbering="numbered">public class MilitaryMarching {
+<programlisting xml:id="MilitaryMarchingProgram" language="java" linenumbering="numbered">public class MilitaryMarching {
 	public static void main( String[] args ) {
 		LeftThread left = new LeftThread();
 		RightThread right = new RightThread();
@@ -20564,7 +20872,7 @@ times, you may see a <literal>Right</literal> out of place once in a while. If y
 increase the repetitions of the <literal>for</literal> loops to a larger number, the
 errors are more likely. Whether or not you see errors is somewhat system
 dependent. We can try <literal>Thread.yield()</literal> instead of <literal>Thread.sleep()</literal>.</simpara>
-<programlisting xml:id="program:LeftYieldThread" xreflabel="LeftYieldThread" language="java" linenumbering="numbered">public class LeftYieldThread extends Thread {
+<programlisting xml:id="LeftYieldThreadProgram" language="java" linenumbering="numbered">public class LeftYieldThread extends Thread {
 	public void run() {
 		for( int i = 0; i &lt; 10; i++ ) {
 			System.out.print("Left ");
@@ -20575,7 +20883,7 @@ dependent. We can try <literal>Thread.yield()</literal> instead of <literal>Thre
 		}
 	}
 }</programlisting>
-<programlisting xml:id="program:RightYieldThread" xreflabel="RightYieldThread" language="java" linenumbering="numbered">public class RightYieldThread extends Thread {
+<programlisting xml:id="RightYieldThreadProgram" language="java" linenumbering="numbered">public class RightYieldThread extends Thread {
 	public void run() {
 		for( int i = 0; i &lt; 10; i++ ) {
 			System.out.print("Right ");
@@ -20600,7 +20908,7 @@ the mark. To do this, we need state variables inside of each class to
 keep track of whether or not it is done. Each thread needs a reference
 to the other thread to make queries, and the driver program must be
 updated to add these in before starting the threads.</simpara>
-<programlisting xml:id="program:LeftPollingThread" xreflabel="LeftPollingThread" language="java" linenumbering="numbered">public class LeftPollingThread extends Thread {
+<programlisting xml:id="LeftPollingThreadProgram" language="java" linenumbering="numbered">public class LeftPollingThread extends Thread {
 	private RightThread right;
 	private boolean done = false;
 
@@ -20623,7 +20931,7 @@ updated to add these in before starting the threads.</simpara>
 	public boolean isDone()	{ return done; }
 	public void setDone( boolean value ) { done = value; }
 }</programlisting>
-<programlisting xml:id="program:RightPollingThread" xreflabel="RightPollingThread" language="java" linenumbering="numbered">public class RightPollingThread extends Thread {
+<programlisting xml:id="RightPollingThreadProgram" language="java" linenumbering="numbered">public class RightPollingThread extends Thread {
 	private LeftThread left;
 	private boolean done = false;
 
@@ -20666,7 +20974,7 @@ its own <literal>done</literal> to <literal>false</literal>.</simpara>
 <simpara>In short, coordinating two or more threads together is a difficult
 problem. None of the solutions we give here are fully acceptable. We
 introduce better tools for coordination and synchronization in
-Chapter <xref linkend="chapter:Synchronization"/>.</simpara>
+<xref linkend="_synchronization"/>.</simpara>
 </example>
 </section>
 <section xml:id="_solution_deadly_virus">
@@ -20676,7 +20984,7 @@ point, the threaded part of this problem should not seem very difficult.
 It is simpler than some of the examples, such as matrix multiplication.
 We begin with the worker class <literal>FactorThread</literal> that can be spawned as a
 thread.</simpara>
-<formalpara xml:id="program:FactorThread" xreflabel="FactorThread">
+<formalpara xml:id="FactorThreadProgram">
 <title>Thread class used to find the sum of the two factors of a large odd composite.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class FactorThread extends Thread {
@@ -20713,7 +21021,7 @@ only search the odd numbers in the range. This solution is tuned for
 efficiency for this specific security problem. A program to find general
 prime factors would have to be more flexible. Next let us examine the
 driver program <literal>Factor</literal>.</simpara>
-<formalpara xml:id="program:Factor" xreflabel="Factor">
+<formalpara xml:id="FactorProgram">
 <title>Driver class which creates threads to lower the average search time for the factors of a large odd composite.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class Factor {
@@ -20750,7 +21058,7 @@ driver program <literal>Factor</literal>.</simpara>
 threads. In the <literal>main()</literal> method, we create an array of threads for
 storage. Then, we create each <literal>FactorThread</literal> object, assigning upper and
 lower bounds at the same time, using the standard technique from
-Section <xref linkend="concurrency:Arrays"/> to divide the work fairly. Because we
+<xref linkend="_concurrency_arrays"/> to divide the work fairly. Because we
 know the number we&#8217;re dividing isn&#8217;t even, we start with 3. By only
 going up to the square root of the number, we know that we will only
 find the smaller of the two factors. In that way we can avoid having one
@@ -20783,39 +21091,39 @@ concurrent programs. Only a few of these have been introduced in this
 chapter. Subsequent chapters give additional tools to code more complex
 concurrent programs.</simpara>
 </section>
-<section xml:id="_exercises_12">
+<section xml:id="_exercises_13">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara><xref linkend="exercise:thread_methods"/> The <literal>start()</literal>, <literal>run()</literal>, and <literal>join()</literal>
+<simpara><anchor xml:id="exercise13.1" xreflabel="[exercise13.1]"/> The <literal>start()</literal>, <literal>run()</literal>, and <literal>join()</literal>
 methods are essential parts of the process of using threads in Java.
 Explain the purpose of each method.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:Thread_vs._Runnable"/> What is the difference between
+<simpara><anchor xml:id="exercise13.2" xreflabel="[exercise13.2]"/> What is the difference between
 extending the <literal>Thread</literal> class and implementing the <literal>Runnable</literal> interface?
 When should you use one over the other?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:sleep_and_yield"/> How do the <literal>Thread.sleep()</literal> method and
+<simpara><anchor xml:id="exercise13.3" xreflabel="[exercise13.3]"/> How do the <literal>Thread.sleep()</literal> method and
 the <literal>Thread.yield()</literal> method each affect thread scheduling?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:math_expression"/> Consider the expression in
-Example <xref linkend="example:Math_expression_tasks"/>. Suppose that the multiply and
+<simpara><anchor xml:id="exercise13.4" xreflabel="[exercise13.4]"/> Consider the expression in
+<xref linkend="mathExpressionTasksExample"/>. Suppose that the multiply and
 exponentiation operations require 1 and 10 time units, respectively.
 Compute the number of time units required to evaluate the expression as
-in Figure <xref linkend="figure:math_evaluation"/>(a) and (b).</simpara>
+in <xref linkend="figure-math_evaluation"/>(a) and (b).</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:multicore-exercise"/> Suppose that a computer has one
-quadcore processor. Can the tasks in Examples <xref linkend="example:Video game
-tasks"/> and <xref linkend="example:Math_expression_tasks"/> be further subdivided to
+<simpara><anchor xml:id="exercise13.5" xreflabel="[exercise13.5]"/> Suppose that a computer has one
+quadcore processor. Can the tasks in <xref linkend="videoGameTasksExample"/> and <xref linkend="mathExpressionTasksExample"/> be further subdivided to
 improve performance on four cores? Why or why not?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:speedup"/> Consider the definition of speedup from
-Section <xref linkend="examples:Concurrency_and_speedup"/>. Let&#8217;s assume you have a
+<simpara><anchor xml:id="exercise13.6" xreflabel="[exercise13.6]"/> Consider the definition of speedup from
+<xref linkend="_examples_concurrency_and_speedup"/>. Let&#8217;s assume you have a
 job 1,000,000 units in size. A thread can process 10,000 units of work
 every second. It takes an additional 100 units of work to create a new
 thread. What is the speedup if you have a dual-core processor and create
@@ -20824,12 +21132,12 @@ Or an 8-core processor and create 8 threads? You may assume that a
 thread does not need to communicate after it has been created.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:speedup_bounds"/> In which situations can speedup be
+<simpara><anchor xml:id="exercise13.7" xreflabel="[exercise13.7]"/> In which situations can speedup be
 smaller than the number of processors? Is it ever possible for speedup
 to be greater than the number of processors?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:Amdahl"/> Amdahl&#8217;s Law is a mathematical description of
+<simpara><anchor xml:id="exercise13.8" xreflabel="[exercise13.8]"/> Amdahl&#8217;s Law is a mathematical description of
 the maximum amount you can improve a system by only improving a part of
 it. One form of it states that the maximum speedup attainable in a
 parallel program is <inlineequation><alt><![CDATA[\frac{1}{1 - P}]]></alt><mathphrase><![CDATA[\frac{1}{1 - P}]]></mathphrase></inlineequation> where <inlineequation><alt><![CDATA[P]]></alt><mathphrase><![CDATA[P]]></mathphrase></inlineequation>
@@ -20839,7 +21147,7 @@ the rest is completely serial, what is the speedup with 2 processors? 4?
 8? What implications does Amdahl&#8217;s Law have?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:task_parallelization"/> Consider the following table of
+<simpara><anchor xml:id="exercise13.9" xreflabel="[exercise13.9]"/> Consider the following table of
 tasks:</simpara>
 <informaltable role="center" frame="all" rowsep="1" colsep="1">
 <tgroup cols="4">
@@ -20902,7 +21210,7 @@ with an unlimited number of people? What is the smallest number of
 people needed to achieve this minimum time?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:interleavings"/> Consider the following code snippet.</simpara>
+<simpara><anchor xml:id="exercise13.10" xreflabel="[exercise13.10]"/> Consider the following code snippet.</simpara>
 <programlisting language="java" linenumbering="unnumbered">x = 13;
 x = x * 10;</programlisting>
 <simpara>Consider this snippet as well.</simpara>
@@ -20915,14 +21223,14 @@ of these snippets can be interleaved in any way.</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:polling"/> Re-implement the array summing problem from
-Example <xref linkend="example:Array_summation"/> using polling instead of <literal>join()</literal>
+<simpara><anchor xml:id="exercise13.11" xreflabel="[exercise13.11]"/> Re-implement the array summing problem from
+<xref linkend="arraySummationExample"/> using polling instead of <literal>join()</literal>
 calls. Your program should not use a single call to <literal>join()</literal>. Polling is
 not an ideal way to solve this problem, but it is worth experimenting
 with the technique.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:echo_effect"/> Composers often work with multiple tracks
+<simpara><anchor xml:id="exercise13.12" xreflabel="[exercise13.12]"/> Composers often work with multiple tracks
 of music. One track might contain solo vocals, another drums, a third
 one violins, and so on. After recording the entire take, a mix engineer
 might want to apply special effects such as an echo to one or more
@@ -20954,13 +21262,13 @@ and <literal>b</literal> to create the desired echo effect.</simpara>
 for an arbitrary number of threads.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:sleep_timer"/> Write a program which takes a number of
+<simpara><anchor xml:id="exercise13.13" xreflabel="[exercise13.13]"/> Write a program which takes a number of
 minutes and seconds as input. In this program, implement a timer using
 <literal>Thread.sleep()</literal> calls. Each second, print the remaining time to the
 screen. How accurate is your timer?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:concurrent_approximation"/> As you know,
+<simpara><anchor xml:id="exercise13.14" xreflabel="[exercise13.14]"/> As you know,
 <inlineequation><alt><![CDATA[\pi\approx
 3.1416]]></alt><mathphrase><![CDATA[\pi\approx
 3.1416]]></mathphrase></inlineequation>. A more precise value can be found by writing a program which
@@ -20981,14 +21289,14 @@ When your program finishes running, you can compare your value against
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:time-measurement"/> Use the <literal>currentTimeMillis()</literal> method
+<simpara><anchor xml:id="exercise13.15" xreflabel="[exercise13.15]"/> Use the <literal>currentTimeMillis()</literal> method
 to measure the time taken to execute a relatively long-running piece of
 Java code you have written. Execute your program several times and
 compare the execution time you obtain during different executions. Why
 do you think the execution times are different?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:thread_overhead"/> Thread creation overhead is an
+<simpara><anchor xml:id="exercise13.16" xreflabel="[exercise13.16]"/> Thread creation overhead is an
 important consideration in writing efficient parallel programs. Write a
 program which creates a large number of threads which do nothing. Test
 how long it takes to create and join various numbers of threads. See if
@@ -20996,9 +21304,9 @@ you can determine how long a single thread creation operation takes on
 your system, on average.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:matrix_multiply"/> Create serial and concurrent
+<simpara><anchor xml:id="exercise13.17" xreflabel="[exercise13.17]"/> Create serial and concurrent
 implementations of matrix multiplication like those described in
-Example <xref linkend="example:Matrix_multiplication"/>.</simpara>
+<xref linkend="matrixMultiplicationExample"/>.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
 <simpara>Experiment with different matrix sizes and thread counts to see how
@@ -21012,24 +21320,24 @@ speedup you can expect to obtain?</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:NumberedThread"/> Repeatedly run the code in
-Example <xref linkend="example:Array_of_threads"/> which creates several
+<simpara><anchor xml:id="exercise13.18" xreflabel="[exercise13.18]"/> Repeatedly run the code in
+<xref linkend="arrayOfThreadsExample"/> which creates several
 <literal>NumberedThread</literal> objects. Can you discover any patterns in the order
 that the threads print? Add a loop and some additional instrumentation
 to the <literal>NumberedThread</literal> class which will allow you to measure how long
 each thread runs before the next thread has a turn.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:ArraySum"/> Create serial and parallel implementations of
-the array summing problem solved in Example <xref linkend="example:Array_summation"/>.
+<simpara><anchor xml:id="exercise13.19" xreflabel="[exercise13.19]"/> Create serial and parallel implementations of
+the array summing problem solved in <xref linkend="arraySummationExample"/>.
 Experiment with different array sizes and thread counts to see how
 performance changes. How does the speedup differ from matrix multiply?
 What happens if you simply sum the numbers instead of taking the sine
 first?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:TreeSum"/> The solution to the array summing problem in
-Example <xref linkend="example:Array_summation"/> seems to use concurrency
+<simpara><anchor xml:id="exercise13.20" xreflabel="[exercise13.20]"/> The solution to the array summing problem in
+<xref linkend="arraySummationExample"/> seems to use concurrency
 half-heartedly. After all the threads have computed their sums, the main
 thread sums up the partial sums sequentially.</simpara>
 <simpara>An alternative approach is to sum up the partial sums concurrently. Once
@@ -21042,7 +21350,7 @@ and will stop. The pattern of summing is like a tree which starts with
 <inlineequation><alt><![CDATA[\frac{k}{2}]]></alt><mathphrase><![CDATA[\frac{k}{2}]]></mathphrase></inlineequation> working at the second stage,
 <inlineequation><alt><![CDATA[\frac{k}{4}]]></alt><mathphrase><![CDATA[\frac{k}{4}]]></mathphrase></inlineequation> working at the third, and so on, until a
 single thread completes the summing process.</simpara>
-<figure>
+<figure xml:id="figure-tree_summation">
 <title>Example of concurrent tree-style summation with 8 threads.</title>
 <mediaobject>
 <imageobject>
@@ -21062,7 +21370,7 @@ thread with a number divisible by 8 should add the partial sum from its
 neighbor, and so on. Thread 0 will perform the final summation.
 Consequently, the main thread only needs to wait for thread 0. So that
 each thread can wait for other threads, the <literal>threads</literal> array will need to
-be a static field. Figure <xref linkend="figure:tree_summation"/> illustrates this
+be a static field. <xref linkend="figure-tree_summation"/> illustrates this
 process.</simpara>
 <simpara>Once you have implemented this design, test it against the original
 <literal>SumThread</literal> class to see how it performs. Restrict the number of threads
@@ -21072,7 +21380,7 @@ wait and which threads terminate.</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Synchronization">
+<chapter xml:id="_synchronization">
 <title>Synchronization</title>
 <blockquote>
 <attribution>
@@ -21084,7 +21392,7 @@ Mary Catherine Bateson
 <title>Introduction</title>
 <simpara>Concurrent programs allow multiple threads to be scheduled and executed,
 but the programmer does not have a great deal of control over when
-threads execute. As explained in Section <xref linkend="concepts:Thread_scheduling"/>,
+threads execute. As explained in <xref linkend="_concepts_thread_scheduling"/>,
 the JVM and the underlying OS are responsible for scheduling threads
 onto processor cores.</simpara>
 <simpara>While writing a concurrent program, you have to ensure that the program
@@ -21108,9 +21416,9 @@ that are periodically filled with rice. Between adjacent philosophers
 are single chopsticks so that there are exactly the same number of
 chopsticks as there are philosophers. These philosophers only think and
 eat. In order to eat, a philosopher must pick up both the chopstick on
-her left and the chopstick on her right. Figure <xref linkend="figure:dining"/> shows
+her left and the chopstick on her right. <xref linkend="figure-dining"/> shows
 an example of the situation.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-dining" role="text-center">
 <title>Table for five dining philosophers.</title>
 <mediaobject>
 <imageobject>
@@ -21136,15 +21444,15 @@ chopstick.</simpara>
 <title>Concepts: Thread interaction</title>
 <simpara>This dining philosopher problem highlights some difficulties which were
 emerging toward the end of the last chapter. In
-Exercise <xref linkend="exercise:interleavings"/> two snippets of code could run
+<link linkend="exercise13.10">Exercise 13.10</link> two snippets of code could run
 concurrently and modify the same shared variable, potentially producing
 incorrect output. Because of the nondeterministic nature of scheduling,
 we have to assume that the code executing in two or more threads can be
 interleaved in any possible way. When the <emphasis role="strong">result</emphasis> of computation
 changes depending on the order of thread execution, it is called a <emphasis>race
 condition</emphasis>. Below is a simple example of a race condition in Java.</simpara>
-<formalpara xml:id="program:RaceCondition" xreflabel="RaceCondition">
-<title>A short example of a race condition.</title>
+<formalpara xml:id="RaceConditionProgram">
+<title>Short example of a race condition.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class RaceCondition extends Thread {
 	private static int counter = 0;
@@ -21182,6 +21490,10 @@ often not be <literal>1000000</literal>. Depending on which JVM, OS, and how man
 you have, you may never get <literal>1000000</literal>, and the answer you do get will
 vary a lot. On all systems, if you change the value of <literal>THREADS</literal> to <literal>1</literal>,
 the answer should always be correct.</simpara>
+<sidebar>
+<simpara><link linkend="exercise14.6">Exercise 14.6</link><?asciidoc-br?>
+<link linkend="exercise14.14">Exercise 14.14</link></simpara>
+</sidebar>
 <simpara>Looking at the code, the problem might not be obvious. Everything
 centers on the statement <literal>counter++</literal> in the <literal>for</literal> loop inside the
 <literal>run()</literal> method. But, this statement appears to execute in a single step!
@@ -21225,6 +21537,9 @@ Mutual exclusion is a deeply researched topic with many approaches other
 than monitors. If you plan to write concurrent programs in another
 language, you may need to brush up on the features provided by that
 language.</simpara>
+<sidebar>
+<simpara><link linkend="exercise14.5">Exercise 14.5</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_syntax_thread_synchronization">
 <title>Syntax: Thread synchronization</title>
@@ -21248,6 +21563,9 @@ similar to the one in <literal>RaceCondition</literal>. Some of the <literal>Str
 concatenations might be overwritten by other calls to <literal>danger()</literal>. You
 would never have more than five copies of <literal>"Danger, "</literal> appended to the
 beginning of <literal>message</literal>, but you might have fewer.</simpara>
+<sidebar>
+<simpara><link linkend="exercise14.1">Exercise 14.1</link></simpara>
+</sidebar>
 <simpara>Any time a thread enters a piece of code protected by the <literal>synchronized</literal>
 keyword, it implicitly acquires a lock which only a single thread can
 hold. If another thread tries to access the code, it is forced to wait
@@ -21255,6 +21573,9 @@ until the lock is released. This lock is <emphasis>re-entrant</emphasis>. Re-ent
 that, when a thread currently holds a lock and tries to get it again, it
 succeeds. This situation frequently occurs with synchronized methods
 which call other synchronized methods.</simpara>
+<sidebar>
+<simpara><link linkend="exercise14.13">Exercise 14.13</link></simpara>
+</sidebar>
 <simpara>Consider method <literal>safety()</literal> which does the &#8220;opposite&#8221; of <literal>danger()</literal>, by
 removing occurrences of <literal>"Danger, "</literal> from the beginning of <literal>message</literal>.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public synchronized void safety() {
@@ -21270,6 +21591,10 @@ method, the object the method is being called on (whichever object
 thread can be inside of either of these methods. If you have 10
 synchronized methods in an object, only one of them can execute at a
 time in a given object.</simpara>
+<sidebar>
+<simpara><link linkend="exercise14.2">Exercise 14.2</link><?asciidoc-br?>
+<link linkend="exercise14.7">Exercise 14.7</link></simpara>
+</sidebar>
 <simpara>Perhaps this level of control is too restrictive. You may have six
 methods which conflict with each other and four others which conflict
 with each other but not the first six. Using <literal>synchronized</literal> in each
@@ -21346,8 +21671,7 @@ is executing synchronized code, it can call <literal>wait()</literal>. Instead o
 waiting, a thread which has called <literal>wait()</literal> will be removed from the
 list of running threads. It will wait in a dormant state until someone
 comes along and notifies the thread that its waiting is done. If you
-recall the threadstate diagram from Chapter <xref linkend="chapter:Concurrent
-Programming"/>, there is a Not Runnable state which threads enter by
+recall the threadstate diagram from <xref linkend="_concurrent_programming"/>, there is a Not Runnable state which threads enter by
 calling <literal>sleep()</literal>, calling <literal>wait()</literal>, or performing blocking I/O. Using
 <literal>wait()</literal>, we can rewrite the vote counting thread.</simpara>
 <programlisting language="java" linenumbering="unnumbered">synchronized( this ) {
@@ -21383,7 +21707,11 @@ waiting thread is notified, that thread may need to notify the next
 waiting thread when it is done. If your code is not very carefully
 designed, some thread may end up waiting forever and never be notified
 if you only rely on <literal>notify()</literal>.</simpara>
-<example>
+<sidebar>
+<simpara><link linkend="exercise14.3">Exercise 14.3</link><?asciidoc-br?>
+<link linkend="exercise14.4">Exercise 14.4</link></simpara>
+</sidebar>
+<example xml:id="producerConsumerExample">
 <title>Producer/consumer</title>
 <simpara>To illustrate the use of <literal>wait()</literal> and <literal>notify()</literal> calls inside of
 synchronized code, we give a simple solution to the producer/consumer
@@ -21397,8 +21725,8 @@ problems often assume a bounded buffer which stores items from the
 producer until the consumer can take them away. Our solution does all
 synchronization on the buffer. Many different threads can share this
 buffer, but all accesses will be controlled.</simpara>
-<formalpara xml:id="program:Buffer" xreflabel="Buffer">
-<title>An example of a synchronized buffer.</title>
+<formalpara xml:id="BufferProgram">
+<title>Example of a synchronized buffer.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class Buffer {
 	public final static int SIZE = 10;
@@ -21441,7 +21769,10 @@ synchronized code is a protection against unsafe concurrency. The goal
 is to minimize the amount of time spent in synchronized code and get
 threads back to concurrent execution as quickly as possible.</simpara>
 </example>
-<example>
+<sidebar>
+<simpara><link linkend="exercise14.10">Exercise 14.10</link></simpara>
+</sidebar>
+<example xml:id="bankAccountExample">
 <title>Bank account</title>
 <simpara>Although producer/consumer is a good model to keep in mind, there are
 other ways that reading and writing threads might interact. Consider the
@@ -21532,7 +21863,7 @@ the balance of the account.</simpara>
 <title>Pitfalls: Synchronization challenges</title>
 <simpara>As you can see from the dining philosophers problem, synchronization
 tools help us get the right answer but also create other difficulties.</simpara>
-<section xml:id="subsection:deadlock">
+<section xml:id="_deadlock">
 <title>Deadlock</title>
 <simpara><emphasis>Deadlock</emphasis> is the situation when two or more threads are both waiting
 for the others to complete, forever. Some combination of locks or other
@@ -21622,7 +21953,7 @@ above, we have already gotten ourselves into trouble.</simpara>
 	}
 }</programlisting>
 </example>
-<example>
+<example xml:id="deadlockSumExample">
 <title>Deadlock sum</title>
 <simpara>Here is another example of deadlock. We emphasize deadlock because it is
 one of the most common and problematic issues with using synchronization
@@ -21723,8 +22054,11 @@ to protect a given resource, but this approach causes problems if the
 same lock is not consistently used. Using the resource itself as a lock
 elegantly avoids this problem.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise14.8">Exercise 14.8</link></simpara>
+</sidebar>
 </section>
-<section xml:id="section:starvation_and_livelock">
+<section xml:id="_starvation_and_livelock">
 <title>Starvation and livelock</title>
 <simpara><emphasis>Starvation</emphasis> is another problem which can occur with careless use of
 synchronization tools. Starvation is a general term which covers any
@@ -21735,7 +22069,7 @@ of the threads which are deadlocking make progress.</simpara>
 with humorous intent. If a philosopher is never able to acquire
 chopsticks, that philosopher will quite literally starve.</simpara>
 <simpara>Starvation does not necessarily mean deadlock, however. Examine the
-implementation in Example <xref linkend="example:Bank_account"/> for the bank account.
+implementation in <xref linkend="bankAccountExample"/> for the bank account.
 That solution is correct in the sense that it preserves mutual
 exclusion. No combination of balance checks, deposits, or withdrawals
 will cause the balance to be incorrect. Money will neither be created
@@ -21745,6 +22079,9 @@ thread can make a deposit or a withdrawal. Balance checking threads
 could be coming and going constantly, incrementing and decrementing the
 <literal>readers</literal> variable, but if <literal>readers</literal> never goes down to zero, threads
 waiting to make deposits and withdrawals will wait forever.</simpara>
+<sidebar>
+<simpara><link linkend="exercise14.11">Exercise 14.11</link></simpara>
+</sidebar>
 <simpara>Another kind of starvation is <emphasis>livelock</emphasis>. In deadlock, two or more
 threads get stuck and wait forever, doing nothing. Livelock is similar
 except that the two threads keep executing code and waiting for some
@@ -21860,8 +22197,7 @@ faster or, worse, runs slower than the sequential version. Too much zeal
 with synchronization tools may produce a program which gives the right
 answer but does not exploit any parallelism.</simpara>
 <simpara>For example, we can take the <literal>run()</literal> method from the parallel
-implementation of matrix multiply given in Example <xref linkend="example:Matrix
-multiplication"/> and use the <literal>synchronized</literal> keyword to lock on the
+implementation of matrix multiply given in <xref linkend="matrixMultiplicationExample"/> and use the <literal>synchronized</literal> keyword to lock on the
 matrix itself.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void run() {
     synchronized( c ) {
@@ -21884,7 +22220,7 @@ more.</simpara>
 </section>
 <section xml:id="_priority_inversion">
 <title>Priority inversion</title>
-<simpara>In Chapter <xref linkend="chapter:Concurrent_Programming"/> we suggest that you use
+<simpara>In <xref linkend="_concurrent_programming"/> we suggest that you use
 thread priorities rarely. Even good reasons to use priorities can be
 thwarted by <emphasis>priority inversion</emphasis>. In priority inversion, a lower
 priority thread holds a lock needed by a higher priority thread,
@@ -21895,9 +22231,13 @@ high priority thread.</simpara>
 priority thread may hold the lock needed by the high priority thread for
 even longer because those medium priority threads reduce the amount of
 CPU time the low priority thread has to finish its task.</simpara>
+<sidebar>
+<simpara><link linkend="exercise14.9">Exercise 14.9</link><?asciidoc-br?>
+<link linkend="exercise14.15">Exercise 14.15</link></simpara>
+</sidebar>
 </section>
 </section>
-<section xml:id="solution:dining_philosophers">
+<section xml:id="_solution_dining_philosophers">
 <title>Solution: Dining philosophers</title>
 <simpara>Now we give our solution to the dining philosophers problem. Although
 deadlock was the key pitfall we were trying to avoid, many other issues
@@ -21920,7 +22260,7 @@ either pick up both chopsticks or neither.</simpara>
 		this.seat = seat;
 	}</programlisting>
 <simpara>We begin with the same setup as the deadlocking version given in
-Section <xref linkend="subsection:deadlock"/>. Unlike that example, we include a
+<xref linkend="_deadlock"/>. Unlike that example, we include a
 <literal>main()</literal> method here for completeness. In <literal>main()</literal>, we set all the
 chopsticks to <literal>false</literal> (unused), create and start a thread for each
 philosopher, and then wait for them to finish.</simpara>
@@ -22035,16 +22375,20 @@ vary, but this kind of behavior will vary from system to system.</simpara>
 <simpara>It is very difficult to come up with a perfect answer to some
 synchronization problems. Such problems have been studied for many
 years, and research continues to find better solutions.</simpara>
+<sidebar>
+<simpara><link linkend="exercise14.12">Exercise 14.12</link></simpara>
+</sidebar>
 </section>
-<section xml:id="_exercises_13">
+<section xml:id="_exercises_14">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara><xref linkend="exercise:synchronized_keyword"/> What is the purpose of the
+<simpara><anchor xml:id="exercise14.1" xreflabel="[exercise14.1]"/> What is the purpose of the
 <literal>synchronized</literal> keyword? How does it work?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:constructor_leak"/> The language specification for Java
+<simpara><anchor xml:id="exercise14.2" xreflabel="[exercise14.2]"/> The language specification for Java
 makes it illegal to use the <literal>synchronized</literal> keyword on constructors.
 During the creation of an object, it is possible to <emphasis>leak</emphasis> data to the
 outside world by adding a reference to the object under construction to
@@ -22052,7 +22396,7 @@ some shared data structure. What&#8217;s the danger of leaking data in this
 way?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:wait_or_notify_without_synchronized"/> If you call
+<simpara><anchor xml:id="exercise14.3" xreflabel="[exercise14.3]"/> If you call
 <literal>wait()</literal> or <literal>notify()</literal> on an object, it must be inside of a block
 synchronized on the same object. If not, the code will compile, but an
 <literal>IllegalMonitorStateException</literal> may be thrown at run time. Why is it
@@ -22060,13 +22404,13 @@ necessary to own the lock on an object before calling <literal>wait()</literal> 
 <literal>notify()</literal> on it?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:notify_vs._notifyAll"/> Why is it safer to call
+<simpara><anchor xml:id="exercise14.4" xreflabel="[exercise14.4]"/> Why is it safer to call
 <literal>notifyAll()</literal> than <literal>notify()</literal>? If it is generally safer to call
 <literal>notifyAll()</literal>, are there any scenarios in which there are good reasons
 to call <literal>notify()</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:restaurant_synchronization"/> Imagine a simulation of a
+<simpara><anchor xml:id="exercise14.5" xreflabel="[exercise14.5]"/> Imagine a simulation of a
 restaurant with many waiter and chef objects. The waiters must submit
 orders to the kitchen staff, and the chefs must divide the work among
 themselves. How would you design this system? How would information and
@@ -22074,13 +22418,13 @@ food be passed from waiter to chef and chef to waiter? How would you
 synchronize the process?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:race_condition"/> What is a race condition? Give a real
+<simpara><anchor xml:id="exercise14.6" xreflabel="[exercise14.6]"/> What is a race condition? Give a real
 life example of one.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:per_object_lock"/> Let&#8217;s reexamine the code that
+<simpara><anchor xml:id="exercise14.7" xreflabel="[exercise14.7]"/> Let&#8217;s reexamine the code that
 increments a variable with several threads from
-Section <xref linkend="concepts:Thread_interaction"/>. We can rewrite the <literal>run()</literal>
+<xref linkend="_concepts_thread_interaction"/>. We can rewrite the <literal>run()</literal>
 method as follows.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public synchronized void run() {
     for( int i = 0; i &lt; COUNT / THREADS; i++ )
@@ -22089,19 +22433,19 @@ method as follows.</simpara>
 <simpara>Will this change fix the race condition? Why or why not?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:deadlock_conditions"/> Examine our deadlock example from
-Example <xref linkend="example:Deadlock_sum"/>. Explain why this example fulfills all
+<simpara><anchor xml:id="exercise14.8" xreflabel="[exercise14.8]"/> Examine our deadlock example from
+<xref linkend="deadlockSumExample"/>. Explain why this example fulfills all
 four conditions for deadlock. Be specific about which threads and which
 resources are needed to show each condition.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:priority_inversion"/> What is priority inversion? Why can
+<simpara><anchor xml:id="exercise14.9" xreflabel="[exercise14.9]"/> What is priority inversion? Why can
 a low priority thread holding a lock be particularly problematic?</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:better_producer/consumer"/> In
-Example <xref linkend="example:Producer/consumer"/> the <literal>Buffer</literal> class used to
+<simpara><anchor xml:id="exercise14.10" xreflabel="[exercise14.10]"/> In
+<xref linkend="producerConsumerExample"/> the <literal>Buffer</literal> class used to
 implement a solution to the producer/consumer problem only has a single
 lock. When the buffer is empty and a producer puts an item in it, both
 producers and consumers are woken up. A similar situation happens
@@ -22111,9 +22455,9 @@ empty buffer only wakes up consumers and a consumer removing an item
 from a full buffer only wakes up producers.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:fair_bank_account"/> In Example <xref linkend="example:Bank_account"/>
+<simpara><anchor xml:id="exercise14.11" xreflabel="[exercise14.11]"/> In <xref linkend="bankAccountExample"/>
 we used the class <literal>SynchronizedAccount</literal> to solve a bank account problem.
-As we mention in Section <xref linkend="section:starvation_and_livelock"/>, depositing
+As we mention in <xref linkend="_starvation_and_livelock"/>, depositing
 and withdrawing threads can be starved out by a steady supply of balance
 checking threads. Add additional synchronization tools to
 <literal>SynchronizedAccount</literal> so that balance checking threads will take turns
@@ -22122,8 +22466,8 @@ withdrawing threads, make your implementation continue to allow an
 unlimited number of balance checking threads to read concurrently.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:philosophers_with_hunger"/> The solution to the dining
-philosophers problem given in Section <xref linkend="solution:dining_philosophers"/>
+<simpara><anchor xml:id="exercise14.12" xreflabel="[exercise14.12]"/>The solution to the dining
+philosophers problem given in <xref linkend="_solution_dining_philosophers"/>
 suffers from the problem that a philosopher could be starved by the two
 philosophers on either side of her, if she happened to get unlucky. Add
 variables to each philosopher which indicate hunger and the last time a
@@ -22137,7 +22481,7 @@ gone hungry the longest, breaking circular wait.</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:time_lock_acquisition"/> Critical sections can slow down
+<simpara><anchor xml:id="exercise14.13" xreflabel="[exercise14.13]"/> Critical sections can slow down
 your program by preventing parallel computation. However, the locks used
 to enforce critical sections can add extra delays on top of that. Design
 a simple experiment which repeatedly acquires a lock and does some
@@ -22146,7 +22490,7 @@ if you can estimate the time needed to acquire a lock in Java on your
 system.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:thread_time_on_CPU"/> Design a program which
+<simpara><anchor xml:id="exercise14.14" xreflabel="[exercise14.14]"/> Design a program which
 experimentally determines how much time a thread is scheduled to spend
 running on a CPU before switching to the next thread. To do this, first
 create a tight loop which runs a large number of iterations, perhaps
@@ -22165,7 +22509,7 @@ reasons. If you are on a multicore machine, it will be more difficult to
 interpret your data since some threads will be running concurrently.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:priority_inversion_experiment"/> Create an experiment to
+<simpara><anchor xml:id="exercise14.15" xreflabel="[exercise14.15]"/> Create an experiment to
 investigate priority inversion in the following way.</simpara>
 <orderedlist numeration="loweralpha">
 <listitem>
@@ -22195,7 +22539,7 @@ you set the priorities of these new threads to <literal>MAX_PRIORITY</literal> o
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Constructing_Graphical_User_Interfaces">
+<chapter xml:id="_constructing_graphical_user_interfaces">
 <title>Constructing Graphical User Interfaces</title>
 <blockquote>
 <attribution>
@@ -22210,7 +22554,7 @@ environment, usually a web browser. The beauty of an applet is that
 anyone with a Java-enabled web browser can run the program without any
 special knowledge or computer skills. Most users don&#8217;t even realize they
 are running a program.</simpara>
-<figure>
+<figure xml:id="mathTutorAppletFigure">
 <title>The <literal>MathTutorApplet</literal> as seen through the Google Chrome browser. (a) Initial applet. (b) Selecting an operation to practice. (c) After some practice.</title>
 <mediaobject>
 <imageobject>
@@ -22232,10 +22576,9 @@ as a label on the applet with a text field to one side. The user should
 be able to enter an answer in the text field and hit a button to submit
 it. The applet should check the answer and display the updated number of
 correct and incorrect answers.</simpara>
-<simpara>Figure <xref linkend="elementaryArithPracticeFigure"/> shows the final applet in two
+<simpara><xref linkend="mathTutorAppletFigure"/> shows the final applet in three
 different states. The screen to the left appears when the applet is
-first initialized. The applet is set in basic mode, and the Submit
-button is disabled until a problem is generated.</simpara>
+first initialized, and the Submit button is disabled until a problem is generated.</simpara>
 </section>
 <section xml:id="_concepts_graphical_user_interfaces">
 <title>Concepts: Graphical user interfaces</title>
@@ -22253,8 +22596,7 @@ interaction are possible.</simpara>
 <simpara>This chapter will teach you how to write programs with GUIs. Although
 GUIs can make input and output easier for the user, the programmer has
 to shoulder the burden of arranging the layout and appearance of the GUI
-and making it function properly. Chapter <xref linkend="chapter:Simple Graphical User
-Interfaces"/> introduced a way to make simple GUIs, but those GUIs came
+and making it function properly. <xref linkend="_simple_graphical_user_interfaces"/> introduced a way to make simple GUIs, but those GUIs came
 in preset flavors designed for displaying a message, getting a range of
 responses in the form of buttons, or reading a short piece of text as
 input. In this chapter we will explore ways to make GUIs of arbitrary
@@ -22368,18 +22710,18 @@ the only way you have of interacting with your application, you can no
 longer use it! At that point, you may have to use a process or task
 manager to shut down the JVM by hand.</simpara>
 </warning>
-<example>
+<example xml:id="emptyFrameExample">
 <title>Empty frame</title>
-<simpara>Program <xref linkend="program:EmptyFrame"/> creates and displays an empty frame with
+<simpara><xref linkend="EmptyFrameProgram"/> creates and displays an empty frame with
 the title &#8220;Sound Check.&#8221; Note that we have used the <literal>import</literal> statement
 to let the compiler know that we are using the Swing library. The first
 line inside the <literal>main()</literal> method declares and creates a <literal>JFrame</literal> object
 and assigns a title to it. The following line sets its size. The third
 line sets the default close operation and the following line makes the
 frame visible. The frame so created is shown in
-Figure <xref linkend="emptyFrameFigure"/>. Note that the frame is resizable.</simpara>
-<formalpara xml:id="program:EmptyFrame" xreflabel="EmptyFrame">
-<title>Program to create an empty frame.</title>
+<xref linkend="emptyFrameFigure"/>. Note that the frame is resizable.</simpara>
+<formalpara xml:id="EmptyFrameProgram">
+<title>Creates an empty frame.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 
@@ -22395,7 +22737,7 @@ public class EmptyFrame {
 }</programlisting>
 </para>
 </formalpara>
-<figure role="text-center">
+<figure xml:id="emptyFrameFigure" role="text-center">
 <title>An empty frame titled &#8220;Sound Check.&#8221;</title>
 <mediaobject>
 <imageobject>
@@ -22446,7 +22788,7 @@ statements add the two buttons one by one to the <literal>soundPanel</literal>. 
 add the panel to a frame object.</simpara>
 <programlisting language="java" linenumbering="unnumbered">soundCheck.add(soundPanel);</programlisting>
 <simpara>This statement adds the <literal>soundPanel</literal> to <literal>soundCheck</literal> frame that we
-created in Example <xref linkend="example:Empty_frame"/>.</simpara>
+created in <xref linkend="emptyFrameExample"/>.</simpara>
 <simpara>Another useful widget is <literal>JTextField</literal>. It creates a text field that can
 be used by a program for both input and output of <literal>String</literal> data.</simpara>
 <programlisting language="java" linenumbering="unnumbered">JTextField message = new JTextField("This is not a pipe.");</programlisting>
@@ -22466,35 +22808,58 @@ one, but the program will not do anything useful. Similarly, the text
 field will not be changed by the program after it is initialized. In the
 next subsection we add actions to each button and make the program more
 useful.</simpara>
-<formalpara xml:id="program:FrameWithPanel" xreflabel="FrameWithPanel">
-<title>Program to create a frame with a panel containing three buttons.</title>
+<formalpara xml:id="FrameWithPanelProgram">
+<title>Creates a frame with a panel containing three buttons.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 
 public class FrameWithPanel {
     public static void main(String[] args){
     	//Create frame
-        JFrame soundCheck = new JFrame("Sound Check");
-        JPanel soundPanel = new JPanel();
+        JFrame soundCheck = new JFrame("Sound Check"); <co xml:id="CO14-1"/>
+        JPanel soundPanel = new JPanel(); <co xml:id="CO14-2"/>
         //Create three buttons
-        JButton chirp = new JButton("Chirp");
+        JButton chirp = new JButton("Chirp"); <co xml:id="CO14-3"/>
         JButton bark = new JButton("Bark");
         JButton exit = new JButton("Exit");
         JTextField message = new JTextField("Listen to nature!");
-        soundPanel.add(chirp); // Add chirp to panel /*@\label{addBirdChirp}@*/
-        soundPanel.add(bark); //Add bark to panel
-        soundPanel.add(message); //Add message box
-        soundPanel.add(exit); //Add exit button/*@\label{addExit}@*/
-        soundCheck.add(soundPanel); //Add the panel to the frame/*@\label{addPanelToFrame}@*/
+        soundPanel.add(chirp); <co xml:id="CO14-4"/>
+        soundPanel.add(bark);
+        soundPanel.add(message);
+        soundPanel.add(exit);
+        soundCheck.add(soundPanel); <co xml:id="CO14-5"/>
         soundCheck.setSize(350,150); //Set size in pixels
-        soundCheck.setDefaultCloseOperation(
-        	JFrame.DISPOSE_ON_CLOSE);
-        soundCheck.setVisible(true); //Display frame
+        soundCheck.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        soundCheck.setVisible(true); <co xml:id="CO14-6"/>
     }
 }</programlisting>
 </para>
 </formalpara>
-<figure role="text-center">
+<calloutlist>
+<callout arearefs="CO14-1">
+<para>We first create a frame named <literal>soundCheck</literal>.</para>
+</callout>
+<callout arearefs="CO14-2">
+<para>Then a panel named <literal>soundPanel</literal>.</para>
+</callout>
+<callout arearefs="CO14-3">
+<para>Next, we create three buttons named <literal>chirp</literal>, <literal>bark</literal>, and <literal>exit</literal> and a text field named <literal>message</literal>.</para>
+</callout>
+<callout arearefs="CO14-4">
+<para>We add the buttons and the text field to <literal>soundPanel</literal>.</para>
+</callout>
+<callout arearefs="CO14-5">
+<para>Add <literal>soundPanel</literal> to <literal>soundCheck</literal>.</para>
+</callout>
+<callout arearefs="CO14-6">
+<para>After setting the size and the closing operation, the frame is made
+visible.</para>
+</callout>
+</calloutlist>
+<simpara>The final GUI is shown in <xref linkend="frameWithAPanelFigure"/>.
+Note that the same GUI may look different on different platforms. Later
+we will see how to add multiple panels to a frame.</simpara>
+<figure xml:id="frameWithAPanelFigure" role="text-center">
 <title>GUI consisting of a frame, a panel, three buttons, and a text field.</title>
 <mediaobject>
 <imageobject>
@@ -22503,17 +22868,10 @@ public class FrameWithPanel {
 <textobject><phrase>frameWithAPanelFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>In the <literal>main()</literal> method in Program <xref linkend="frameWithAPanelFigure"/>, we first
-create a frame named <literal>soundCheck</literal> and a panel named <literal>soundPanel</literal>. Next,
-we create three buttons named <literal>chirp</literal>, <literal>bark</literal>, and <literal>exit</literal>, labeled
-&#8220;Chirp,&#8221; &#8220;Bark,&#8221; and &#8220;Exit,&#8221; respectively. Lines <xref linkend="addBirdChirp"/>
-until <xref linkend="addExit"/> add the three buttons and the text field to
-<literal>soundPanel</literal>. At line <xref linkend="addPanelToFrame"/>, <literal>soundPanel</literal> is added to
-<literal>soundCheck</literal>. After setting the closing operation, the frame is made
-visible. The final GUI is shown in Figure <xref linkend="frameWithAPanelFigure"/>.
-Note that the same GUI may look different on different platforms. Later
-we will see how to add multiple panels to a frame.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise15.17">Exercise 15.17</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_adding_actions_to_widgets">
 <title>Adding actions to widgets</title>
@@ -22522,7 +22880,7 @@ could click a button labeled &#8220;Chirp,&#8221; causing the program to play a
 bird chirp sound. Clicking a button generates an <emphasis>event</emphasis>. In Java, an
 event is processed by one or more <emphasis>listeners</emphasis>. Java provides various
 types of listeners, some of which are introduced here and a few others
-in Section <xref linkend="subsection:Applets"/>. Next we show you how to handle action
+in <xref linkend="_applets"/>. Next we show you how to handle action
 events generated by a few different kinds of widgets.</simpara>
 <section xml:id="_the_literal_actionlistener_literal_interface">
 <title>The <literal>ActionListener</literal> interface</title>
@@ -22533,7 +22891,7 @@ object generates <literal>ActionEvent</literal> when it is pressed. Any class th
 implements the <literal>ActionListener</literal> interface can be registered as an action
 listener on a <literal>JButton</literal> or any other widget that generates an
 <literal>ActionEvent</literal>.</simpara>
-<simpara>As discussed in Chapter <xref linkend="chapter:Interfaces"/>, an interface is a set of
+<simpara>As discussed in <xref linkend="_interfaces"/>, an interface is a set of
 method signatures. If you implement an interface, you promise to have
 all of the methods in the interface. If a class implements
 <literal>ActionListener</literal>, it&#8217;s saying that it knows what to do when an action is
@@ -22571,22 +22929,21 @@ exist yet, we have to create it. Of course, it is possible to supply any
 object that implements the <literal>ActionListener</literal> interface, not just
 instances of anonymous classes. For more information about nested
 classes, inner classes, and anonymous classes, refer to
-Sections <xref linkend="advanced:Nested_classes"/> and <xref linkend="advanced:Local and anonymous
-classes"/>.</simpara>
+<xref linkend="_advanced_nested_classes"/> and <xref linkend="_advanced_local_and_anonymous_classes"/>.</simpara>
 <example>
 <title>GUI with actions</title>
-<simpara>We now modify Program <xref linkend="program:FrameWithPanel"/> to respond to button
+<simpara>We now modify <xref linkend="FrameWithPanelProgram"/> to respond to button
 clicks. When the <literal>chirp</literal> button is clicked, the program will display the
 message &#8220;Chirp requested.&#8221; in the text field. Similarly, when the
 <literal>bark</literal> button is clicked, the program will display &#8220;Bark requested.&#8221;</simpara>
-<simpara>Program <xref linkend="program:FrameWithPanelAndActions"/> is largely the same as
-Program <xref linkend="program:FrameWithPanel"/>. It adds the same buttons and text
+<simpara><xref linkend="FrameWithPanelAndActionsProgram"/> is largely the same as
+<xref linkend="FrameWithPanelProgram"/>. It adds the same buttons and text
 field but then adds an action listener to each button. The action
 performed when the <literal>chirp</literal> and <literal>bark</literal> buttons are clicked is to display
 a message in the text box. When the <literal>exit</literal> button is clicked, the
 listener displays a message on the console and exits the program.</simpara>
-<formalpara xml:id="program:FrameWithPanelAndActions" xreflabel="FrameWithPanelAndActions">
-<title>Program to demonstrate handling of action events.</title>
+<formalpara xml:id="FrameWithPanelAndActionsProgram">
+<title>Demonstrates handling of action events.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.event.*;
@@ -22643,6 +23000,9 @@ same scope as the inner class. For technical reasons, any local variable
 used in an anonymous inner class must be declared <literal>final</literal>. This
 restriction does not apply to class variables.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise15.16">Exercise 15.16</link></simpara>
+</sidebar>
 <example>
 <title>GUI with alternate action listener style</title>
 <simpara>In the previous example we added an <literal>ActionListener</literal> object to each
@@ -22652,11 +23012,11 @@ inner classes. An alternate way to use <literal>ActionListener</literal> is to i
 <literal>actionPerformed()</literal> method exactly once instead of creating several
 individual anonymous inner classes which each handle an event. Let&#8217;s
 examine one such implementation in
-Program <xref linkend="program:AlternateActionListener"/> and contrast it with
-Program <xref linkend="program:FrameWithPanelAndActions"/>. Note that both programs
+<xref linkend="AlternateActionListenerProgram"/> and contrast it with
+<xref linkend="FrameWithPanelAndActionsProgram"/>. Note that both programs
 generate exactly the same GUI and exhibit identical behavior.</simpara>
-<formalpara xml:id="program:AlternateActionListener" xreflabel="AlternateActionListener">
-<title>Program to demonstrate handling of action events by implementing <literal>ActionListener</literal> at the class level.</title>
+<formalpara xml:id="AlternateActionListenerProgram">
+<title>Demonstrates handling of action events by implementing <literal>ActionListener</literal> at the class level.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.event.*;
@@ -22669,7 +23029,7 @@ public class AlternateActionListener implements ActionListener {
   JButton exitButton = new JButton("Exit");
   JTextField message = new JTextField("Listen to nature!");
 
-  public AlternateActionListener (){/*@\label{alternateActionListenerLine}@*/
+  public AlternateActionListener (){ <co xml:id="CO15-1"/>
     chirpButton.addActionListener(this);
     barkButton.addActionListener(this);
     exitButton.addActionListener(this);
@@ -22679,58 +23039,51 @@ public class AlternateActionListener implements ActionListener {
 	soundPanel.add(exitButton);
     soundCheck.add(soundPanel);
     soundCheck.setSize(200,125);
-    soundCheck.setDefaultCloseOperation(
-    	JFrame.DISPOSE_ON_CLOSE);
+    soundCheck.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     soundCheck.setVisible(true);
   }
 
-  public void actionPerformed(ActionEvent e){/*@\label{actionPerformedLine}@*/
-    Object button = e.getSource(); /*@\label{identifyObjectLine}@*/
-    if(button == chirpButton)
-      message.setText("Chirp requested.");
+  public void actionPerformed(ActionEvent e){ <co xml:id="CO15-2"/>
+    Object button = e.getSource(); <co xml:id="CO15-3"/>
+    if(button == chirpButton) <co xml:id="CO15-4"/>
+		message.setText("Chirp requested.");
     else if(button == barkButton)
-      message.setText("Bark requested.");
+		message.setText("Bark requested.");
     else {
-      System.out.println("Exit");
-      soundCheck.dispose();
+		System.out.println("Exit");
+		soundCheck.dispose();
     }
   }
 
-  public static void main(String[] args){
+  public static void main(String[] args){ <co xml:id="CO15-5"/>
     new AlternateActionListener();
   }
 }</programlisting>
 </para>
 </formalpara>
-<simpara>In Program <xref linkend="program:AlternateActionListener"/> class
-<literal>AlternateActionListener</literal> implements <literal>ActionListener</literal>. Doing so requires
-the class to include <literal>actionPerformed()</literal>. The constructor, starting at
-line <xref linkend="alternateActionListenerLine"/>, adds an <literal>ActionListener</literal> to each
-button. The listener added is <literal>this</literal>, specifying that the
-<literal>AlternateActionListener</literal> object is the one that will process any action
-event generated by the buttons. The remainder of the code for the
-constructor is essentially the same as that from the <literal>main()</literal> method in
-Program <xref linkend="program:FrameWithPanelAndActions"/>.</simpara>
-<simpara>The <literal>actionPerformed()</literal> method, starting at
-line <xref linkend="actionPerformedLine"/>, has exactly one parameter, an
-<literal>ActionEvent</literal> object. Whenever an action event occurs, its attributes
-are bundled into an <literal>ActionEvent</literal> object and passed into the
-<literal>actionPerformed()</literal> method. At line <xref linkend="identifyObjectLine"/> the
-<literal>getSource()</literal> method is used to determine which object is responsible
-for the event. Variable <literal>button</literal> holds the object returned by
-<literal>getSource()</literal>. The next <literal>if</literal> statement compares <literal>button</literal> with <literal>chirp</literal>
-and <literal>bark</literal> to determine if either of these generated the event. Then a
-suitable message is displayed in the <literal>message</literal> box. If neither button
-generated the event, it must have been <literal>exit</literal>, and the frame disposes
-itself after displaying &#8220;Exit&#8221; on the console.</simpara>
-<simpara>The <literal>main()</literal> method simply creates an instance of
-<literal>AlternateActionListener</literal> and terminates. The program does not end
-because the threads for the GUI are still running.</simpara>
+<calloutlist>
+<callout arearefs="CO15-1">
+<para>The constructor adds an <literal>ActionListener</literal> to each button. The listener added is <literal>this</literal>, specifying that the <literal>AlternateActionListener</literal> object is the one that will process any action event generated by the buttons. The remainder of the code for the constructor is essentially the same as that from the <literal>main()</literal> method in <xref linkend="FrameWithPanelAndActionsProgram"/>.</para>
+</callout>
+<callout arearefs="CO15-2">
+<para>A class that implements <literal>ActionListener</literal> must include an <literal>actionPerformed()</literal> method.  It has exactly one parameter, an <literal>ActionEvent</literal> object. Whenever an action event occurs, its attributes are bundled into an <literal>ActionEvent</literal> object and passed into the <literal>actionPerformed()</literal> method.</para>
+</callout>
+<callout arearefs="CO15-3">
+<para>Here the <literal>getSource()</literal> method is used to determine which object is responsible for the event. Variable <literal>button</literal> holds the object returned by
+<literal>getSource()</literal>.</para>
+</callout>
+<callout arearefs="CO15-4">
+<para>These <literal>if</literal> statements compare <literal>button</literal> with <literal>chirp</literal> and <literal>bark</literal> to determine if either of these generated the event. Then a suitable message is displayed in the <literal>message</literal> box. If neither button generated the event, it must have been <literal>exit</literal>, and the frame disposes itself after displaying &#8220;Exit&#8221; on the console.</para>
+</callout>
+<callout arearefs="CO15-5">
+<para>The <literal>main()</literal> method simply creates an instance of <literal>AlternateActionListener</literal> and terminates. The program does not end because the threads for the GUI are still running.</para>
+</callout>
+</calloutlist>
 </example>
 <simpara>It is instructive to note the differences between
-Programs <xref linkend="program:FrameWithPanelAndActions"/> and
-<xref linkend="program:AlternateActionListener"/>. In
-Program <xref linkend="program:AlternateActionListener"/>, most of the code has been
+<xref linkend="FrameWithPanelAndActionsProgram"/> and
+<xref linkend="AlternateActionListenerProgram"/>. In
+<xref linkend="AlternateActionListenerProgram"/>, most of the code has been
 moved from the ` main()` method to the constructor. Various objects,
 namely the <literal>soundCheck</literal> frame, the <literal>soundPanel</literal> panel, all three
 buttons, and the text box are now fields of the object instead of local
@@ -22745,6 +23098,9 @@ subclass of <literal>JFrame</literal>) as the <literal>ActionListener</literal> 
 events in a centralized location. It can be easier to find errors when
 all events are handled in one <literal>actionPerformed()</literal> method, but the method
 can become long and complex as well.</simpara>
+<sidebar>
+<simpara><link linkend="exercise15.16">Exercise 15.16</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_the_literal_mouselistener_literal_interface">
 <title>The <literal>MouseListener</literal> interface</title>
@@ -22790,37 +23146,28 @@ argument. To handle mouse events, a class must implement the
 <literal>ActionListener</literal> interface from the previous section, but implementing
 <literal>MouseListener</literal> requires a definition for <emphasis role="strong">each</emphasis> of the five methods
 listed above. The next example illustrates <literal>MouseListener</literal> in use.</simpara>
-<example>
+<example xml:id="mouseListenerExample">
 <title>Mouse listener</title>
-<simpara>We write a program that displays a GUI containing two buttons labeled
+<simpara>We can write a program that displays a GUI containing two buttons labeled
 &#8220;One&#8221; and &#8220;Two.&#8221; In addition a text box displays a suitable message
 when the cursor enters a button. When a button is clicked, the status
 box should display the total number of times that button has been
 clicked so far.</simpara>
-<simpara>Program <xref linkend="program:SimpleMouseEvents"/> generates the GUI shown in
-Figure <xref linkend="simpleMouseEventsFigure"/>. At
-line <xref linkend="simpleMouseEventsClassDefLine"/> class <literal>SimpleMouseEvents</literal> is
-declared, implementing the <literal>MouseListener</literal> interface. The following few
-lines declare frame <literal>frame</literal>, buttons <literal>one</literal> and <literal>two</literal>, and a text box
-<literal>status</literal>. Two integers <literal>oneClicks</literal> and <literal>twoClicks</literal> are initialized to 0
-and are used to keep track of the number of times each button has been
-clicked.</simpara>
-<formalpara xml:id="program:SimpleMouseEvents" xreflabel="SimpleMouseEvents">
-<title>Program to demonstrate the handling of mouse generated events using the <literal>MouseListener</literal> interface.</title>
+<formalpara xml:id="SimpleMouseEventsProgram">
+<title>Demonstrates the handling of mouse generated events using the <literal>MouseListener</literal> interface.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 
-public class SimpleMouseEvents implements MouseListener {/*@\label{simpleMouseEventsClassDefLine}@*/
+public class SimpleMouseEvents implements MouseListener { <co xml:id="CO16-1"/>
 	JFrame frame = new JFrame("Mouse Events");
-	JTextField status = new JTextField(
-		"Mouse status comes here.");
+	JTextField status = new JTextField("Mouse status comes here.");
 	JButton one = new JButton("One");
 	JButton two = new JButton("Two");
 	int oneClicks = 0, twoClicks = 0; //Number of clicks
 
-    public SimpleMouseEvents() {/*@\label{simpleMouseEventsConstructorLine}@*/
+    public SimpleMouseEvents() { <co xml:id="CO16-2"/>
         JPanel panel = new JPanel();
         one.addMouseListener(this);
         two.addMouseListener(this);
@@ -22835,36 +23182,57 @@ public class SimpleMouseEvents implements MouseListener {/*@\label{simpleMouseEv
     }
 
     // Implement all abstract methods in MouseListener
-    public void mouseEntered(MouseEvent e) { /*@\label{mouseEnteredEventLine}@*/
-	    if (e.getSource() == one) /*@\label{getObjectEnteredLine}@*/
+    public void mouseEntered(MouseEvent e) { <co xml:id="CO16-3"/>
+	    if (e.getSource() == one)
 	        status.setText("Mouse enters One.");
 	    else
 	        status.setText("Mouse enters Two.");
     }
 
-	public void mouseClicked(MouseEvent e) {
-		if (e.getSource() == one) {/*@\label{getObjectClickedLine}@*/
+	public void mouseClicked(MouseEvent e) { <co xml:id="CO16-4"/>
+		if (e.getSource() == one) {
 			oneClicks++;
-			status.setText("One clicked "+ oneClicks +
-				" times.");
+			status.setText("One clicked "+ oneClicks + " times.");
 		}
 		else {
 			twoClicks++;
-			status.setText("Two clicked "+ twoClicks  +
-				" times.");
+			status.setText("Two clicked "+ twoClicks  + " times.");
 		}
 	}
 
-	public void mouseExited(MouseEvent e) {} /*@\label{exitedNotImplementedLine}@*/
+	public void mouseExited(MouseEvent e) {} // Unimplemented methods
 	public void mousePressed(MouseEvent e) {}
 	public void mouseReleased(MouseEvent e) {}
-	public static void main(String[] args){
+
+	public static void main(String[] args){ <co xml:id="CO16-5"/>
 		  new SimpleMouseEvents();
 	}
 }</programlisting>
 </para>
 </formalpara>
-<figure role="text-center">
+<calloutlist>
+<callout arearefs="CO16-1">
+<para>We declare class <literal>SimpleMouseEvents</literal>, implementing the <literal>MouseListener</literal> interface. The following few lines declare frame <literal>frame</literal>, buttons <literal>one</literal> and <literal>two</literal>, and a text box <literal>status</literal>. Two integers <literal>oneClicks</literal> and <literal>twoClicks</literal> are initialized to 0 and are used to keep track of the number of times each button has been clicked.</para>
+</callout>
+<callout arearefs="CO16-2">
+<para>The first line of the <literal>SimpleMouseEvents</literal> constructor creates the panel
+<literal>panel</literal>. It doesn&#8217;t need to be a field, and it&#8217;s always preferable to
+keep a variable local if it can be. The next two lines add a <literal>MouseListener</literal> to the two buttons. Note the use of <literal>this</literal> in the argument to <literal>addMouseListener()</literal> which refers to the object being created by the constructor. Next, the panel is set up and added to the frame. Finally the frame size and its default close operations are set, and the frame is made visible.</para>
+</callout>
+<callout arearefs="CO16-3">
+<para>The <literal>mouseEntered()</literal> method is invoked when the cursor enters either of the two buttons. First we retrieve the source of the event using the <literal>getSource()</literal> method and identify which object generated the event. A suitable message is displayed in the status box using the <literal>setText()</literal> method.</para>
+</callout>
+<callout arearefs="CO16-4">
+<para>The <literal>mouseClicked()</literal> method is invoked when the mouse cursor is placed over a button and clicked. As before, we retrieve the source of the event using the <literal>getSource()</literal> method. A suitable message, including the number of clicks, is displayed in the text box. Of course, recording the button clicks could have been done with an <literal>ActionListener</literal> instead.</para>
+</callout>
+<callout arearefs="CO16-5">
+<para>The only job of the <literal>main()</literal> method is to create an instance of
+<literal>SimpleMouseEvents</literal>.</para>
+</callout>
+</calloutlist>
+<simpara><xref linkend="SimpleMouseEventsProgram"/> generates the GUI shown in
+<xref linkend="simpleMouseEventsFigure"/>.</simpara>
+<figure xml:id="simpleMouseEventsFigure" role="text-center">
 <title>GUI consisting of two buttons and a text box. Button clicks and entry of the cursor into a button are reported by the text box.</title>
 <mediaobject>
 <imageobject>
@@ -22873,34 +23241,15 @@ public class SimpleMouseEvents implements MouseListener {/*@\label{simpleMouseEv
 <textobject><phrase>simpleMouseEventsFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>The first line of the <literal>SimpleMouseEvents</literal> constructor creates the panel
-<literal>panel</literal>. It does not need to be a field, and it is always preferable to
-keep a variable local if it can be. The next two lines add a
-<literal>MouseListener</literal> to the two buttons. Note the use of <literal>this</literal> in the
-argument to <literal>addMouseListener()</literal> which refers to the object being
-created by the constructor. Next, the panel is set up and added to the
-frame. Finally the frame size and its default close operations are set,
-and the frame is made visible.</simpara>
-<simpara>Implementation of the methods in the <literal>MouseListener</literal> interface begins at
-line <xref linkend="mouseEnteredEventLine"/>. The <literal>mouseEntered()</literal> method is invoked
-when the cursor enters either of the two buttons. First we retrieve the
-source of the event using the <literal>getSource()</literal> method and identify which
-object generated the event. A suitable message is displayed in the
-status box using the <literal>setText()</literal> method.</simpara>
-<simpara>The <literal>mouseClicked()</literal> method is invoked when the mouse cursor is placed
-over a button and clicked. As before, we retrieve the source of the
-event using the <literal>getSource()</literal> method. A suitable message, including the
-number of clicks, is displayed in the text box. Of course, recording the
-button clicks could have been done with an <literal>ActionListener</literal> instead.</simpara>
-<simpara>The only job of the <literal>main()</literal> method is to create an instance of
-<literal>SimpleMouseEvents</literal>. You may wish to compile and execute the program and
-test whether or not the program behaves as described.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise15.8">Exercise 15.8</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_mouse_adapter">
 <title>Mouse adapter</title>
 <simpara>Creating a <literal>MouseListener</literal> requires all five methods in the interface to
-be implemented. In some cases, as in Example <xref linkend="example:Mouse_listener"/>,
+be implemented. In some cases, as in <xref linkend="mouseListenerExample"/>,
 there is no need to implement all the methods because we are not
 interested in all the corresponding events. In such situations we are
 forced to include the methods without any statement in the method body.
@@ -22914,22 +23263,16 @@ mouse events. We can override these implementations as needed, and we do
 not need to provide an implementation of a method that is not used.</simpara>
 <example>
 <title>Mouse adapter</title>
-<simpara>Program <xref linkend="program:SimpleMouseAdapter"/> is a revised version of
-Program <xref linkend="program:SimpleMouseEvents"/>. At
-line <xref linkend="simpleMouseAdapterClassDefLine"/> class <literal>SimpleMouseAdapter</literal>
-extends the abstract class <literal>MouseAdapter</literal>. Thus, it inherits all the
-empty methods defined in <literal>MouseAdapter</literal>. We then override only the
-implementations of the methods we want to use, <literal>mouseEntered()</literal> and
-<literal>mouseClicked()</literal> in this example. Remember that an abstract class is
-<emphasis role="strong">extended</emphasis> whereas an interface is <emphasis role="strong">implemented</emphasis>.</simpara>
-<formalpara xml:id="program:SimpleMouseAdapter" xreflabel="SimpleMouseAdapter">
-<title>Program to handle mouse generated events using the <literal>MouseAdapter</literal> abstract class.</title>
+<simpara><xref linkend="SimpleMouseAdapterProgram"/> is a revised version of
+<xref linkend="SimpleMouseEventsProgram"/>. Remember that an abstract class is <emphasis role="strong">extended</emphasis> whereas an interface is <emphasis role="strong">implemented</emphasis>.</simpara>
+<formalpara xml:id="SimpleMouseAdapterProgram">
+<title>Handles mouse generated events using the <literal>MouseAdapter</literal> abstract class.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 
-public class SimpleMouseAdapter extends MouseAdapter {/*@\label{simpleMouseAdapterClassDefLine}@*/
+public class SimpleMouseAdapter extends MouseAdapter { <co xml:id="CO17-1"/>
     JFrame frame = new JFrame("Mouse Events");
     JTextField status = new JTextField(
     	"Mouse status comes here.");
@@ -22946,39 +23289,50 @@ public class SimpleMouseAdapter extends MouseAdapter {/*@\label{simpleMouseAdapt
         panel.add(status);
         frame.add(panel);
         frame.setSize(200,100);
-        frame.setDefaultCloseOperation(
-        	JFrame.DISPOSE_ON_CLOSE);
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         frame.setVisible(true);
     }
 
-    // Override only those methods we wants
-    public void mouseEntered(MouseEvent e) { /*@\label{implementMouseEnteredLine}@*/
+    // Override only those methods we want
+    public void mouseEntered(MouseEvent e) { <co xml:id="CO17-2"/>
 	    if (e.getSource() == one)
 	        status.setText("Mouse enters One.");
 	    else
 	        status.setText("Mouse enters Two.");
     }
 
-    public void mouseClicked(MouseEvent e) {/*@\label{implementMouseClickedLine}@*/
+    public void mouseClicked(MouseEvent e) { <co xml:id="CO17-3"/>
     	if (e.getSource() == one) {
 			oneClicks++;
-			status.setText("One clicked "+ oneClicks +
-				" times.");
+			status.setText("One clicked "+ oneClicks + " times.");
 		}
 		else {
 			twoClicks++;
-			status.setText("Two clicked "+ twoClicks  +
-				" times.");
+			status.setText("Two clicked "+ twoClicks  + " times.");
 		}
     }
 
     public static void main(String[] args){
-      new SimpleMouseAdapter ();
+		new SimpleMouseAdapter ();
     }
 }</programlisting>
 </para>
 </formalpara>
+<calloutlist>
+<callout arearefs="CO17-1">
+<para>Class <literal>SimpleMouseAdapter</literal> extends the abstract class <literal>MouseAdapter</literal>. Thus, it inherits all the empty methods defined in <literal>MouseAdapter</literal>.</para>
+</callout>
+<callout arearefs="CO17-2">
+<para>We override the method <literal>mouseEntered()</literal>.</para>
+</callout>
+<callout arearefs="CO17-3">
+<para>We override the method <literal>mouseClicked()</literal>.  No other methods need to be overridden in this example.</para>
+</callout>
+</calloutlist>
 </example>
+<sidebar>
+<simpara><link linkend="exercise15.3">Exercise 15.3</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_other_event_listeners">
 <title>Other event listeners</title>
@@ -22993,7 +23347,7 @@ the methods <literal>mouseDragged()</literal> and <literal>mouseMoved()</literal
 handle mouse movement with or without the button pressed.</simpara>
 <simpara>An <literal>ItemListener</literal> can be attached to a widget such as a check box or a
 radio button to listen for a check box to be selected. This listener is
-illustrated in Section <xref linkend="subsection:Applets"/>.</simpara>
+illustrated in <xref linkend="_applets"/>.</simpara>
 <simpara>Java provides several other listeners to handle a variety of events. For
 example, the <literal>DocumentListener</literal> can be attached to a <literal>JTextField</literal> or a
 <literal>JTextArea</literal> object to listen to document events, which include the
@@ -23043,15 +23397,15 @@ URL, exactly once. If you want to play the clip in a loop, use the
 <programlisting language="java" linenumbering="unnumbered">chirpClip.stop();</programlisting>
 <simpara>Now that we have seen how to declare, load, play, and stop an audio
 clip, we are ready to write a more interesting version of
-Program <xref linkend="program:FrameWithPanelAndActions"/>.</simpara>
-<example>
+<xref linkend="FrameWithPanelAndActionsProgram"/>.</simpara>
+<example xml:id="soundGameExample">
 <title>Sound game</title>
-<simpara>We can rewrite Program <xref linkend="program:FrameWithPanelAndActions"/> so that the
+<simpara>We can rewrite <xref linkend="FrameWithPanelAndActionsProgram"/> so that the
 new program plays the sound clips in a loop when the corresponding
 button is clicked. Think of the new program as a Java version of the
 pull-string toys that children use to play animal sounds. Our program
 only has two sounds, but more could be added.</simpara>
-<figure role="text-center">
+<figure xml:id="soundGameFigures" role="text-center">
 <title>GUI for the sound game application. (a) On program start. (b) After the &#8220;Chirp&#8221; button has been clicked and the clip is playing.</title>
 <mediaobject>
 <imageobject>
@@ -23063,20 +23417,14 @@ only has two sounds, but more could be added.</simpara>
 <simpara>We will add a new button labeled &#8220;Stop Sound&#8221; that stops the playback
 of sounds when clicked. Let&#8217;s assume that this program is only allowed
 to play one sound at a time. When it starts, the GUI will look like
-Figure <xref linkend="SoundGameFigures"/>(a). Note that the <literal>stop</literal> button is gray,
+<xref linkend="soundGameFigures"/>(a). Note that the <literal>stop</literal> button is gray,
 indicating that it is disabled.</simpara>
 <simpara>The complete program for the game is shown in
-Program <xref linkend="program:SoundGame"/>. Because most of this program is similar
-to Program <xref linkend="program:FrameWithPanel"/>, we will only look at the
-differences. The action listeners for the <literal>chirp</literal> and <literal>bark</literal> buttons are
-called when these two buttons are clicked. On line <xref linkend="buttonDisableLine"/>
-we disable the <literal>bark</literal> button when the bird chirp sound is playing. Also,
-on line <xref linkend="buttonEnableLine"/> we enable the <literal>stop</literal> button so that the
-user can stop the chirp sound. Note that the <literal>stop</literal> button begins
-disabled and remains that way until a sound is played. The GUI now looks
-like Figure <xref linkend="SoundGameFigures"/>(b).</simpara>
-<formalpara xml:id="program:SoundGame" xreflabel="SoundGame">
-<title>An animal sound game.</title>
+<xref linkend="SoundGameProgram"/>. Because most of this program is similar
+to <xref linkend="FrameWithPanelProgram"/>, we will only look at the
+differences.</simpara>
+<formalpara xml:id="SoundGameProgram">
+<title>Animal sound game.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.event.*;
@@ -23091,8 +23439,7 @@ public class SoundGame {
     final JButton bark = new JButton("Bark");
     final JButton stop = new JButton("Stop Sound");
     final JButton exit = new JButton("Exit");
-    final JTextField message =
-    	new JTextField("Click Chirp or Bark.   ");
+    final JTextField message = new JTextField("Click Chirp or Bark.   ");
     URL chirpURL = new URL("file:sounds/chirp.wav");
     URL barkURL = new URL("file:sounds/bark.wav");
     final AudioClip chirpClip = Applet.newAudioClip(chirpURL);
@@ -23103,55 +23450,72 @@ public class SoundGame {
     soundPanel.add(exit);
     soundPanel.add(message);
     soundGame.add(soundPanel);
-    stop.setEnabled(false); /*@\label{stopButtonDisableLine}@*/
-    chirp.addActionListener(new ActionListener() {
-      public void actionPerformed(ActionEvent e){
-        message.setText("Chirp sound playing.");
-        bark.setEnabled(false);  /*@\label{buttonDisableLine}@*/
-        chirpClip.loop(); /*@\label{soundPlayLine}@*/
-        stop.setEnabled(true); /*@\label{buttonEnableLine}@*/
+    stop.setEnabled(false); <co xml:id="CO18-1"/>
+    chirp.addActionListener(new ActionListener() { <co xml:id="CO18-2"/>
+		public void actionPerformed(ActionEvent e){
+			message.setText("Chirp sound playing.");
+			bark.setEnabled(false);
+			chirpClip.loop();
+			stop.setEnabled(true);
       }
     });
-    bark.addActionListener(new ActionListener(){
-      public void actionPerformed(ActionEvent e){
-        message.setText("Bark sound playing.");
-        chirp.setEnabled(false);
-        barkClip.loop();
-        stop.setEnabled(true);
+    bark.addActionListener(new ActionListener(){ <co xml:id="CO18-3"/>
+		public void actionPerformed(ActionEvent e){
+			message.setText("Bark sound playing.");
+			chirp.setEnabled(false);
+			barkClip.loop();
+			stop.setEnabled(true);
       }
     });
-    stop.addActionListener(new ActionListener(){
-      public void actionPerformed(ActionEvent e){
-        message.setText("Click Chirp or Bark.");
-        chirpClip.stop();
-        bark.setEnabled(true);
-        barkClip.stop();
-        chirp.setEnabled(true);
-        stop.setEnabled(false);
+    stop.addActionListener(new ActionListener(){ <co xml:id="CO18-4"/>
+		public void actionPerformed(ActionEvent e){
+			message.setText("Click Chirp or Bark.");
+			chirpClip.stop();
+			bark.setEnabled(true);
+			barkClip.stop();
+			chirp.setEnabled(true);
+			stop.setEnabled(false);
       }
     });
-    exit.addActionListener(new ActionListener(){
-      public void actionPerformed(ActionEvent e){
-        System.out.println("Exit");
-        soundGame.dispose();
+    exit.addActionListener(new ActionListener(){ <co xml:id="CO18-5"/>
+		public void actionPerformed(ActionEvent e){
+			System.out.println("Exit");
+			soundGame.dispose();
       }
     });
     soundGame.setSize(175,175); //Set size in pixels
-    soundGame.setDefaultCloseOperation(
-    	JFrame.DISPOSE_ON_CLOSE);
+    soundGame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     soundGame.setVisible(true); //Display it
   }
 }</programlisting>
 </para>
 </formalpara>
-<simpara>The actions for the <literal>bark</literal> button are very similar to the actions for
-the <literal>chirp</literal> button, but the actions for <literal>stop</literal> are different. When
-<literal>stop</literal> is clicked, the action listener does not know which sound is
-playing. For that reason, it stops both sounds and then disables the
-stop button. An exercise asks you to modify the program so that the
-action listener associated with the <literal>stop</literal> button knows which sound is
+<calloutlist>
+<callout arearefs="CO18-1">
+<para>We start with the <literal>stop</literal> button disabled.</para>
+</callout>
+<callout arearefs="CO18-2">
+<para>Here we define the action listener for the <literal>chirp</literal> button, which
+disables the <literal>bark</literal> button, tells the user that the chirp sound is playing, plays the sound, and enables the <literal>stop</literal> button.</para>
+</callout>
+<callout arearefs="CO18-3">
+<para>The action listener for the <literal>bark</literal> button is similar.</para>
+</callout>
+<callout arearefs="CO18-4">
+<para>The action listener for the <literal>stop</literal> button does not know what sound is playing, so it stops both sounds and then disables the
+stop button.</para>
+</callout>
+<callout arearefs="CO18-5">
+<para>The action listener for the <literal>exit</literal> button prints &#8220;Exit&#8221; and disposes the frame.</para>
+</callout>
+</calloutlist>
+<simpara>When the <literal>chirp</literal> button is clicked, the GUI looks like <xref linkend="soundGameFigures"/>(b). An exercise asks you to modify the program so that the action listener associated with the <literal>stop</literal> button knows which sound is
 playing.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise15.11">Exercise 15.11</link><?asciidoc-br?>
+<link linkend="exercise15.12">Exercise 15.12</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_images_and_icons">
 <title>Images and icons</title>
@@ -23170,12 +23534,15 @@ button.</simpara>
 smile.add(smileIcon);</programlisting>
 <simpara>Similarly you can add an image icon to a label. The next example gives a
 simple program that creates a button with an image.</simpara>
+<sidebar>
+<simpara><link linkend="exercise15.10">Exercise 15.10</link></simpara>
+</sidebar>
 <example>
 <title>Icon example</title>
-<simpara>Figure <xref linkend="IconExampleFigure"/> shows a GUI with a button decorated with a
-picture. Program <xref linkend="program:IconExample"/> gives the code to create this
+<simpara><xref linkend="IconExampleFigure"/> shows a GUI with a button decorated with a
+picture. <xref linkend="IconExampleProgram"/> gives the code to create this
 GUI using the <literal>ImageIcon</literal> class.</simpara>
-<figure role="text-center">
+<figure xml:id="IconExampleFigure" role="text-center">
 <title>A GUI with a button decorated by an image icon.</title>
 <mediaobject>
 <imageobject>
@@ -23184,37 +23551,39 @@ GUI using the <literal>ImageIcon</literal> class.</simpara>
 <textobject><phrase>iconExampleFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>As explained earlier, an image icon is created at
-line <xref linkend="iconCreationLine"/> from a JPEG file named <literal>smile.jpg</literal> located in
-the <literal>pictures</literal> directory. The following line creates a button named
-<literal>smile</literal> and decorates it with the icon by supplying it as an argument to
-the <literal>JButton</literal> constructor. Note that, if the file cannot be found, the
-program will fail <emphasis>quietly</emphasis>. This means that no exception is thrown.
-Instead, the button will appear with no image. Subsequent lines add the
-button to the frame, set the frame size and its default close operation,
-and make the frame visible.</simpara>
-<formalpara xml:id="program:IconExample" xreflabel="IconExample">
-<title>A program to create a GUI with a button decorated by a picture.</title>
+<formalpara xml:id="IconExampleProgram">
+<title>Creates a GUI with a button decorated by a picture.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
 
 public class IconExample {
-  public static void main(String[] args) {
-	JFrame iconFrame = new JFrame("Icon Example");
-	ImageIcon smileIcon = new ImageIcon(/*@\label{iconCreationLine}@*/
-		"pictures/smile.jpg");
-	JButton  smile = new JButton(smileIcon);/*@\label{adIconToButtonLine}@*/
-	iconFrame.add(smile);
-	iconFrame.setSize(325,250);
-	iconFrame.setDefaultCloseOperation(
-		JFrame.DISPOSE_ON_CLOSE);
-	iconFrame.setVisible(true);
+	public static void main(String[] args) {
+		JFrame iconFrame = new JFrame("Icon Example");
+		ImageIcon smileIcon = new ImageIcon("pictures/smile.jpg"); <co xml:id="CO19-1"/>
+		JButton  smile = new JButton(smileIcon); <co xml:id="CO19-2"/>
+		iconFrame.add(smile);
+		iconFrame.setSize(325,250);
+		iconFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+		iconFrame.setVisible(true);
   }
 }</programlisting>
 </para>
 </formalpara>
+<calloutlist>
+<callout arearefs="CO19-1">
+<para>An image icon is created from a JPEG file named <literal>smile.jpg</literal> located in
+the <literal>pictures</literal> directory.</para>
+</callout>
+<callout arearefs="CO19-2">
+<para>We create a button named <literal>smile</literal> and decorate it with the icon by supplying it as an argument to the <literal>JButton</literal> constructor. Note that, if the file cannot be found, the program will fail <emphasis>quietly</emphasis>. This means that no exception is thrown. Instead, the button will appear with no image.</para>
+</callout>
+</calloutlist>
+<simpara>The remaining lines add the button to the frame, set the frame size and its default close operation, and make the frame visible.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise15.9">Exercise 15.9</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_labels_icons_and_text">
 <title>Labels, icons, and text</title>
@@ -23246,12 +23615,9 @@ vertical positions of the text.</simpara>
 flower.setHorizontalTextPosition(JLabel.CENTER);</programlisting>
 <example>
 <title>Label example</title>
-<simpara>Figure <xref linkend="labelExampleFigure"/>(a) is generated by executing Program 
-<xref linkend="program:LabelExample"/>. You will see the GUI shown in
-Figure <xref linkend="labelExampleFigure"/>(b) if the alignment instructions at
-lines <xref linkend="verticalTextPositioningLine"/> and
-<xref linkend="horizontalTextPositioningLine"/> are omitted.</simpara>
-<figure>
+<simpara><xref linkend="labelExampleFigure"/>(a) is generated by executing Program 
+<xref linkend="LabelExampleProgram"/>.</simpara>
+<figure xml:id="labelExampleFigure">
 <title>(a) A GUI with a label decorated by an image icon and a title beneath it. (b) The GUI with unaligned text.</title>
 <mediaobject>
 <imageobject>
@@ -23260,8 +23626,8 @@ lines <xref linkend="verticalTextPositioningLine"/> and
 <textobject><phrase>labelExampleFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<formalpara xml:id="program:LabelExample" xreflabel="LabelExample">
-<title>A program to create a GUI with a label decorated by a picture and text.</title>
+<formalpara xml:id="LabelExampleProgram">
+<title>Creates a GUI with a label decorated by a picture and text.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
@@ -23269,21 +23635,28 @@ import java.awt.*;
 public class LabelExample {
 	public static void main(String[] args) {
 		JFrame frame = new JFrame("Label Example");
-		ImageIcon hibiscus = new ImageIcon(
-			"pictures/hibiscus.jpg");
-		JLabel flower = new JLabel("Red Hibiscus",
-			hibiscus, JLabel.CENTER);
-		flower.setVerticalTextPosition(JLabel.BOTTOM); /*@\label{verticalTextPositioningLine}@*/
-		flower.setHorizontalTextPosition(JLabel.CENTER);/*@\label{horizontalTextPositioningLine}@*/
+		ImageIcon hibiscus = new ImageIcon("pictures/hibiscus.jpg");
+		JLabel flower = new JLabel("Red Hibiscus", hibiscus, JLabel.CENTER);
+		flower.setVerticalTextPosition(JLabel.BOTTOM); <co xml:id="CO20-1"/>
+		flower.setHorizontalTextPosition(JLabel.CENTER); <co xml:id="CO20-2"/>
 		frame.add(flower);
 		frame.setSize(300,250);
-		frame.setDefaultCloseOperation(
-			JFrame.DISPOSE_ON_CLOSE);
+		frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 		frame.setVisible(true);
   }
 }</programlisting>
 </para>
 </formalpara>
+<calloutlist>
+<callout arearefs="CO20-1">
+<para>Vertically position the text on the bottom of the label.</para>
+</callout>
+<callout arearefs="CO20-2">
+<para>Horizontally center the text on the label.</para>
+</callout>
+</calloutlist>
+<simpara>You will see the GUI shown in
+<xref linkend="labelExampleFigure"/>(b) if the alignment instructions on these two lines are omitted.</simpara>
 </example>
 </section>
 </section>
@@ -23314,38 +23687,43 @@ the <literal>BorderLayout</literal> manager by default, which would have complic
 examples. The next example illustrates <literal>FlowLayout</literal> further.</simpara>
 <example>
 <title>FlowLayout</title>
-<simpara>Program <xref linkend="program:FlowLayoutExample"/> creates a GUI with several
-buttons. It first creates a frame. At line <xref linkend="setLayoutManagerLine"/> it
-creates a panel and set its layout manager to <literal>FlowLayout</literal>. Then, it
-uses a <literal>for</literal> loop to create a new button, label it appropriately, and
-add it to the panel.</simpara>
-<simpara>The <literal>Flowlayout</literal> manager neatly places the buttons along a number of
-rows depending on the width of the frame. The GUI created is shown in
-Figure <xref linkend="figure:FlowLayoutExampleFigure"/>. Run the program and resize
-the frame to see the effect on the layout of the buttons.</simpara>
-<formalpara xml:id="program:FlowLayoutExample" xreflabel="FlowLayoutExample">
-<title>Adding several buttons using <literal>FlowLayout</literal>.</title>
+<simpara><xref linkend="FlowLayoutExampleProgram"/> creates a GUI with several
+buttons.</simpara>
+<formalpara xml:id="FlowLayoutExampleProgram">
+<title>Adds several buttons using <literal>FlowLayout</literal>.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
 
 public class FlowLayoutExample {
-  public static void main(String[] args) {
-    JFrame frame = new JFrame("FlowLayout Example");
-    JPanel panel = new JPanel(new FlowLayout());  /*@\label{setLayoutManagerLine}@*/
-    final int MAX_BUTTONS = 6;
-    for(int i = 0; i &lt; MAX_BUTTONS; i++)
-    	panel.add(new JButton("   " + i + "   "));/*@\label{createAButtonLine}@*/
-    frame.add(panel);
-    frame.setSize(250,100);
-    frame.setResizable(false);/*@\label{disableResizableLine}@*/
-    frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-    frame.setVisible(true);
-  }
+	public static void main(String[] args) {
+		JFrame frame = new JFrame("FlowLayout Example"); <co xml:id="CO21-1"/>
+		JPanel panel = new JPanel(new FlowLayout()); <co xml:id="CO21-2"/>
+		final int MAX_BUTTONS = 6;
+		for(int i = 0; i &lt; MAX_BUTTONS; i++) <co xml:id="CO21-3"/>
+			panel.add(new JButton("   " + i + "   "));
+		frame.add(panel);
+		frame.setSize(250,100);
+		frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+		frame.setResizable(false);
+		frame.setVisible(true);
+	}
 }</programlisting>
 </para>
 </formalpara>
-<figure role="text-center">
+<calloutlist>
+<callout arearefs="CO21-1">
+<para>We first create a frame.</para>
+</callout>
+<callout arearefs="CO21-2">
+<para>We create a panel and set its layout manager to <literal>FlowLayout</literal>.</para>
+</callout>
+<callout arearefs="CO21-3">
+<para>This <literal>for</literal> loop is used to create new buttons, label them appropriately, and add them to the panel.</para>
+</callout>
+</calloutlist>
+<simpara>The <literal>Flowlayout</literal> manager neatly places the buttons along a number of rows depending on the width of the frame. The GUI created is shown in <xref linkend="FlowLayoutExampleFigure"/>.</simpara>
+<figure xml:id="FlowLayoutExampleFigure" role="text-center">
 <title>Using the <literal>FlowLayout</literal> manager to generate a GUI containing six buttons.</title>
 <mediaobject>
 <imageobject>
@@ -23355,6 +23733,10 @@ public class FlowLayoutExample {
 </mediaobject>
 </figure>
 </example>
+<sidebar>
+<simpara><link linkend="exercise15.18">Exercise 15.18</link><?asciidoc-br?>
+<link linkend="exercise15.19">Exercise 15.19</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_literal_gridlayout_literal">
 <title><literal>GridLayout</literal></title>
@@ -23369,8 +23751,8 @@ of rows and columns, respectively. The last two arguments give the
 horizontal and vertical gaps between the neighboring cells in the grid.
 In this example the frame will contain a total of six cells organized
 into three rows with two columns.</simpara>
-<figure role="text-center">
-<title>A 3 <inlineequation><alt><![CDATA[\times]]></alt><mathphrase><![CDATA[\times]]></mathphrase></inlineequation> 2 grid layout containing six buttons using left to right orientation.</title>
+<figure xml:id="gridLayoutLToRFigure" role="text-center">
+<title>A 3 × 2 grid layout containing six buttons using left to right orientation.</title>
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/15-gui/images/gridLayoutLToRFigure.png" width="40%"/>
@@ -23378,20 +23760,23 @@ into three rows with two columns.</simpara>
 <textobject><phrase>gridLayoutLToRFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>Figure <xref linkend="gridLayoutLToRFigure"/> shows how <literal>frame</literal> will look after six
+<simpara><xref linkend="gridLayoutLToRFigure"/> shows how <literal>frame</literal> will look after six
 buttons, labeled 0 through 5, have been added to it in that order. A key
 feature of using a <literal>GridLayout</literal> is that all cells in the grid will be
 the same size and will stretch to fill the entire container. Also note
 the equal spacing between the neighboring cells. It is possible to add
 more or fewer cells than specified in the <literal>GridLayout</literal> constructor, but
 the layout manager will be forced to guess at your intentions.</simpara>
+<sidebar>
+<simpara><link linkend="exercise15.20">Exercise 15.20</link></simpara>
+</sidebar>
 <example>
 <title>Animal identifier</title>
 <simpara>We can write a program to displays pictures of animals and identify
 which animal the mouse is current hovering over. The animal&#8217;s name will
 be displayed in the title of the frame.
-Figure <xref linkend="animalIdentifierFigure"/> shows this GUI.</simpara>
-<figure role="text-center">
+<xref linkend="animalIdentifierFigure"/> shows this GUI.</simpara>
+<figure xml:id="animalIdentifierFigure" role="text-center">
 <title>A GUI for an animal identifier. Note that the bison is identified according to the frame title.</title>
 <mediaobject>
 <imageobject>
@@ -23400,105 +23785,113 @@ Figure <xref linkend="animalIdentifierFigure"/> shows this GUI.</simpara>
 <textobject><phrase>animalIdentifierFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>Program <xref linkend="program:AnimalIdentifier"/> creates the GUI shown in
-Figure <xref linkend="animalIdentifierFigure"/>. Class <literal>AnimalIdentifier</literal> declares
-four labels and a frame as fields. The labels are named <literal>bison</literal>, <literal>dove</literal>,
-<literal>gecko</literal>, and <literal>spider</literal>.</simpara>
-<formalpara xml:id="program:AnimalIdentifier" xreflabel="AnimalIdentifier">
-<title>A program that identifies which animal is in various images when the mouse hovers over the image. Images are laid out using a <literal>GridLayout</literal> manager.</title>
+<simpara><xref linkend="AnimalIdentifierProgram"/> creates the GUI shown in
+<xref linkend="animalIdentifierFigure"/>.</simpara>
+<formalpara xml:id="AnimalIdentifierProgram">
+<title>Identifies which animal is in various images when the mouse hovers over the image. Images are laid out using a <literal>GridLayout</literal> manager.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 
-public class AnimalIdentifier implements MouseListener {
-  JLabel bison, dove, gecko, spider;
-  JFrame frame = new JFrame("Animal Identifier: Bison");
+public class AnimalIdentifier implements MouseListener {  <co xml:id="CO22-1"/>
+	JLabel bison, dove, gecko, spider;
+	JFrame frame = new JFrame("Animal Identifier: Bison");
 
-  public AnimalIdentifier() {/*@\label{PicIdentifierConstructorLine}@*/
-	JPanel panel = new JPanel(new GridLayout(2,2,5,5));
-    ImageIcon bisonIcon = new ImageIcon("pictures/bison.jpg");
-    ImageIcon doveIcon = new ImageIcon("pictures/dove.jpg");
-    ImageIcon geckoIcon = new ImageIcon("pictures/gecko.jpg");
-    ImageIcon spiderIcon = new ImageIcon("pictures/spider.jpg");
-    bison = new JLabel(bisonIcon);
-    bison.addMouseListener(this); /*@\label{buttonDecoratorLine}@*/
-    dove = new JLabel(doveIcon);
-    dove.addMouseListener(this);
-    gecko = new JLabel(geckoIcon);
-    gecko.addMouseListener(this);
-    spider = new JLabel(spiderIcon);
-    spider.addMouseListener(this);
-    // Add labels
-    panel.add(bison); /*@\label{prepareButtonPanelLine}@*/
-    panel.add(dove);
-    panel.add(gecko);
-    panel.add(spider);
-    frame.add(panel);
-    frame.setSize(400,400);
-    frame.pack();
-    frame.setDefaultCloseOperation(
-    	JFrame.DISPOSE_ON_CLOSE);
-    frame.setVisible(true);
-  }
-  // Implement all abstract methods in MouseListener
-  public void mouseEntered(MouseEvent e) { /*@\label{mouseEventEnteredLine}@*/
-    Object label = e.getSource();/*@\label{getPicMouseEventLine}@*/
-    if (label == bison)
-      frame.setTitle("Animal Identifier: Bison");
-    else if(label == dove)
-      frame.setTitle("Animal Identifier: Dove");
-    else if (label == gecko)
-      frame.setTitle("Animal Identifier: Gecko");
-    else if (label == spider)
-      frame.setTitle("Animal Identifier: Spider");
-  }
+	public AnimalIdentifier() { <co xml:id="CO22-2"/>
+		JPanel panel = new JPanel(new GridLayout(2,2,5,5));
+		ImageIcon bisonIcon = new ImageIcon("pictures/bison.jpg");
+		ImageIcon doveIcon = new ImageIcon("pictures/dove.jpg");
+		ImageIcon geckoIcon = new ImageIcon("pictures/gecko.jpg");
+		ImageIcon spiderIcon = new ImageIcon("pictures/spider.jpg");
+		bison = new JLabel(bisonIcon); <co xml:id="CO22-3"/>
+		bison.addMouseListener(this);
+		dove = new JLabel(doveIcon);
+		dove.addMouseListener(this);
+		gecko = new JLabel(geckoIcon);
+		gecko.addMouseListener(this);
+		spider = new JLabel(spiderIcon);
+		spider.addMouseListener(this);
+		// Add labels
+		panel.add(bison); <co xml:id="CO22-4"/>
+		panel.add(dove);
+		panel.add(gecko);
+		panel.add(spider);
+		frame.add(panel);
+		frame.setSize(400,400); <co xml:id="CO22-5"/>
+		frame.pack();
+		frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+		frame.setVisible(true);
+	}
+	// Implement all abstract methods in MouseListener
+	public void mouseEntered(MouseEvent e) { <co xml:id="CO22-6"/>
+		Object label = e.getSource(); <co xml:id="CO22-7"/>
+		if (label == bison)
+		  frame.setTitle("Animal Identifier: Bison");
+		else if(label == dove)
+		  frame.setTitle("Animal Identifier: Dove");
+		else if (label == gecko)
+		  frame.setTitle("Animal Identifier: Gecko");
+		else if (label == spider)
+		  frame.setTitle("Animal Identifier: Spider");
+	}
 
-  public void mouseExited(MouseEvent e) {
-	  System.out.println("Mouse exited."); /*@\label{mouseEventsLine}@*/
-  }
+	public void mouseExited(MouseEvent e) {
+		System.out.println("Mouse exited.");
+	}
 
-  public void mousePressed(MouseEvent e) {
-	  System.out.println("Mouse pressed.");
-  }
+	public void mousePressed(MouseEvent e) {
+		System.out.println("Mouse pressed.");
+	}
 
-  public void mouseReleased(MouseEvent e) {
-	  System.out.println("Mouse released");
-  }
+	public void mouseReleased(MouseEvent e) {
+		System.out.println("Mouse released");
+	}
 
-  public void mouseClicked(MouseEvent e) {
-	  System.out.println("Mouse clicked.");
-  }
+	public void mouseClicked(MouseEvent e) {
+		System.out.println("Mouse clicked.");
+	}
 
-  public static void main(String[] args) {
-    new AnimalIdentifier();
-  }
+	public static void main(String[] args) {
+		new AnimalIdentifier();
+	}
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Inside the constructor, we create a panel with a
-<inlineequation><alt><![CDATA[2 \times 2]]></alt><mathphrase><![CDATA[2 \times 2]]></mathphrase></inlineequation> <literal>GridLayout</literal>. Then, we create four image icons,
-one to decorate each label. Next, starting at
-line <xref linkend="buttonDecoratorLine"/>, each of the four labels is created with
-its respective icon. We also add a <literal>MouseListener</literal> to each label.
-Starting at line <xref linkend="prepareButtonPanelLine"/>, the buttons are added to
-the panel, and the panel is added to the frame. The last few lines set
-the size of the frame, pack it, set its close operation, and make it
-visible.</simpara>
-<simpara>Since <literal>AnimalIdentifier</literal> implements <literal>MouseListener</literal>, we need to define
-all the methods in the <literal>MouseListener</literal> interface. These are implemented
-starting at line <xref linkend="mouseEventEnteredLine"/>. As we are only interested in
-displaying the name of a picture when the mouse moves over it, the
-<literal>mouseEntered()</literal> method is where most of our even handling code will be.
-At line <xref linkend="getPicMouseEventLine"/> we get the label the mouse entered. We
-compare this label to the four labels and change the frame title
-correspondingly.</simpara>
+<calloutlist>
+<callout arearefs="CO22-1">
+<para>Class <literal>AnimalIdentifier</literal> declares four labels and a frame as fields. The labels are named <literal>bison</literal>, <literal>dove</literal>, <literal>gecko</literal>, and <literal>spider</literal>.</para>
+</callout>
+<callout arearefs="CO22-2">
+<para>Inside the constructor, we create a panel with a 2 × 2 <literal>GridLayout</literal>. Then, we create four image icons, one to decorate each label.</para>
+</callout>
+<callout arearefs="CO22-3">
+<para>Each of the four labels is created with its respective icon. We also add a <literal>MouseListener</literal> to each label.</para>
+</callout>
+<callout arearefs="CO22-4">
+<para>The buttons are added to the panel, and the panel is added to the frame.</para>
+</callout>
+<callout arearefs="CO22-5">
+<para>The last few lines set the size of the frame, pack it, set its close operation, and make it visible.</para>
+</callout>
+<callout arearefs="CO22-6">
+<para>Since <literal>AnimalIdentifier</literal> implements <literal>MouseListener</literal>, we need to define
+all the methods in the <literal>MouseListener</literal> interface. As we are only interested in displaying the name of a picture when the mouse moves over it, the
+<literal>mouseEntered()</literal> method is where most of our event handling code will be.</para>
+</callout>
+<callout arearefs="CO22-7">
+<para>We get the label the mouse entered. We compare this label to the four labels and change the frame title correspondingly.</para>
+</callout>
+</calloutlist>
 <simpara>We implement the remaining methods from <literal>MouseListener</literal> to report the
 event on the console. The <literal>main()</literal> method creates a new instance of
 class <literal>AnimalIdentifier</literal>, launching the GUI.</simpara>
-<simpara>Play with Program <xref linkend="program:AnimalIdentifier"/>. What happens when you
+<simpara>Play with <xref linkend="AnimalIdentifierProgram"/>. What happens when you
 resize the window?</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise15.13">Exercise 15.13</link></simpara>
+</sidebar>
 </section>
 <section xml:id="_literal_borderlayout_literal">
 <title><literal>BorderLayout</literal></title>
@@ -23520,8 +23913,8 @@ stretch as big as it needs to fill the container.</simpara>
 <title>BorderLayout</title>
 <simpara>Here is an example of a frame using <literal>BorderLayout</literal>. Five buttons have
 been added, one to each region, using the program shown below.</simpara>
-<formalpara xml:id="program:BorderLayoutExample" xreflabel="BorderLayoutExample">
-<title>Program showing buttons laid out in each of the five regions of a <literal>BorderLayout</literal>.</title>
+<formalpara xml:id="BorderLayoutExampleProgram">
+<title>Shows buttons laid out in each of the five regions of a <literal>BorderLayout</literal>.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
@@ -23543,8 +23936,8 @@ public class BorderLayoutExample {
 }</programlisting>
 </para>
 </formalpara>
-<figure role="text-center">
-<title>A GUI demonstrating <literal>BorderLayout</literal> generated by Program <xref linkend="program:BorderLayoutExample"/>.</title>
+<figure xml:id="borderLayoutFigure" role="text-center">
+<title>A GUI demonstrating <literal>BorderLayout</literal> generated by <xref linkend="BorderLayoutExampleProgram"/>.</title>
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/15-gui/images/borderLayoutFigure.png" width="40%"/>
@@ -23578,8 +23971,8 @@ enter button. At the top is a display that shows the current value.</simpara>
 <simpara>We create ten <literal>JButton</literal> objects for the digits and three more <literal>JButton</literal>
 objects for plus, minus, and enter. The display is a <literal>JLabel</literal>. The code
 is given below.</simpara>
-<formalpara xml:id="program:CalculatorLayout" xreflabel="CalculatorLayout">
-<title>Program to layout a simple calculator.</title>
+<formalpara xml:id="CalculatorLayoutProgram">
+<title>Lays out a simple calculator.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
@@ -23614,8 +24007,8 @@ public class CalculatorLayout {
 }</programlisting>
 </para>
 </formalpara>
-<figure role="text-center">
-<title>GUI generated by Program <xref linkend="program:CalculatorLayout"/>.</title>
+<figure xml:id="calculatorLayoutFigure" role="text-center">
+<title>GUI generated by <xref linkend="CalculatorLayoutProgram"/>.</title>
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/15-gui/images/calculatorLayoutFigure.png" width="40%"/>
@@ -23682,6 +24075,10 @@ frame.setJMenuBar(bar);</programlisting>
 possible to use the <literal>add()</literal> method instead of the <literal>setJMenuBar()</literal> method
 to add a <literal>JMenuBar</literal> to a <literal>JFrame</literal>. However, doing so will add the
 <literal>JMenuBar</literal> to the regular content area, <emphasis role="strong">not</emphasis> to the menu area.</simpara>
+<sidebar>
+<simpara><link linkend="exercise15.4">Exercise 15.4</link><?asciidoc-br?>
+<link linkend="exercise15.21">Exercise 15.21</link></simpara>
+</sidebar>
 <simpara>Sometimes you might need to disable a menu item and enable it only under
 certain conditions.</simpara>
 <programlisting language="java" linenumbering="unnumbered">JMenuItem subtraction = new JMenuItem("Subtraction");
@@ -23720,11 +24117,11 @@ that fired the <literal>ItemEvent</literal> is now selected or deselected.</simp
 <example>
 <title>Math tutor</title>
 <simpara>Here we give the code to generate the GUI shown in
-Figure <xref linkend="MathTutorFigure"/> which displays basic (addition and
+<xref linkend="MathTutorFigure"/> which displays basic (addition and
 subtraction) as well as advanced (multiplication and division) problems.
-In Section <xref linkend="subsection:Applets"/> we transform this GUI into an applet
-like the one described in Section <xref linkend="problem:Math_applet"/>.</simpara>
-<figure>
+In <xref linkend="_applets"/> we transform this GUI into an applet
+like the one described in <xref linkend="_problem_math_applet"/>.</simpara>
+<figure xml:id="MathTutorFigure">
 <title>GUI for the <literal>MathTutor</literal>. (a) No menu selected. (b) Type selected. (c) Operations selected.</title>
 <mediaobject>
 <imageobject>
@@ -23733,7 +24130,7 @@ like the one described in Section <xref linkend="problem:Math_applet"/>.</simpa
 <textobject><phrase>mathTutorFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>As shown in Figure <xref linkend="MathTutorFigure"/>, this GUI has a menu bar
+<simpara>As shown in <xref linkend="MathTutorFigure"/>, this GUI has a menu bar
 consisting of two menus labeled &#8220;Type&#8221; and &#8220;Operations.&#8221; The
 &#8220;Type&#8221; menu contains a check box labeled &#8220;Advanced&#8221; while the
 &#8220;Operations&#8221; menu contains four menu items labeled &#8220;Add,&#8221;
@@ -23744,7 +24141,7 @@ user selects the &#8220;Advanced&#8221; check box.</simpara>
 class called <literal>ProblemGenerator</literal> that can randomly generate arithmetic
 problems. The class is designed so that the answers are always positive
 integers.</simpara>
-<formalpara xml:id="program:ProblemGenerator" xreflabel="ProblemGenerator">
+<formalpara xml:id="ProblemGeneratorProgram">
 <title>Utility class to generate random addition, subtraction, multiplication, and division problems.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Random;
@@ -23786,32 +24183,29 @@ public class ProblemGenerator {
 <simpara>The code listed above has four static methods <literal>addPractice()</literal>,
 <literal>subtractPractice()</literal>, <literal>multiplyPractice()</literal>, and <literal>dividePractice()</literal>. Each
 method generates an appropriate math problem, sets an input <literal>JLabel</literal> to
-display the problem, and returns the solution. Note that <literal>\\u00D7</literal> and
-<literal>\\u00F7</literal> are the Unicode values for the multiplication and division
+display the problem, and returns the solution. Note that <literal>\u00D7</literal> and
+<literal>\u00F7</literal> are the Unicode values for the multiplication and division
 symbols.</simpara>
-<simpara>Program <xref linkend="program:MathTutor"/> generates the GUI in
-Figure <xref linkend="MathTutorFigure"/>. Class <literal>MathTutor</literal> begins by creating only
-the objects that need to interact with event handlers: four menu items,
-a label, and a text field.</simpara>
-<formalpara xml:id="program:MathTutor" xreflabel="MathTutor">
-<title>Program that uses menus to generate math problems.</title>
+<simpara><xref linkend="MathTutorProgram"/> generates the GUI in
+<xref linkend="MathTutorFigure"/>.</simpara>
+<formalpara xml:id="MathTutorProgram">
+<title>Uses menus to generate math problems.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 
 public class MathTutor implements ActionListener, ItemListener {
-	private JMenuItem add = new JMenuItem("Addition");
+	private JMenuItem add = new JMenuItem("Addition"); <co xml:id="CO23-1"/>
 	private JMenuItem subtract = new JMenuItem("Subtraction");
 	private JMenuItem multiply = new JMenuItem("Multiply");
 	private JMenuItem divide = new JMenuItem ("Divide");
-    private JLabel score =
-    	new JLabel("Score: 0 Correct 0 Incorrect");
+    private JLabel score = new JLabel("Score: 0 Correct 0 Incorrect");
     private JLabel label = new JLabel();
     private JTextField field = new JTextField(10);
     private JButton submit = new JButton("Submit");
 
-    public MathTutor() {
+    public MathTutor() { <co xml:id="CO23-2"/>
         JFrame frame = new JFrame("Math Tutor");
         JMenuBar menuBar = new JMenuBar();
         JMenu type = new JMenu("Type");
@@ -23819,24 +24213,24 @@ public class MathTutor implements ActionListener, ItemListener {
         JCheckBoxMenuItem advanced =
         	new JCheckBoxMenuItem("Advanced");
     	// Add ActionListeners to menu items
-    	add.addActionListener(this);/*@\label{addActionsToMenuItemsLine}@*/
+    	add.addActionListener(this); <co xml:id="CO23-3"/>
         subtract.addActionListener(this);
         multiply.addActionListener(this);
         divide.addActionListener(this);
         // Add ItemListener to checkbox menu item
         advanced.addItemListener(this);
         // Fill menu for problem type
-        type.add(advanced); /*@\label{createMenuLine}@*/
+        type.add(advanced); <co xml:id="CO23-4"/>
         // Fill menu for operations
         operations.add(add);
         operations.add(subtract);
         operations.add(multiply);
         operations.add(divide);
         // Disable advanced operations
-        multiply.setEnabled(false); /*@\label{defaultDisableLine}@*/
+        multiply.setEnabled(false); <co xml:id="CO23-5"/>
         divide.setEnabled(false);
         // Fill menu bar set on frame
-        menuBar.add(type);
+        menuBar.add(type); <co xml:id="CO23-6"/>
         menuBar.add(operations);
         frame.setJMenuBar(menuBar);
 		// Add widgets to frame and display GUI
@@ -23849,22 +24243,22 @@ public class MathTutor implements ActionListener, ItemListener {
         frame.setVisible(true);
     }
 
-    public void itemStateChanged(ItemEvent e) {
-    	if(e.getStateChange() == ItemEvent.SELECTED ) {
-            add.setEnabled(false); /*@\label{enableDisableAdvancedLine}@*/
+    public void itemStateChanged(ItemEvent e) { <co xml:id="CO23-7"/>
+    	if(e.getStateChange() == ItemEvent.SELECTED) {
+            add.setEnabled(false);
             subtract.setEnabled(false);
             multiply.setEnabled(true);
             divide.setEnabled(true);
     	}
     	else {
-			add.setEnabled(true); /*@\label{enableDisableBasicLine}@*/
+			add.setEnabled(true);
 			subtract.setEnabled(true);
 			multiply.setEnabled(false);
 			divide.setEnabled(false);
     	}
     }
 
-    public void actionPerformed(ActionEvent e){
+    public void actionPerformed(ActionEvent e){ <co xml:id="CO23-8"/>
     	Object menuItem = e.getSource();
     	if( menuItem == add )
     		ProblemGenerator.addPractice( label );
@@ -23877,40 +24271,46 @@ public class MathTutor implements ActionListener, ItemListener {
     	field.setText("");
     }
 
-    public static void main(String[] args){
+    public static void main(String[] args){ <co xml:id="CO23-9"/>
         new MathTutor();
     }
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Inside the <literal>MathTutor</literal> constructor, the frame and remaining widgets are
-created. Action listeners are added to the four operations menu items.
-An item listener is added to the &#8220;Advanced&#8221; check box menu item,
-because it requires a different kind of event handler. Note that
-<literal>MathTutor</literal> implements both the <literal>ActionListener</literal> and <literal>ItemListener</literal>
-interfaces, allowing it to handle both kinds of events.</simpara>
-<simpara>Starting at line <xref linkend="createMenuLine"/>, the two menus are populated with
-their respective menu items. At line <xref linkend="defaultDisableLine"/> the
-<literal>multiply</literal> and <literal>divide</literal> menu items are disabled because the application
-starts in basic mode. The menus are then added to the menu bar, and the
-menu bar is set on the frame. Finally, the label and text field are
-added to the frame, which is made visible. Note that these two widgets
-are added directly to the frame with the parameters <literal>BorderLayout.NORTH</literal>
-and <literal>BorderLayout.SOUTH</literal>. <literal>JFrame</literal> objects use the <literal>BorderLayout</literal>
-manager by default.</simpara>
-<simpara>The <literal>itemStateChanged()</literal> method enables the <literal>multiply</literal> and <literal>divide</literal>
-menus and disables the <literal>add</literal> and <literal>subtract</literal> menus if the <literal>advanced</literal>
-check box is selected and does the reverse if it has been unselected.</simpara>
-<simpara>The <literal>actionPerformed()</literal> method is similar to earlier examples. Depending
-on which menu item fired the event, the appropriate static methods from
-the <literal>ProblemGenerator</literal> class are used to display a math problem on
-<literal>label</literal>.</simpara>
-<simpara>The <literal>main()</literal> method creates an instance of <literal>MathTutor</literal>, initiating GUI
-construction.</simpara>
+<calloutlist>
+<callout arearefs="CO23-1">
+<para>Class <literal>MathTutor</literal> begins by creating only the objects that need to interact with event handlers: four menu items, a label, a text field, and a button.</para>
+</callout>
+<callout arearefs="CO23-2">
+<para>Inside the <literal>MathTutor</literal> constructor, the frame and remaining widgets are
+created.</para>
+</callout>
+<callout arearefs="CO23-3">
+<para>Action listeners are added to the four operations menu items. An item listener is added to the &#8220;Advanced&#8221; check box menu item, because it requires a different kind of event handler. Note that <literal>MathTutor</literal> implements both the <literal>ActionListener</literal> and <literal>ItemListener</literal> interfaces, allowing it to handle both kinds of events.</para>
+</callout>
+<callout arearefs="CO23-4">
+<para>The two menus are populated with their respective menu items.</para>
+</callout>
+<callout arearefs="CO23-5">
+<para>The <literal>multiply</literal> and <literal>divide</literal> menu items are disabled because the application starts in basic mode.</para>
+</callout>
+<callout arearefs="CO23-6">
+<para>The menus are then added to the menu bar, and the menu bar is set on the frame. Finally, the label and text field are added to the frame, which is made visible. Note that these two widgets are added directly to the frame with the parameters <literal>BorderLayout.NORTH</literal> and <literal>BorderLayout.SOUTH</literal>. <literal>JFrame</literal> objects use the <literal>BorderLayout</literal> manager by default.</para>
+</callout>
+<callout arearefs="CO23-7">
+<para>The <literal>itemStateChanged()</literal> method enables the <literal>multiply</literal> and <literal>divide</literal> menus and disables the <literal>add</literal> and <literal>subtract</literal> menus if the <literal>advanced</literal> check box is selected and does the reverse if it has been unselected.</para>
+</callout>
+<callout arearefs="CO23-8">
+<para>The <literal>actionPerformed()</literal> method is similar to earlier examples. Depending on which menu item fired the event, the appropriate static methods from the <literal>ProblemGenerator</literal> class are used to display a math problem on <literal>label</literal>.</para>
+</callout>
+<callout arearefs="CO23-9">
+<para>The <literal>main()</literal> method creates an instance of <literal>MathTutor</literal>, initiating GUI construction.</para>
+</callout>
+</calloutlist>
 </example>
 </section>
 </section>
-<section xml:id="subsection:Applets">
+<section xml:id="_applets">
 <title>Applets</title>
 <simpara>An applet is a Java program that is written to run inside a web browser.
 A normal Java application is stored on disk and runs on the command line
@@ -23941,14 +24341,14 @@ that an applet should not define a constructor. Instead, an applet uses
 the <literal>init()</literal> method. When the applet is executed, often through a
 browser, its <literal>init()</literal> method is called first. You can use this method to
 set up the applet GUI by adding various widgets and event listeners.</simpara>
-<example>
-<title>RainbowApplet</title>
+<example xml:id="rainbowAppletExample">
+<title><literal>RainbowApplet</literal></title>
 <simpara>We can create a simple applet with a button and a label. Clicking this
 button sets the text on the label to contain some information about the
 colors in a rainbow. This applet is shown in
-Figure <xref linkend="rainbowAppletFigure"/>. Program <xref linkend="program:RainbowApplet"/>
+<xref linkend="rainbowAppletFigure"/>. <xref linkend="RainbowAppletProgram"/>
 defines the applet.</simpara>
-<figure role="text-center">
+<figure xml:id="rainbowAppletFigure" role="text-center">
 <title>A simple applet containing one button.</title>
 <mediaobject>
 <imageobject>
@@ -23957,8 +24357,8 @@ defines the applet.</simpara>
 <textobject><phrase>rainbowAppletFigure</phrase></textobject>
 </mediaobject>
 </figure>
-<formalpara xml:id="program:RainbowApplet" xreflabel="RainbowApplet">
-<title>An applet with a button and a label.</title>
+<formalpara xml:id="RainbowAppletProgram">
+<title>Applet with a button and a label.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
@@ -24021,8 +24421,8 @@ its source.</simpara>
         &lt;hr /&gt;&lt;a href="RainbowApplet.java"&gt;The source.&lt;/a&gt;
     &lt;/body&gt;
 &lt;/html&gt;</programlisting>
-<figure role="text-center">
-<title>The <literal>RainbowApplet</literal> as seen through a web browser. Clicking on the link displays the Java source code of the applet in Program <xref linkend="program:RainbowApplet"/>.</title>
+<figure xml:id="rainbowAppletInBrowserFigure" role="text-center">
+<title>The <literal>RainbowApplet</literal> as seen through a web browser. Clicking on the link displays the Java source code of the applet in <xref linkend="RainbowAppletProgram"/>.</title>
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/15-gui/images/rainbowAppletInBrowserFigure.png" width="60%"/>
@@ -24052,6 +24452,9 @@ applet by double-clicking on the HTML file. Of course, if you are able
 to upload the HTML file and the class file to a web server, you can view
 the applet and share it with anyone with an Internet connection.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise15.22">Exercise 15.22</link></simpara>
+</sidebar>
 <simpara>Applets can be much more complex than <literal>RainbowApplet</literal>. We now solve the
 problem posed at the beginning of the chapter with an applet with a
 fully functional GUI designed to be an arithmetic tutor.</simpara>
@@ -24060,13 +24463,13 @@ fully functional GUI designed to be an arithmetic tutor.</simpara>
 <section xml:id="_solution_math_applet">
 <title>Solution: Math applet</title>
 <simpara>The applet that meets the specification given at the beginning of the
-chapter is similar to Program <xref linkend="program:MathTutor"/>. Modifications must
+chapter is similar to <xref linkend="MathTutorProgram"/>. Modifications must
 be made to convert that program into an applet and add full
 functionality to the event handlers. We now go through this rather long
 Java program step by step. GUI programs in Java tend to be longer than
 their command line versions because of the code needed to set up all the
 widgets.</simpara>
-<figure role="text-center">
+<figure xml:id="menusInArithPracticeFigure" role="text-center">
 <title>The Type (a) and Operations (b) menus in the <literal>MathTutorApplet</literal>. Note that the &#8220;Multiply&#8221; and &#8220;Divide&#8221; operations are disabled because the &#8220;Advanced&#8221; option is not checked.</title>
 <mediaobject>
 <imageobject>
@@ -24077,7 +24480,7 @@ widgets.</simpara>
 </figure>
 <simpara>The <literal>MathTutorApplet.java</literal> file begins with the usual Swing imports and
 the class declaration, followed by a list of its fields.</simpara>
-<programlisting language="java" linenumbering="numbered">import javax.swing.*;
+<programlisting language="java" linenumbering="unnumbered">import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 
@@ -24087,8 +24490,7 @@ public class MathTutorApplet extends JApplet
     private JMenuItem subtract = new JMenuItem("Subtraction");
     private JMenuItem multiply = new JMenuItem("Multiply");
     private JMenuItem divide = new JMenuItem ("Divide");
-    private JLabel score =
-    	new JLabel("Score: 0 Correct 0 Incorrect");
+    private JLabel score = new JLabel("Score: 0 Correct 0 Incorrect");
     private JLabel label = new JLabel();
     private JTextField field = new JTextField(10);
     private JButton submit = new JButton("Submit");
@@ -24102,12 +24504,11 @@ answers and the current answer that the user is trying to find.</simpara>
 method. As you can see, this method is almost identical to the
 constructor in the <literal>MathTutor</literal> stand-alone application. Indeed, the
 <literal>init()</literal> method is very much like the constructor for an applet.</simpara>
-<programlisting language="java" linenumbering="numbered">    public void init() {
+<programlisting language="java" linenumbering="unnumbered">    public void init() {
         JMenuBar menuBar = new JMenuBar();
         JMenu type = new JMenu("Type");
         JMenu operations = new JMenu("Operations");
-        JCheckBoxMenuItem advanced =
-        	new JCheckBoxMenuItem("Advanced");
+        JCheckBoxMenuItem advanced = new JCheckBoxMenuItem("Advanced");
     	// Add ActionListeners to menu items and buttons
     	add.addActionListener(this);
         subtract.addActionListener(this);
@@ -24132,10 +24533,10 @@ constructor in the <literal>MathTutor</literal> stand-alone application. Indeed,
         menuBar.add(operations);
         setJMenuBar(menuBar);
 		//Add widgets to applet content
-        add( score, BorderLayout.NORTH );
-        add( label, BorderLayout.WEST );
-        add( field, BorderLayout.EAST );
-        add( submit, BorderLayout.SOUTH );
+        add(score, BorderLayout.NORTH);
+        add(label, BorderLayout.WEST);
+        add(field, BorderLayout.EAST);
+        add(submit, BorderLayout.SOUTH);
     }</programlisting>
 <simpara>Just like the <literal>MathTutor</literal> constructor, this method creates the menu bar,
 the menus, and the menu items. Then, it adds action listeners to the
@@ -24153,8 +24554,8 @@ constants.</simpara>
 creates a <literal>JFrame</literal> object. In <literal>MathTutorApplet</literal> no <literal>JFrame</literal> is necessary
 because the class itself is a child of <literal>JApplet</literal> and thus is a GUI
 container.</simpara>
-<programlisting language="java" linenumbering="numbered">    public void itemStateChanged(ItemEvent e) {
-    	if(e.getStateChange() == ItemEvent.SELECTED ) {
+<programlisting language="java" linenumbering="unnumbered">    public void itemStateChanged(ItemEvent e) {
+    	if(e.getStateChange() == ItemEvent.SELECTED) {
             add.setEnabled(false);
             subtract.setEnabled(false);
             multiply.setEnabled(true);
@@ -24174,7 +24575,7 @@ Note that this method would be more complicated if we were listening to
 more than one object. Since we are only listening to the <literal>advanced</literal>
 check box menu item, we know that it is what is being selected or
 deselected.</simpara>
-<programlisting language="java" linenumbering="numbered">    public void actionPerformed(ActionEvent e) {
+<programlisting language="java" linenumbering="unnumbered">    public void actionPerformed(ActionEvent e) {
     	Object object = e.getSource();
     	if( object == submit ) {
     		int response = Integer.parseInt(field.getText());
@@ -24184,7 +24585,7 @@ deselected.</simpara>
     			incorrect++;
 			label.setText("");
     		score.setText("Score: " + correct + " Correct " +
-    				incorrect + " Incorrect");
+    			incorrect + " Incorrect");
 			submit.setEnabled(false);
     	}
     	else {
@@ -24228,7 +24629,7 @@ similar to the <literal>RainbowApplet.html</literal> file presented before.</sim
     &lt;/body&gt;
 &lt;/html&gt;</programlisting>
 <simpara>In the stand-alone <literal>MathTutor</literal> application, we created a <literal>JFrame</literal> and
-set its size to 250 <inlineequation><alt><![CDATA[\times]]></alt><mathphrase><![CDATA[\times]]></mathphrase></inlineequation> 125 pixels. The <literal>width</literal> and
+set its size to 250 × 125 pixels. The <literal>width</literal> and
 <literal>height</literal> attributes in the HTML allow us to accomplish something
 similar. Note that the widgets in the applet have more room than in the
 <literal>JFrame</literal> version because the size of the <literal>JFrame</literal> includes the title bar
@@ -24250,7 +24651,7 @@ This thread handles events like button clicks. When you write your
 actually execute the code inside.</simpara>
 <simpara>If you are writing a complex program, the EDT may interact with many
 other threads, and the synchronization issues discussed in
-Chapter <xref linkend="chapter:Synchronization"/> will become important. However, only
+<xref linkend="_synchronization"/> will become important. However, only
 the EDT is allowed to change the state of widgets in a GUI. Using other
 threads to do so will work some of the time, but it is not thread-safe
 and violates the design of Swing.</simpara>
@@ -24272,8 +24673,8 @@ When one button is pressed, the EDT goes to sleep for 5 seconds before
 displaying an answer on the first label (in this case, approximately
 <inlineequation><alt><![CDATA[\sqrt{2}]]></alt><mathphrase><![CDATA[\sqrt{2}]]></mathphrase></inlineequation>). When the other button is pressed, it increments
 a counter and displays the value in the second label.</simpara>
-<formalpara xml:id="program:UnresponsiveGUI" xreflabel="UnresponsiveGUI">
-<title>A GUI that becomes unresponsive when the &#8220;Compute&#8221; button is pressed.</title>
+<formalpara xml:id="UnresponsiveGUIProgram">
+<title>GUI that becomes unresponsive when the &#8220;Compute&#8221; button is pressed.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
@@ -24321,8 +24722,8 @@ public class UnresponsiveGUI extends JFrame
 }</programlisting>
 </para>
 </formalpara>
-<figure role="text-center">
-<title>GUI generated by Program <xref linkend="program:UnresponsiveGUI"/>.</title>
+<figure xml:id="unresponsiveGUIFigure" role="text-center">
+<title>GUI generated by <xref linkend="UnresponsiveGUIProgram"/>.</title>
 <mediaobject>
 <imageobject>
 <imagedata fileref="chapters/15-gui/images/unresponsiveGUIFigure.png" width="40%"/>
@@ -24337,13 +24738,16 @@ systems. Furthermore, some thread in the GUI is registering the clicks
 you do on the &#8220;Increment&#8221; button, but events triggered by those clicks
 are not handled until after the EDT wakes up. At that point, the counter
 will shoot up in value unpredictably.</simpara>
+<sidebar>
+<simpara><link linkend="exercise15.23">Exercise 15.23</link><?asciidoc-br?>
+<link linkend="exercise15.24">Exercise 15.24</link></simpara>
+</sidebar>
 <simpara>One solution is to create an anonymous inner class that extends
 <literal>SwingWorker</literal>. The <literal>SwingWorker</literal> class is abstract, but it is also
 <emphasis>generic</emphasis>, meaning that it has type parameters (given in angle brackets)
 which specify what type of objects it interacts with. Generic classes
 are often containers like <literal>LinkedList</literal> where the type parameter says
-what kind of objects will be kept in the list. Chapter <xref linkend="chapter:Dynamic
-Data Structures"/> covers generics in some depth. The reason we need
+what kind of objects will be kept in the list. <xref linkend="_dynamic_data_structures"/> covers generics in some depth. The reason we need
 generics for <literal>SwingWorker</literal> is so that it can specify what kind of object
 it will return when it finishes its work. The first type parameter
 specifies the type that the worker will return when it completes its
@@ -24351,9 +24755,9 @@ work. The second specifies the type that the worker will return
 periodically in the process of doing work (which can be useful for
 updating progress bars). Examine the following program which has added a
 <literal>SwingWorker</literal> to its <literal>actionPerformed()</literal> method but is otherwise the
-same as Program <xref linkend="program:UnresponsiveGUI"/>.</simpara>
-<formalpara xml:id="program:WorkerGUI" xreflabel="WorkerGUI">
-<title>A GUI that uses <literal>SwingWorker</literal> to avoid becoming unresponsive.</title>
+same as <xref linkend="UnresponsiveGUIProgram"/>.</simpara>
+<formalpara xml:id="WorkerGUIProgram">
+<title>GUI that uses <literal>SwingWorker</literal> to avoid becoming unresponsive.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import javax.swing.*;
 import java.awt.*;
@@ -24389,7 +24793,7 @@ public class WorkerGUI extends JFrame implements ActionListener {
 			SwingWorker worker = new SwingWorker&lt;String, Void&gt;() {
 			    public String doInBackground() {
 			    	try {
-			            Thread.sleep(5000);/*@\label{responsive sleep}@*/
+			            Thread.sleep(5000);
 			        } catch( Exception ignore ) {}
 			        return "Answer: " + Math.sqrt(2.0);
 			    }
@@ -24430,6 +24834,9 @@ task. It spawns a thread transparently, and then the EDT is given work
 when the thread gives back its answer. Using a <literal>SwingWorker</literal> is not
 always required, but it is a useful tool to have in your arsenal if you
 plan on writing industrial-strength GUIs.</simpara>
+<sidebar>
+<simpara><link linkend="exercise15.25">Exercise 15.25</link></simpara>
+</sidebar>
 </section>
 </section>
 <section xml:id="_summary_6">
@@ -24448,72 +24855,73 @@ it should be easy to understand the extensive Java tutorial at
 <link xl:href="http://download.oracle.com/javase/tutorial/uiswing/components/">http://download.oracle.com/javase/tutorial/uiswing/components/</link> or other
 reference sources.</simpara>
 </section>
-<section xml:id="_exercises_14">
+<section xml:id="_exercises_15">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara><xref linkend="exercise:finalButtonExercise"/> In
-Program <xref linkend="program:FrameWithPanelAndActions"/>, why have we declared the
+<simpara><anchor xml:id="exercise15.1" xreflabel="[exercise15.1]"/> In
+<xref linkend="FrameWithPanelAndActionsProgram"/>, why have we declared the
 buttons and the text box to be <literal>final</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:actionVsMouseListener"/> Note that both <literal>ActionListener</literal>
+<simpara><anchor xml:id="exercise15.2" xreflabel="[exercise15.2]"/> Note that both <literal>ActionListener</literal>
 and <literal>MouseListener</literal> interfaces can be used to process button clicks.
 Under which circumstances is <literal>ActionListener</literal> better? Under which is
 <literal>MouseListener</literal> better?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:adapterInterfaceExercise"/> Why is the <literal>MouseAdapter</literal>
+<simpara><anchor xml:id="exercise15.3" xreflabel="[exercise15.3]"/> Why is the <literal>MouseAdapter</literal>
 abstract class useful?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:multipleMenuBars"/> What do you expect will happen if you
+<simpara><anchor xml:id="exercise15.4" xreflabel="[exercise15.4]"/> What do you expect will happen if you
 used <literal>setJMenuBar()</literal> to set two different menu bars on a single <literal>JFrame</literal>
 object?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:listenerExercise"/> Describe the situations that the
+<simpara><anchor xml:id="exercise15.5" xreflabel="[exercise15.5]"/> Describe the situations that the
 following event listeners are useful for: <literal>ActionListener</literal>,
 <literal>MouseListener</literal>, <literal>ItemListener</literal>, and <literal>KeyListener</literal></simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:actionListenerComparisonExercise"/> Remove the two
+<simpara><anchor xml:id="exercise15.6" xreflabel="[exercise15.6]"/> Remove the two
 instances of the keyword <literal>final</literal> from
-Program <xref linkend="program:FrameWithPanelAndActions"/> and try to compile it. Why
+<xref linkend="FrameWithPanelAndActionsProgram"/> and try to compile it. Why
 does the compiler complain? What do you conclude regarding the use of
 <literal>final</literal> with respect to local variables used in the <literal>actionPerformed()</literal>
 method of an anonymous inner class? Why is this not a concern for
 top-level, named classes used as an <literal>ActionListener</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:frameWithPanelExercise"/> Write a program that creates a
+<simpara><anchor xml:id="exercise15.7" xreflabel="[exercise15.7]"/> Write a program that creates a
 GUI containing two buttons labeled &#8220;Start&#8221; and &#8220;Done.&#8221; The GUI frame
 should be labeled &#8220;Start and Done.&#8221;</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:mouseEventsExercise"/> Modify
-Program <xref linkend="program:SimpleMouseEvents"/> by implementing the
+<simpara><anchor xml:id="exercise15.8" xreflabel="[exercise15.8]"/> Modify
+<xref linkend="SimpleMouseEventsProgram"/> by implementing the
 <literal>mouseExited()</literal>, <literal>mousePressed()</literal>, and <literal>mouseReleased()</literal> methods. Each
 method must display a suitable message in the text box when the
 corresponding event occurs. For example, when the mouse exits button
 <literal>one</literal>, the text box should display &#8220;Mouse exits One.&#8221;</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:iconAndSoundExercise"/> Modify
-Program <xref linkend="program:IconExample"/> such that clicking the icon-decorated
+<simpara><anchor xml:id="exercise15.9" xreflabel="[exercise15.9]"/> Modify
+<xref linkend="IconExampleProgram"/> such that clicking the icon-decorated
 button generates a roaring sound. Note that this will require you to add
 an <literal>ActionListener</literal> to the button, create an audio clip for the desired
 sound, and then play this click when the button is clicked. Consider
 visiting <link xl:href="http://www.freesound.org/">http://www.freesound.org/</link> for free sound files.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:addIconToLabelExercise"/> Write a Java program that
+<simpara><anchor xml:id="exercise15.10" xreflabel="[exercise15.10]"/> Write a Java program that
 creates a GUI containing a label with a picture of yourself.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:SoundGameExtension"/> Extend the <literal>SoundGame</literal> class
-developed in Example <xref linkend="example:Sound_game"/> to include sounds for
+<simpara><anchor xml:id="exercise15.11" xreflabel="[exercise15.11]"/> Extend the <literal>SoundGame</literal> class
+developed in <xref linkend="soundGameExample"/> to include sounds for
 various animals. You may find a variety of publicly available sounds
 files for use in your program. The Freesound link above is only one
 source.</simpara>
@@ -24522,26 +24930,24 @@ into your program. In those cases, download the sound file into your
 local directory and load it from there into your application.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:SoundGameProperStopExercise"/> In Example <xref linkend="example:Sound
-game"/> we stopped both the chirp and the bark sounds because the action
+<simpara><anchor xml:id="exercise15.12" xreflabel="[exercise15.12]"/> In <xref linkend="soundGameExample"/> we stopped both the chirp and the bark sounds because the action
 listener corresponding to the &#8220;Stop Playing&#8221; button does not know
-which sound is playing. Modify Program <xref linkend="program:SoundGame"/> so that
+which sound is playing. Modify <xref linkend="SoundGameProgram"/> so that
 only the sound that is playing is stopped. You may need to declare
 another variable to keep track of which is playing.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:animalIdentifierExercise"/> Modify
-Program <xref linkend="program:AnimalIdentifier"/> so that it plays a sound associated
+<simpara><anchor xml:id="exercise15.13" xreflabel="[exercise15.13]"/> Modify
+<xref linkend="AnimalIdentifierProgram"/> so that it plays a sound associated
 with an animal when the mouse is clicked over its label. Note that this
 is an example of a situation where a <literal>MouseListener</literal> can be used to
 listen for mouse click events though an <literal>ActionListener</literal> cannot. As in
-Exercises <xref linkend="exercise:SoundGameExtension"/> and
-<xref linkend="exercise:iconAndSoundExercise"/>, you may need to download sounds from
+<link linkend="exercise15.9">Exercise 15.9</link> and <link linkend="exercise15.11">Exercise 15.11</link>, you may need to download sounds from
 the Internet.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:addSessionCountExercise"/> Modify the applet from
-Section <xref linkend="solution:Math_applet"/> to display the problem number the user
+<simpara><anchor xml:id="exercise15.14" xreflabel="[exercise15.14]"/> Modify the applet from
+<xref linkend="_solution_math_applet"/> to display the problem number the user
 is working on. The first problem is numbered &#8220;Problem 1&#8221; with
 subsequent problems 2, 3, and so on. The number should increase each
 time the user hits the Submit button. Find a suitable place on the GUI
@@ -24549,9 +24955,9 @@ to display this information. You may need to add a panel to reorganize
 the GUI.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:anonymousInnerClass"/> Remove the <literal>actionPerformed()</literal> and
+<simpara><anchor xml:id="exercise15.15" xreflabel="[exercise15.15]"/> Remove the <literal>actionPerformed()</literal> and
 <literal>itemStateChanged()</literal> methods from the <literal>MathTutorApplet</literal> class given in
-Section <xref linkend="solution:Math_applet"/>. Move the code from these methods into
+<xref linkend="_solution_math_applet"/>. Move the code from these methods into
 individual anonymous inner classes added to the <literal>add</literal>, <literal>subtract</literal>,
 <literal>multiply</literal>, <literal>divide</literal>, <literal>submit</literal>, and <literal>advanced</literal> objects.</simpara>
 <simpara>Note that you are now able to remove <literal>ActionListener</literal> and <literal>ItemListener</literal>
@@ -24560,39 +24966,37 @@ Reorganizing the code this way should have no impact on the
 functionality of the applet. Is doing so a good idea or not? Why?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:panelSequencingExercise"/> In
-Program <xref linkend="program:FrameWithPanelAndActions"/> exchange the first two
+<simpara><anchor xml:id="exercise15.16" xreflabel="[exercise15.16]"/> In
+<xref linkend="FrameWithPanelAndActionsProgram"/> exchange the first two
 <literal>add()</literal> method calls on the <literal>soundPanel</literal> so that <literal>bark</literal> is added to the
 panel before the <literal>chirp</literal>. Explain how the appearance of the GUI is
 changed.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:multiplePanelsExercise"/> Modify
-Program <xref linkend="program:FrameWithPanel"/> by adding a second panel named
+<simpara><anchor xml:id="exercise15.17" xreflabel="[exercise15.17]"/> Modify
+<xref linkend="FrameWithPanelProgram"/> by adding a second panel named
 <literal>secondPanel</literal>. Create a new button named <literal>train</literal> with the label
 &#8220;Train.&#8221; Add <literal>train</literal> to <literal>secondPanel</literal>. Now add <literal>secondPanel</literal> to
 <literal>soundCheck</literal> and look at the GUI generated. Can you explain why only one
 panel is visible?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:flowLayoutFrameSizeExercise"/> Remove
-line <xref linkend="disableResizableLine"/> from
-Program <xref linkend="program:FlowLayoutExample"/>. Run the modified program and
+<simpara><anchor xml:id="exercise15.18" xreflabel="[exercise15.18]"/> Remove the line <literal>frame.setResizable(false);</literal> from <xref linkend="FlowLayoutExampleProgram"/>. Run the modified program and
 resize the frame to various sizes. How does the placement of the buttons
 change?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:flowLayoutPackExercise"/> Modify
-Program <xref linkend="program:FlowLayoutExample"/> by deleting the lines that set the
+<simpara><anchor xml:id="exercise15.19" xreflabel="[exercise15.19]"/> Modify
+<xref linkend="FlowLayoutExampleProgram"/> by deleting the lines that set the
 frame size. What does the resulting GUI look like? Now add the following
-code just before line <xref linkend="disableResizableLine"/>:</simpara>
+code just before the line <literal>frame.setResizable(false);</literal>:</simpara>
 <programlisting language="java" linenumbering="unnumbered">demo.pack();</programlisting>
 <simpara>When you run the modified program, what is the impact of using the
 <literal>pack()</literal> method?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:gridLayoutExercise"/> Create a GUI with a frame that uses
-<literal>GridLayout</literal> and has a suitable size. Use a 3 <inlineequation><alt><![CDATA[\times]]></alt><mathphrase><![CDATA[\times]]></mathphrase></inlineequation> 2
+<simpara><anchor xml:id="exercise15.20" xreflabel="[exercise15.20]"/> Create a GUI with a frame that uses
+<literal>GridLayout</literal> and has a suitable size. Use a 3 × 2
 layout with a horizontal and vertical spacing of 5 pixels each. Use a
 loop to add eight buttons to your frame, labeled 1 through 8. Observe
 how the frame expands to include all the buttons even though the
@@ -24601,7 +25005,7 @@ frame size, you might have to resize the window to see all cells and
 buttons. What happens if you add fewer than 6?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:poorAdditionOfMenuBar"/> Write a Java program that creates
+<simpara><anchor xml:id="exercise15.21" xreflabel="[exercise15.21]"/> Write a Java program that creates
 a GUI with a frame and a menu bar containing a single menu. Add a menu
 item to this menu. Use the <literal>add()</literal> method, not the <literal>setJMenuBar()</literal>
 method, to add the menu bar to the frame. What is the difference between
@@ -24609,9 +25013,9 @@ using the <literal>add()</literal> method and the <literal>setJMenuBar()</litera
 bar to a <literal>JFrame</literal>?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:rainbowAppletExercise"/> Use the example from the book to
+<simpara><anchor xml:id="exercise15.22" xreflabel="[exercise15.22]"/> Use the example from the book to
 create a suitable HTML file that embeds the <literal>RainbowApplet</literal> class from
-Example <xref linkend="example:RainbowApplet"/> and links to the Java source code. Now
+<xref linkend="rainbowAppletExample"/> and links to the Java source code. Now
 upload the class file, the source code, and the HTML file to a web
 server so that you can run the applet over the Internet. Have a friend
 test out your code on a computer in another location to make sure that
@@ -24619,28 +25023,25 @@ it works.</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:unresponsive_GUI"/> Recall that
-Program <xref linkend="program:UnresponsiveGUI"/> is unresponsive because the event
-dispatch thread goes to sleep for 5 seconds (5,000 milliseconds) on
-line <xref linkend="unresponsive_sleep"/>. Experiment with this value to determine
+<simpara><anchor xml:id="exercise15.23" xreflabel="[exercise15.23]"/> Recall that
+<xref linkend="UnresponsiveGUIProgram"/> is unresponsive because the event
+dispatch thread goes to sleep for 5 seconds (5,000 milliseconds). Experiment with this value to determine
 what is a reasonable amount of time for the EDT to be blocked before the
 GUI feels unresponsive.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:busy_GUI"/> Program <xref linkend="program:UnresponsiveGUI"/> is
+<simpara><anchor xml:id="exercise15.24" xreflabel="[exercise15.24]"/> <xref linkend="UnresponsiveGUIProgram"/> is
 unrealistic because the EDT simply goes to sleep. Normally, a GUI
 becomes unresponsive because the EDT is performing extensive
-calculations or doing slow I/O operations. Replace line <xref linkend="unresponsive
-sleep"/> with a short loop that performs significant calculations. One
+calculations or doing slow I/O operations. Replace the line that sleeps with a short loop that performs significant calculations. One
 simple way to spend a lot of computational time is by summing the sines
-of random numbers, similar to the work done in Example <xref linkend="example:Array
-summation"/>. How many sines do you need to compute to make the GUI
+of random numbers, similar to the work done in <xref linkend="arraySummationExample"/>. How many sines do you need to compute to make the GUI
 unresponsive for 5 seconds?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:busy_workers"/> Take the computationally expensive loop
-from Exercise <xref linkend="exercise:busy_GUI"/> and use it to replace
-line <xref linkend="responsive_sleep"/> in Program <xref linkend="program:WorkerGUI"/>, the
+<simpara><anchor xml:id="exercise15.25" xreflabel="[exercise15.25]"/> Take the computationally expensive loop
+from <link linkend="exercise15.24">Exercise 15.24</link> and use it to replace
+the line that sleeps in <xref linkend="WorkerGUIProgram"/>, the
 <literal>SwingWorker</literal> version of the program. Does the program become
 unresponsive if you run it? If possible, run the program on Windows,
 Mac, and Linux environments. If it is unresponsive in some environments
@@ -24649,7 +25050,7 @@ but not others, why do you think that might be?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Testing_and_Debugging">
+<chapter xml:id="_testing_and_debugging">
 <title>Testing and Debugging</title>
 <blockquote>
 <attribution>
@@ -24657,7 +25058,7 @@ John Peel
 </attribution>
 <simpara>I never make stupid mistakes. Only very, very clever ones.</simpara>
 </blockquote>
-<section xml:id="section:Fixing_bugs">
+<section xml:id="_fixing_bugs">
 <title>Fixing bugs</title>
 <simpara>This chapter is about finding, fixing, and, more importantly, preventing
 bugs in software. This chapter is unique in that it is not based on
@@ -25059,14 +25460,14 @@ watch variables, but local variables are also displayed by default.</simpara>
 just experience. Having seen a bug before means you know to expect it in
 the future. There is no substitute for pulling your hair out over a bug
 for hours before finally squashing it, but we will give a few examples
-corresponding to the common bugs listed in Section <xref linkend="section:Fixing_bugs"/>.</simpara>
+corresponding to the common bugs listed in <xref linkend="_fixing_bugs"/>.</simpara>
 <example>
 <title>Precision errors</title>
 <simpara>Precision can cause some subtle errors, especially with <literal>float</literal> types.
 Here is an example of a program attributed to Cleve Moler that gives
 some estimation of the threshold for floating point precision. Note that
-<literal>a</literal> <inlineequation><alt><![CDATA[\approx 4/3]]></alt><mathphrase><![CDATA[\approx 4/3]]></mathphrase></inlineequation>, making <literal>b</literal> <inlineequation><alt><![CDATA[\approx 1/3]]></alt><mathphrase><![CDATA[\approx 1/3]]></mathphrase></inlineequation>, <literal>c</literal>
-<inlineequation><alt><![CDATA[\approx 1]]></alt><mathphrase><![CDATA[\approx 1]]></mathphrase></inlineequation>, and <literal>d</literal> <inlineequation><alt><![CDATA[\approx 0]]></alt><mathphrase><![CDATA[\approx 0]]></mathphrase></inlineequation>. Nevertheless,
+<literal>a</literal> ≈ 4/3, making <literal>b</literal> ≈ 1/3, <literal>c</literal>
+≈ 1, and <literal>d</literal> ≈ 0. Nevertheless,
 the comparison <literal>(d == 0.0)</literal> in the <literal>if</literal> statement in this code will
 evaluate to <literal>false</literal>.</simpara>
 <programlisting language="java" linenumbering="unnumbered">double a, b, c, d;
@@ -25171,7 +25572,7 @@ point type to an integer type always uses truncation, never rounding.</simpara>
 <simpara>This assignment will always store <literal>2</literal> into <literal>three</literal>. The <literal>Math.round()</literal>
 method or some other additional step is needed to perform rounding.</simpara>
 <simpara>Casting errors are not limited to primitive data types. Object casting
-will be discussed at length in Chapter <xref linkend="chapter:Polymorphism"/>. The
+will be discussed at length in <xref linkend="_polymorphism"/>. The
 biggest danger there is an incorrect explicit upcast.</simpara>
 <programlisting language="java" linenumbering="unnumbered">Fruit snack = new ChiliPepper();
 Apple apple = (Apple)snack;</programlisting>
@@ -25186,7 +25587,7 @@ superclass of the item you generally expect to be in there. If a large
 team is working on a body of code which such a list in it, half of the
 team might expect the list to contain only <literal>Apple</literal> objects while the
 other expected only <literal>ChiliPepper</literal> objects. The use of generics,
-discussed in Chapter <xref linkend="chapter:Dynamic_Data_Structures"/>, can reduce the
+discussed in <xref linkend="_dynamic_data_structures"/>, can reduce the
 number of casting errors of this kind, but some applications require a
 list to hold many different types with a common superclass. In those
 cases, some amount of explicit (and therefore dangerous) casting will
@@ -25480,7 +25881,7 @@ accessing at any given time can appear obvious, even if it really isn&#8217;t.</
 identifier. If the scopes are two separate methods, then they will never
 interfere with each other. However, if one scope encloses another, the
 inner variable will <emphasis>shadow</emphasis> or hide the outer variable.</simpara>
-<programlisting xml:id="program:Shadow" xreflabel="Shadow" language="java" linenumbering="numbered">public class Shadow {
+<programlisting xml:id="ShadowProgram" language="java" linenumbering="numbered">public class Shadow {
 	int darkness = 10;
 
 	public void deepen( int darkness ) {
@@ -25513,7 +25914,7 @@ fix the problem in the preceding example.</simpara>
 <simpara>In Java, scope is also defined in terms of classes and their parent
 classes. A parent class variable can be shadowed by a child class
 variable of the same name.</simpara>
-<programlisting xml:id="program:Bodybuilder" xreflabel="Bodybuilder" language="java" linenumbering="numbered">public class Bodybuilder {
+<programlisting xml:id="BodybuilderProgram" language="java" linenumbering="numbered">public class Bodybuilder {
 	public int strength = 8;
 
 	public boolean isStrongEnough( int strengthNeeded ) {
@@ -25522,7 +25923,7 @@ variable of the same name.</simpara>
 
 	public void setStrength( int value ) { strength = value; }
 }</programlisting>
-<programlisting xml:id="program:BraggingBodybuilder" xreflabel="BraggingBodybuilder" language="java" linenumbering="numbered">public class BraggingBodybuilder extends Bodybuilder {
+<programlisting xml:id="BraggingBodybuilderProgram" language="java" linenumbering="numbered">public class BraggingBodybuilder extends Bodybuilder {
 	public int strength = 10;
 
 	public void brag() {
@@ -25538,20 +25939,26 @@ her strength to other values. When strength is tested, it will use the
 <literal>setStrength()</literal> method. Sometimes similar behavior is desired, but it
 seems to be accidental here. When classes have large numbers of fields,
 making such a mistake becomes easier.</simpara>
-<programlisting language="numberLines" linenumbering="unnumbered">Bodybuilder builder = new BraggingBodybuilder();
-builder.strength = 15;/*@\label{line:strength=15}@*/
+<simpara>Dynamic and static binding complicate this scope problem further. The
+fragment of code below using the class definitions from above highlights these
+complications.</simpara>
+<programlisting language="java" linenumbering="numbered">Bodybuilder builder = new BraggingBodybuilder();
+builder.strength = 15; <co xml:id="CO24-1"/>
 BraggingBodybuilder bragger = (BraggingBodybuilder)builder;
 bragger.brag();
-bragger.strength = 20;/*@\label{line:strength=20}@*/
+bragger.strength = 20; <co xml:id="CO24-2"/>
 bragger.brag();</programlisting>
-<simpara>Dynamic and static binding complicate this scope problem further. This
-fragment of code using the class definitions above highlights these
-complications. Because fields are statically bound to the class of the
-object, the <literal>strength</literal> field for <literal>Bodybuilder</literal> will be set to 15 on line
-<xref linkend="line:strength=15"/>, and the <literal>strength</literal> field for <literal>BraggingBodybuilder</literal>
-will be set to 20 on line <xref linkend="line:strength=20"/>. Thus, the first call to
-<literal>brag()</literal> will print out <literal>My strength is 10!</literal>, but the second call will
-print out <literal>My strength is 20!</literal>.</simpara>
+<calloutlist>
+<callout arearefs="CO24-1">
+<para>Because fields are statically bound to the class of the
+object, the <literal>strength</literal> field for <literal>Bodybuilder</literal> will be set to 15.</para>
+</callout>
+<callout arearefs="CO24-2">
+<para>However, the <literal>strength</literal> field for <literal>BraggingBodybuilder</literal>
+will be set to 20 here.</para>
+</callout>
+</calloutlist>
+<simpara>Thus, the first call to <literal>brag()</literal> will print out <literal>My strength is 10!</literal>, but the second call will print out <literal>My strength is 20!</literal>.</simpara>
 </example>
 <example>
 <title>Reference vs. value</title>
@@ -25610,7 +26017,7 @@ blindly use a null reference without checking it first, causing a
 <title>Concurrency: Parallel bugs</title>
 <simpara>We will only briefly discuss parallel bugs here because we have already
 gone into depth about the dangers of parallel programming in
-Chapter <xref linkend="chapter:Synchronization"/>. Except in the case of deadlocks and
+<xref linkend="_synchronization"/>. Except in the case of deadlocks and
 livelocks, the real trouble with parallel bugs is that they make the
 appearance of ordinary sequential bugs become nondeterministic.</simpara>
 <section xml:id="_race_conditions">
@@ -26105,8 +26512,8 @@ including an epsilon threshold in case the values don&#8217;t match exactly.</si
 <title>JUnit math testing</title>
 <simpara>Using these methods, we can finally write a complete (though very
 simple) implementation of <literal>MathTest.java</literal>.</simpara>
-<formalpara xml:id="program:MathTest" xreflabel="MathTest">
-<title>A simple testing suite.</title>
+<formalpara xml:id="MathTestProgram">
+<title>Simple testing suite.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import org.junit.*;
 import static org.junit.Assert.*;
@@ -26162,12 +26569,12 @@ that you haven&#8217;t added the jar file to your classpath permanently, let&#82
 say that you are using JUnit 4.5 from a jar file called <literal>junit-4.5.jar</literal>
 that can be found in <literal>C:\Utilities\Java\JUnit\</literal>. To compile <literal>MathTest</literal>,
 you would type:</simpara>
-<programlisting language="java" linenumbering="unnumbered">javac -classpath .;C:\Utilities\Java\JUnit\junit-4.5.jar MathTest.java}</programlisting>
+<literallayout class="monospaced">javac -classpath .;C:\Utilities\Java\JUnit\junit-4.5.jar MathTest.java</literallayout>
 <simpara>To actually run the code, you still need to include <literal>junit-4.5.jar</literal> in
 your classpath, but you also need to invoke the test runner called
 <literal>org.junit.runner.JUnitCore</literal> as follows:</simpara>
-<programlisting language="java" linenumbering="unnumbered">java -classpath .;C:\Utilities\Java\JUnit\junit-4.5.jar
-    org.junit.runner.JUnitCore MathTest</programlisting>
+<literallayout class="monospaced">java -classpath .;C:\Utilities\Java\JUnit\junit-4.5.jar
+    org.junit.runner.JUnitCore MathTest</literallayout>
 <simpara>If you had multiple test classes, you could just list them all after
 <literal>org.junit.runner.JUnitCore</literal> and all the methods marked <literal>@Test</literal> in them
 would be run. Note that methods without an <literal>@Test</literal> decoration will not
@@ -26267,8 +26674,8 @@ you another example of JUnit testing.</simpara>
 3D space. We are also going to introduce some errors into the class.
 Because the class is so simple, the errors should be obvious.
 Nevertheless, we have picked errors that are reasonable to make.</simpara>
-<formalpara xml:id="program:PointCharge" xreflabel="PointCharge">
-<title>Example physics class with errors.</title>
+<formalpara xml:id="PointChargeProgram">
+<title>Physics class with errors.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class PointCharge {
 	private double charge;  // C
@@ -26353,7 +26760,7 @@ public void distance() {
 distance between <literal>charge2</literal> and <literal>charge3</literal> should be about
 <inlineequation><alt><![CDATA[\sqrt{2}]]></alt><mathphrase><![CDATA[\sqrt{2}]]></mathphrase></inlineequation>. Yet, when we run this test with JUnit, the test
 fails. We get:</simpara>
-<programlisting language="java" linenumbering="unnumbered">java.lang.AssertionError: expected:&lt;1.0&gt; but was:&lt;1.4142135623730951&gt;</programlisting>
+<literallayout class="monospaced">java.lang.AssertionError: expected:&lt;1.0&gt; but was:&lt;1.4142135623730951&gt;</literallayout>
 <simpara>for the second assertion in the method. But why? If we comb through the
 <literal>distance()</literal> methods in <literal>PointCharge</literal>, they all look correct. The
 problem must be deeper. <literal>PointCharge</literal> does not have accessor methods for
@@ -26371,8 +26778,8 @@ public void scalarForce() {
 }</programlisting>
 <simpara>When we run this test with JUnit, the last assertion fails. We get the
 following output.</simpara>
-<programlisting language="java" linenumbering="unnumbered">java.lang.AssertionError: expected:&lt;-8.987551787368176E9&gt;
-    but was:&lt;-1.797510357473635E10&gt;</programlisting>
+<literallayout class="monospaced">java.lang.AssertionError: expected:&lt;-8.987551787368176E9&gt;
+    but was:&lt;-1.797510357473635E10&gt;</literallayout>
 <simpara>A close inspection reveals that the actual value is about twice the
 expected value. Where does this extra factor of 2 come from? Scanning
 the code for <literal>scalarForce()</literal>, we find <literal>return K*charge*p.charge/r*r;</literal></simpara>
@@ -26388,7 +26795,7 @@ simple, but it also illustrates the importance of serious testing.</simpara>
 simplicity, we&#8217;ll test the field at the locations of <literal>charge1</literal>,
 <literal>charge3</literal>, and <literal>charge4</literal> with respect to <literal>charge2</literal>.</simpara>
 <simpara>This time the first assertion fails. We get the following output.</simpara>
-<programlisting language="java" linenumbering="unnumbered">java.lang.AssertionError: expected:&lt;1.797510357473635E10&gt; but was:&lt;2.0&gt;</programlisting>
+<literallayout class="monospaced">java.lang.AssertionError: expected:&lt;1.797510357473635E10&gt; but was:&lt;2.0&gt;</literallayout>
 <simpara><literal>2.0</literal> seems like a very strange result when we were expecting a value
 with an order of magnitude 10 times larger. Perhaps the constant was
 omitted? Yes, our version of <literal>fieldMagnitude()</literal> left off a factor of
@@ -26399,7 +26806,7 @@ JUnit test method stops once a failure has happened.</simpara>
 </example>
 <simpara>Here is the fully corrected version of <literal>PointCharge</literal> renamed
 <literal>FixedPointCharge</literal>.</simpara>
-<formalpara xml:id="program:FixedPointCharge" xreflabel="FixedPointCharge">
+<formalpara xml:id="FixedPointChargeProgram">
 <title>Corrected version of <literal>PointCharge</literal>.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class FixedPointCharge {
@@ -26445,7 +26852,7 @@ JUnit test method stops once a failure has happened.</simpara>
 <literal>TestPointCharge</literal>. Note that you will have to change the name
 <literal>PointCharge</literal> to <literal>FixedPointCharge</literal> if you want to test the corrected
 class.</simpara>
-<formalpara xml:id="program:TestPointCharge" xreflabel="TestPointCharge">
+<formalpara xml:id="TestPointChargeProgram">
 <title>Class for testing <literal>PointCharge</literal>.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import org.junit.*;
@@ -26491,15 +26898,16 @@ public class TestPointCharge {
 </para>
 </formalpara>
 </section>
-<section xml:id="_exercises_15">
+<section xml:id="_exercises_16">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>What is the purpose of the <literal>assert</literal> keyword in Java? What steps must
+<simpara><anchor xml:id="exercise16.1" xreflabel="[exercise16.1]"/> What is the purpose of the <literal>assert</literal> keyword in Java? What steps must
 be taken for it to be active?</simpara>
 </listitem>
 <listitem>
-<simpara>What is the value of <literal>j</literal> after the following statements are
+<simpara><anchor xml:id="exercise16.2" xreflabel="[exercise16.2]"/> What is the value of <literal>j</literal> after the following statements are
 executed?</simpara>
 <programlisting language="java" linenumbering="unnumbered">int j = 1;
 int i;
@@ -26509,14 +26917,14 @@ for( i = 0; i &lt; 10; i++ );
 error does it fall under?</simpara>
 </listitem>
 <listitem>
-<simpara>The following loop is intended to print out all possible <literal>byte</literal>
+<simpara><anchor xml:id="exercise16.3" xreflabel="[exercise16.3]"/> The following loop is intended to print out all possible <literal>byte</literal>
 values. What is the conceptual error made in the following loop? How
 many times will it execute?</simpara>
 <programlisting language="java" linenumbering="unnumbered">for( byte value = 0; value &lt; 256; ++value )
     System.out.println("Byte: " + value);</programlisting>
 </listitem>
 <listitem>
-<simpara>What are all the possible run-time errors that could occur in this
+<simpara><anchor xml:id="exercise16.4" xreflabel="[exercise16.4]"/> What are all the possible run-time errors that could occur in this
 method that reverses a section of an array?</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void reverse( Object[] array, int start, int end ) {
     Object temp;
@@ -26532,7 +26940,7 @@ method that reverses a section of an array?</simpara>
 <simpara>What checks could be added to catch these errors?</simpara>
 </listitem>
 <listitem>
-<simpara>Consider the following definition of a stack that holds <literal>int</literal>
+<simpara><anchor xml:id="exercise16.5" xreflabel="[exercise16.5]"/> Consider the following definition of a stack that holds <literal>int</literal>
 values.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class IntegerStack {
     private static Node {
@@ -26557,21 +26965,21 @@ values.</simpara>
 be thrown?</simpara>
 </listitem>
 <listitem>
-<simpara>This question sometimes comes up in job interviews. Imagine that you
+<simpara><anchor xml:id="exercise16.6" xreflabel="[exercise16.6]"/> This question sometimes comes up in job interviews. Imagine that you
 have a simple singly linked list such as the one described in
-Chapter <xref linkend="chapter:Dynamic_Data_Structures"/>. What if there is a loop in
+<xref linkend="_dynamic_data_structures"/>. What if there is a loop in
 the list such that the last element in the list points to an earlier
 element in the list? For this reason, a simple traversal of the list
 will go on forever. How could you detect such a problem during program
 execution?</simpara>
 </listitem>
 <listitem>
-<simpara>What is the difference between black box testing and white box
+<simpara><anchor xml:id="exercise16.7" xreflabel="[exercise16.7]"/> What is the difference between black box testing and white box
 testing? What kinds of bugs are more likely to be caught by black box
 testing? By white box testing?</simpara>
 </listitem>
 <listitem>
-<simpara>The Microsoft Zune is a portable media player in competition with
+<simpara><anchor xml:id="exercise16.8" xreflabel="[exercise16.8]"/> The Microsoft Zune is a portable media player in competition with
 the Apple iPod. The first generation Zune 30 received negative publicity
 because many of them froze on December 31, 2008 due to a leap year bug.
 It is possible to find segments of the source code that caused this
@@ -26584,12 +26992,12 @@ should Microsoft have done to prevent this bug?</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Apply JUnit testing to the last major assignment you did in class.
+<simpara><anchor xml:id="exercise16.9" xreflabel="[exercise16.9]"/> Apply JUnit testing to the last major assignment you did in class.
 What bugs did you uncover?</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>James Gosling&#8217;s original specification for Java contained
+<simpara><anchor xml:id="exercise16.10" xreflabel="[exercise16.10]"/> James Gosling&#8217;s original specification for Java contained
 assertions, but they were not included until Java 1.4. One of the
 concerns about an assertion mechanism is the additional time required to
 process the assertions. Time a program of at least moderate length
@@ -26599,7 +27007,7 @@ slight decrease in performance when assertions are enabled. When
 disabled, you should see almost none. How great is the performance hit?</simpara>
 </listitem>
 <listitem>
-<simpara>Take another look at your last programming assignment. Calculate the
+<simpara><anchor xml:id="exercise16.11" xreflabel="[exercise16.11]"/> Take another look at your last programming assignment. Calculate the
 number of branches based on <literal>if</literal> and <literal>switch</literal> statements and compute 2
 raised to that power. Time your program executing once under normal
 circumstances. Multiply that time by the number of different
@@ -26607,7 +27015,7 @@ possibilities you would need to exercise every possible combination of
 branches in your program. How long would it take?</simpara>
 </listitem>
 <listitem>
-<simpara>Take a concurrent program you have written that relies on explicit
+<simpara><anchor xml:id="exercise16.12" xreflabel="[exercise16.12]"/> Take a concurrent program you have written that relies on explicit
 synchronization mechanisms for correctness. Remove all synchronization
 tools and run the code many times, testing for race conditions. Then,
 instrument the code with ConTest and run it many more times. Do you see
@@ -26617,7 +27025,7 @@ conditions?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Polymorphism">
+<chapter xml:id="_polymorphism">
 <title>Polymorphism</title>
 <blockquote>
 <attribution>
@@ -26627,7 +27035,7 @@ Neutral Milk Hotel
 </blockquote>
 <section xml:id="_problem_banking_account_with_a_vengeance">
 <title>Problem: Banking account with a vengeance</title>
-<simpara>In Chapter <xref linkend="chapter:Synchronization"/>, we introduced the
+<simpara>In <xref linkend="_synchronization"/>, we introduced the
 <literal>SynchronizedAccount</literal> class that guarantees that checking the balance,
 making deposits, and making withdrawals will all be safe even in a
 multi-threaded environment. Unfortunately, <literal>SynchronizedAccount</literal> gives
@@ -26655,7 +27063,7 @@ greater than $0, the account earns interest corresponding to
 <inlineequation><alt><![CDATA[\frac{1}{12}]]></alt><mathphrase><![CDATA[\frac{1}{12}]]></mathphrase></inlineequation> of the annual rate. However, if the balance
 is below $1000, a $25 service fee is charged each month, regardless of
 how low the balance becomes.</simpara>
-<simpara>In Chapter <xref linkend="chapter:Inheritance"/> you were exposed to concepts in
+<simpara>In <xref linkend="_inheritance"/> you were exposed to concepts in
 inheritance. We are now returning to these concepts and exploring them
 further. In the first place, concurrency is on the table now, and you
 must be careful to keep your derived classes thread-safe. In the second,
@@ -26684,12 +27092,12 @@ any place where a base class could have been used.</simpara>
 <section xml:id="_the_is_a_relationship">
 <title>The is-a relationship</title>
 <simpara>Consider the two following class definitions:</simpara>
-<programlisting xml:id="program:Racecar" xreflabel="Racecar" language="java" linenumbering="numbered">public class Racecar {
+<programlisting xml:id="RacecarProgram" language="java" linenumbering="numbered">public class Racecar {
 	public double getTopSpeed() { return 200.0; }
 	public int getHorsepower() { return 700; }
 	public double speed = 0;
 }</programlisting>
-<programlisting xml:id="program:TurboRacecar" xreflabel="TurboRacecar" language="java" linenumbering="numbered">public class TurboRacecar extends Racecar {
+<programlisting xml:id="TurboRacecarProgram" language="java" linenumbering="numbered">public class TurboRacecar extends Racecar {
 	public int getHorsepower() { return 1100; }
 }</programlisting>
 <simpara>Now, imagine that a <literal>RaceTrack</literal> has an <literal>addCar(Racecar car)</literal> method
@@ -26717,12 +27125,12 @@ or not a method is dynamically bound.</simpara>
 <simpara>Only methods are dynamically bound in Java. Fields are <emphasis>statically
 bound</emphasis>. Consider the following re-definitions of <literal>Racecar</literal> and
 <literal>TurboRacecar</literal>.</simpara>
-<programlisting xml:id="program:StaticRacecar" xreflabel="StaticRacecar" language="java" linenumbering="numbered">public class StaticRacecar {
+<programlisting xml:id="StaticRacecarProgram" language="java" linenumbering="numbered">public class StaticRacecar {
 	public static final double TOP_SPEED = 200.0;
 	public static final int HORSEPOWER = 700;
 	public double speed = 0;
 }</programlisting>
-<programlisting xml:id="program:StaticTurboRacecar" xreflabel="StaticTurboRacecar" language="java" linenumbering="numbered">public class StaticTurboRacecar extends StaticRacecar {
+<programlisting xml:id="StaticTurboRacecarProgram" language="java" linenumbering="numbered">public class StaticTurboRacecar extends StaticRacecar {
 	public static final int HORSEPOWER = 1100;
 }</programlisting>
 <simpara>Assume that <literal>RaceTrack</literal> contains a method which prints out the
@@ -26745,12 +27153,12 @@ a class than you need but never a more general one. You can use a
 square will do the job of a rectangle, but a rectangle will not always
 be suitable when a square is needed.</simpara>
 <simpara>Consider the following two classes:</simpara>
-<programlisting xml:id="program:Vehicle" xreflabel="Vehicle" language="java" linenumbering="numbered">public class Vehicle {
+<programlisting xml:id="VehicleProgram" language="java" linenumbering="numbered">public class Vehicle {
 	public void travel( String destination ) {
 		System.out.println("Traveling to " + destination + "!");
 	}
 }</programlisting>
-<programlisting xml:id="program:RocketShip" xreflabel="RocketShip" language="java" linenumbering="numbered">public class RocketShip extends Vehicle {
+<programlisting xml:id="RocketShipProgram" language="java" linenumbering="numbered">public class RocketShip extends Vehicle {
 	public void blastOff() {
 		System.out.println("FOOOOM!");
 	}
@@ -26799,7 +27207,7 @@ never be instantiated. In order to use an abstract class, it is
 necessary to derive a class from it. To create an abstract class, you
 just need to add the <literal>abstract</literal> keyword to its definition, as in the
 following example.</simpara>
-<programlisting xml:id="program:Useless" xreflabel="Useless" language="java" linenumbering="numbered">public abstract class Useless {
+<programlisting xml:id="UselessProgram" language="java" linenumbering="numbered">public abstract class Useless {
 	protected int variable;
 
 	public Useless( int input ) {
@@ -26817,7 +27225,7 @@ object has been created. Finally, since an abstract class cannot be
 instantiated, the following code snippet will not compile.</simpara>
 <programlisting language="java" linenumbering="unnumbered">Useless thing = new Useless( 14 );</programlisting>
 <simpara>Instead, we must create a new class that extends <literal>Useless</literal>.</simpara>
-<programlisting xml:id="program:Useful" xreflabel="Useful" language="java" linenumbering="numbered">public class Useful extends Useless {
+<programlisting xml:id="UsefulProgram" language="java" linenumbering="numbered">public class Useful extends Useless {
 	public int getVariable() { return variable; }
 
 	public void setVariable( int value ) {
@@ -26840,7 +27248,7 @@ class that will be used directly.</simpara>
 <simpara>Methods can be abstract as well. If you have an abstract class, you can
 create a method header which describes a method that all non-abstract
 children classes must implement, as show below.</simpara>
-<programlisting xml:id="program:Sequence" xreflabel="Sequence" language="java" linenumbering="numbered">public abstract class Sequence {
+<programlisting xml:id="SequenceProgram" language="java" linenumbering="numbered">public abstract class Sequence {
 	protected int number;
 	protected final int CONSTANT;
 
@@ -26857,13 +27265,13 @@ produce some sequence of numbers. Note that there is no body for the
 non-abstract derived class must implement a <literal>getNextValue()</literal> method to
 produce the next number in the sequence. For example, we could implement
 an arithmetic or a geometric sequence as follows.</simpara>
-<programlisting xml:id="program:ArithmeticSequence" xreflabel="ArithmeticSequence" language="java" linenumbering="numbered">public class ArithmeticSequence extends Sequence {
+<programlisting xml:id="ArithmeticSequenceProgram" language="java" linenumbering="numbered">public class ArithmeticSequence extends Sequence {
 	public abstract int getNextValue() {
 		number += CONSTANT;
 		return number;
 	}
 }</programlisting>
-<programlisting xml:id="program:GeometricSequence" xreflabel="GeometricSequence" language="java" linenumbering="numbered">public class GeometricSequence extends Sequence {
+<programlisting xml:id="GeometricSequenceProgram" language="java" linenumbering="numbered">public class GeometricSequence extends Sequence {
 	public abstract int getNextValue() {
 		number *= CONSTANT;
 		return number;
@@ -27043,7 +27451,7 @@ to be more specific.</simpara>
 class <literal>RocketShip</literal> and not for objects of a subclass like
 <literal>FusionPoweredRocketShip</literal>.</simpara>
 </section>
-<section xml:id="subsection:Inheritance_and_exceptions">
+<section xml:id="_inheritance_and_exceptions">
 <title>Inheritance and exceptions</title>
 <simpara>Beyond `ClassCastException`s, there are a few other issues that come up
 when combining exceptions with inheritance. As you already know, an
@@ -27101,7 +27509,7 @@ hierarchy.</simpara>
 <textobject><phrase>animals</phrase></textobject>
 </mediaobject>
 </figure>
-<programlisting xml:id="program:Animal" xreflabel="Animal" language="java" linenumbering="numbered">public abstract class Animal {
+<programlisting xml:id="AnimalProgram" language="java" linenumbering="numbered">public abstract class Animal {
 	private boolean alive = true;
 	private boolean happy = true;
 	private final boolean warmblooded;
@@ -27123,7 +27531,7 @@ definition for animals which includes whether the animal is alive,
 whether the animal is happy, and whether it is warmblooded (declared
 <literal>final</literal> because an animal can&#8217;t switch between warmblooded and
 coldblooded).</simpara>
-<programlisting xml:id="program:Mammal" xreflabel="Mammal" language="java" linenumbering="numbered">public abstract class Mammal extends Animal {
+<programlisting xml:id="MammalProgram" language="java" linenumbering="numbered">public abstract class Mammal extends Animal {
 	public static final boolean MALE = false;
 	public static final boolean FEMALE = true;
 	private final boolean gender;
@@ -27143,7 +27551,7 @@ addition, it is assumed that all mammals make some sound. Mammals also
 have well-defined genders, declared <literal>final</literal> because it cannot change
 once it has been set. Like <literal>Animal</literal>, <literal>Mammal</literal> is an abstract class, and
 any non-abstract subclass of <literal>Mammal</literal> must implement <literal>makeSound()</literal>.</simpara>
-<programlisting xml:id="program:Platypus" xreflabel="Platypus" language="java" linenumbering="numbered">public class Platypus extends Mammal {
+<programlisting xml:id="PlatypusProgram" language="java" linenumbering="numbered">public class Platypus extends Mammal {
 	public Platypus( boolean gender ) {
 		super( gender );
 	}
@@ -27182,7 +27590,7 @@ solved, this class might warrant a great deal more specialization. Right
 now the main addition is taking happiness as an argument to the
 constructor. Unfortunately, the default human state is not necessarily
 happiness.</simpara>
-<programlisting xml:id="program:DavidBowie" xreflabel="DavidBowie" language="java" linenumbering="numbered">public final class DavidBowie extends Human {
+<programlisting xml:id="DavidBowieProgram" language="java" linenumbering="numbered">public final class DavidBowie extends Human {
 	public DavidBowie() {
 		super( MALE, true );
 	}
@@ -27219,7 +27627,7 @@ chapter and give its solution. We have already given you the
 <textobject><phrase>accounts</phrase></textobject>
 </mediaobject>
 </figure>
-<formalpara xml:id="program:CheckingAccount" xreflabel="CheckingAccount">
+<formalpara xml:id="CheckingAccountProgram">
 <title>Subclass of <literal>BankAccount</literal> that models a normal checking account.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class CheckingAccount extends BankAccount {
@@ -27261,7 +27669,7 @@ safe.</simpara>
 <simpara>Note that we do not use the constant <literal>FEE</literal> directly in <literal>update()</literal>.
 Instead, we call the <literal>getFee()</literal> method. The reason for this decision is
 due to the next class.</simpara>
-<formalpara xml:id="program:DirectDepositAccount" xreflabel="DirectDepositAccount">
+<formalpara xml:id="DirectDepositAccountProgram">
 <title>Subclass of <literal>CheckingAccount</literal> that models the behavior of accounts with direct deposits.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Calendar;
@@ -27302,7 +27710,7 @@ has been a recent direct deposit, the fee is nothing, otherwise, it
 returns the fee from the <literal>CheckingAccount</literal>. Because of dynamic binding,
 the <literal>update()</literal> method defined in <literal>CheckingAccount</literal> will call this
 overridden <literal>getFee()</literal> method for <literal>DirectDepositAccount</literal> objects.</simpara>
-<formalpara xml:id="program:SavingsAccount" xreflabel="SavingsAccount">
+<formalpara xml:id="SavingsAccountProgram">
 <title>Subclass of <literal>BankAccount</literal> that models the behavior of a savings account.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class SavingsAccount extends BankAccount {
@@ -27366,16 +27774,16 @@ operations that are guaranteed to execute atomically. For example, the
 variable with atomic accesses. One of its methods is
 <literal>incrementAndGet()</literal>, which will atomically increment its internal value
 by 1 and return the result. Recall from
-Program <xref linkend="program:RaceCondition"/> that even an operation as simple as
+<xref linkend="RaceConditionProgram"/> that even an operation as simple as
 <literal>++</literal> is not atomic. If many different threads try to increment a single
 variable, some of those increments can get lost, causing the final value
 to be less than it should be.</simpara>
 <example>
 <title>AtomicInteger</title>
 <simpara>We can use the <literal>AtomicInteger</literal> class to rewrite
-Program <xref linkend="program:RaceCondition"/> so that no race condition occurs.</simpara>
-<formalpara xml:id="program:NoRaceCondition" xreflabel="NoRaceCondition">
-<title>Program to demonstrate the use of <literal>AtomicInteger</literal>.</title>
+<xref linkend="RaceConditionProgram"/> so that no race condition occurs.</simpara>
+<formalpara xml:id="NoRaceConditionProgram">
+<title>Demonstrates the use of <literal>AtomicInteger</literal>.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.concurrent.atomic.*;
 
@@ -27407,7 +27815,7 @@ public class NoRaceCondition extends Thread {
 }</programlisting>
 </para>
 </formalpara>
-<simpara>This program is identical to Program <xref linkend="program:RaceCondition"/>, except
+<simpara>This program is identical to <xref linkend="RaceConditionProgram"/>, except
 that the type of <literal>counter</literal> has been changed from <literal>int</literal> to
 <literal>AtomicInteger</literal> (and an appropriate <literal>import</literal> has been added).
 Consequently, the <literal>++</literal> operation was changed to an <literal>incrementAndGet()</literal>
@@ -27415,13 +27823,16 @@ method call, and a <literal>get()</literal> method call was needed to get the fi
 value. If you run this program, the final answer should always be
 1000000, no matter what.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise17.9">Exercise 17.9</link></simpara>
+</sidebar>
 <simpara>The <literal>java.util.concurrent.atomic</literal> package includes <literal>AtomicBoolean</literal> and
 <literal>AtomicLong</literal> as well as <literal>AtomicInteger</literal>. Likewise, the
 <literal>AtomicIntegerArray</literal> and <literal>AtomicLongArray</literal> classes are included to
 perform atomic array accesses. For general purposes, the
 <literal>AtomicReference&lt;V&gt;</literal> class provides an atomic way to store a reference
 to any object. (The <literal>&lt;V&gt;</literal> is a generic type parameter, which will be
-discussed in Chapter <xref linkend="chapter:Dynamic_Data_Structures"/>.)</simpara>
+discussed in <xref linkend="_dynamic_data_structures"/>.)</simpara>
 <simpara>Although you could use the <literal>synchronized</literal> keyword to create each one of
 these classes yourself, the result would not be as efficient. The atomic
 classes use a special <emphasis>lock-free</emphasis> mechanism. Unlike using the
@@ -27433,13 +27844,17 @@ instructions on the CPU. Since there is no waiting to acquire a lock or
 fighting over which thread has the lock, the operation is very fast.
 Many high performance concurrent applications depends on CAS
 implementations.</simpara>
+<sidebar>
+<simpara><link linkend="exercise17.11">Exercise 17.11</link></simpara>
+</sidebar>
 </section>
-<section xml:id="_exercises_16">
+<section xml:id="_exercises_17">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>Consider the following two classes:</simpara>
-<programlisting xml:id="program:Sale" xreflabel="Sale" language="java" linenumbering="numbered">public class Sale {
+<simpara><anchor xml:id="exercise17.1" xreflabel="[exercise17.1]"/> Consider the following two classes:</simpara>
+<programlisting xml:id="SaleProgram" language="java" linenumbering="numbered">public class Sale {
 	public double discount = 0.25;
 
 	public double getDiscount() {
@@ -27450,7 +27865,7 @@ implementations.</simpara>
 		discount = value;
 	}
 }</programlisting>
-<programlisting xml:id="program:Blowout" xreflabel="Blowout" language="java" linenumbering="numbered">public class Blowout extends Sale {
+<programlisting xml:id="BlowoutProgram" language="java" linenumbering="numbered">public class Blowout extends Sale {
 	public double discount = 0.5;
 
 	public double getDiscount() {
@@ -27471,11 +27886,11 @@ sale.setDiscount( 0.75 );
 System.out.println( sale.discount );</programlisting>
 </listitem>
 <listitem>
-<simpara>What are the differences and similarities between abstract classes
+<simpara><anchor xml:id="exercise17.2" xreflabel="[exercise17.2]"/> What are the differences and similarities between abstract classes
 and interfaces?</simpara>
 </listitem>
 <listitem>
-<simpara>Assume that the <literal>Corn</literal>, <literal>Carrot</literal>, and <literal>Potato</literal> classes are all
+<simpara><anchor xml:id="exercise17.3" xreflabel="[exercise17.3]"/> Assume that the <literal>Corn</literal>, <literal>Carrot</literal>, and <literal>Potato</literal> classes are all
 derived from <literal>Vegetable</literal>. Both <literal>Carrot</literal> and <literal>Potato</literal> classes have a
 <literal>peel()</literal> method, but <literal>Corn</literal> does not. Examine the following code and
 identify which line will cause an error and why.</simpara>
@@ -27493,11 +27908,11 @@ while( index &gt;= 0 ) {
 }</programlisting>
 </listitem>
 <listitem>
-<simpara>How many different meanings of the keyword <literal>final</literal> are there in
+<simpara><anchor xml:id="exercise17.4" xreflabel="[exercise17.4]"/> How many different meanings of the keyword <literal>final</literal> are there in
 Java, and what does each mean?</simpara>
 </listitem>
 <listitem>
-<simpara>Assume that <literal>Quicksand</literal> is a subclass of <literal>Danger</literal>.</simpara>
+<simpara><anchor xml:id="exercise17.5" xreflabel="[exercise17.5]"/>  Assume that <literal>Quicksand</literal> is a subclass of <literal>Danger</literal>.</simpara>
 <simpara>What is the output of the following code?</simpara>
 <programlisting language="java" linenumbering="unnumbered">Quicksand quicksand = new Quicksand();
 if( quicksand instanceof Danger ) {
@@ -27512,7 +27927,7 @@ if( quicksand.getClass() == Quicksand.class )
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Implement a program to assess income tax on normal employees,
+<simpara><anchor xml:id="exercise17.6" xreflabel="[exercise17.6]"/> Implement a program to assess income tax on normal employees,
 students, and international students using a class hierarchy. Normal
 employees pay a 6.2% social security tax and a 1.45% Medicare tax every
 year, but neither kind of student pays these taxes. All three groups pay
@@ -27562,15 +27977,15 @@ international students whose country has a treaty with the U.S. so that
 they do not have to pay tax on the first $50,000 of income.</simpara>
 </listitem>
 <listitem>
-<simpara>Refer to the sort given in Section <xref linkend="solution:Sort_it_out"/> as the
+<simpara><anchor xml:id="exercise17.7" xreflabel="[exercise17.7]"/> Refer to the sort given in <xref linkend="_solution_sort_it_out"/> as the
 solution to the Sort It Out problem. Add another <literal>boolean</literal> to the
 parameters of the sort which specifies whether the sort is ascending or
 descending. Make the needed changes throughout the code to add this
 functionality.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:parallel_bubble_sort"/> Again refer to the sort from
-Section <xref linkend="solution:Sort_it_out"/>. The goal now is to parallelize the
+<simpara><anchor xml:id="exercise17.8" xreflabel="[exercise17.8]"/> Again refer to the sort from
+<xref linkend="_solution_sort_it_out"/>. The goal now is to parallelize the
 sort. Change the sort to work with <literal>int</literal> values then write some code
 which will generate an array of random <literal>int</literal> values. Design your code so
 that you can spawn <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> threads. Partition the single array
@@ -27588,8 +28003,8 @@ Make sure that you are careful not to go beyond the end of the arrays
 which are being merged.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:use_atomics"/> Re-implement the original
-<literal>SynchronizedAccount</literal> class from Example <xref linkend="example:Bank_account"/> using
+<simpara><anchor xml:id="exercise17.9" xreflabel="[exercise17.9]"/> Re-implement the original
+<literal>SynchronizedAccount</literal> class from <xref linkend="bankAccountExample"/> using
 atomic classes. For simplicity, you can change the <literal>balance</literal> type from
 <literal>double</literal> to <literal>AtomicInteger</literal> since there is no <literal>AtomicDouble</literal> class. How
 much has this simplified the implementation? Is the <literal>readers</literal> field
@@ -27597,19 +28012,19 @@ still necessary? Why or why not?</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Once you have implemented the sort in parallel from
-Exercise <xref linkend="exercise:parallel_bubble_sort"/>, time it against the
+<simpara><anchor xml:id="exercise17.10" xreflabel="[exercise17.10]"/> Once you have implemented the sort in parallel from
+<link linkend="exercise17.8">Exercise 17.8</link>, time it against the
 sequential version. Try 2, 4, and 8 different threads, particularly if
 you have 8 cores. Be sure to create one random array and use the same
 array for both the parallel and sequential versions. Try array sizes of
-1000, 100000, and 1000000. Did the performance increase as much as you
+1,000, 100,000, and 1,000,000. Did the performance increase as much as you
 expect?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:test_atomics"/> Take Program <xref linkend="program:NoRaceCondition"/>
+<simpara><anchor xml:id="exercise17.11" xreflabel="[exercise17.11]"/> Take <xref linkend="NoRaceConditionProgram"/>
 and increase <literal>COUNT</literal> to <literal>100000000</literal>. Run it several times and time how
 long it takes to run to completion.</simpara>
-<simpara>Then, take Program <xref linkend="program:RaceCondition"/> and increase its <literal>COUNT</literal> to
+<simpara>Then, take <xref linkend="RaceConditionProgram"/> and increase its <literal>COUNT</literal> to
 <literal>100000000</literal> as well. Change the body of the <literal>for</literal> loop inside the
 <literal>run()</literal> method so that <literal>count++;</literal> is inside of a <literal>synchronized</literal> block
 that uses <literal>RaceCondition.class</literal> as the lock. (The choice of
@@ -27624,7 +28039,7 @@ the implementation of locks and CAS on your OS and hardware platform.</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Dynamic_Data_Structures">
+<chapter xml:id="_dynamic_data_structures">
 <title>Dynamic Data Structures</title>
 <blockquote>
 <attribution>
@@ -27634,19 +28049,17 @@ Niklaus Wirth
 </blockquote>
 <section xml:id="_problem_infix_conversion">
 <title>Problem: Infix conversion</title>
-<simpara>If a math teacher writes the expression <inlineequation><alt><![CDATA[(1 + 7\times8 -
-6\times(4 + 5) \div  3)]]></alt><mathphrase><![CDATA[(1 + 7\times8 -
-6\times(4 + 5) \div  3)]]></mathphrase></inlineequation> on the blackboard and asks a group of 10 year
-old children to solve it, different children may give different answers.
+<simpara>If a math teacher writes the expression 1 + 7 × 8 -
+6 × (4 + 5) ÷ 3 on the blackboard and asks a group of 10-year-old children to solve it, different children may give different answers.
 The difficulty is that the children may not understand the order of
 operations. Modern graphing calculators and many computer programs can,
 of course, evaluate such expressions correctly, but how do they do it?
 You intuitively grasp order of operations (left to right, multiplication
 and division take higher precedence than addition and subtraction), but
-encoding that intuition into a computer program is more difficult.</simpara>
+encoding that intuition into a computer program takes effort.</simpara>
 <simpara>One way a computer scientist might approach this problem is to turn the
-mathematical expression from one that is difficult to evaluate to one
-that is easy. The normal style of writing mathematical expressions is
+mathematical expression from one that&#8217;s difficult to evaluate to one
+that&#8217;s easy. The normal style of writing mathematical expressions is
 called <emphasis>infix notation</emphasis>, because the operators are written in between
 the operands they are used on. A much easier notation for automatic
 evaluation is called <emphasis>postfix notation</emphasis>, because an operator is placed
@@ -27688,7 +28101,7 @@ notation has the benefit of exactly specifying the order of operations
 without using any precedence rules and without needing parentheses to
 clarify. To understand how to compute an expression in postfix notation,
 we rely on the idea of a stack, which we first introduces in
-Chapter <xref linkend="chapter:Classes"/> and examine in much greater depth here.</simpara>
+<xref linkend="_classes"/> and examine in much greater depth here.</simpara>
 <simpara>Recall that a stack has three operations: <emphasis>push</emphasis>, <emphasis>pop</emphasis>, and <emphasis>top</emphasis>. It
 works like a stack of physical objects. The push operation places an
 object on the top, the pop operation removes an item from the top, and
@@ -27751,7 +28164,7 @@ the stack, treat <literal>(</literal> as if it has even lower precedence than <l
 <simpara>Following this algorithm, we are able to write a program that converts
 infix notation to postfix notation. We further restrict our problem to
 the case when the only operands are positive integers in the range
-<inlineequation><alt><![CDATA[[0, 9]]></alt><mathphrase><![CDATA[[0, 9]]></mathphrase></inlineequation>]. Since each is a single character, parsing the
+[0, 9]. Since each is a single character, parsing the
 input is much easier. The same ideas for postfix conversion holds no
 matter how the input is formatted, but parsing arbitrarily formatted
 numbers is a difficult problem in its own right. This restriction also
@@ -27759,8 +28172,7 @@ makes spaces unnecessary.</simpara>
 <simpara>To solve the infix conversion problem, we need to create a stack data
 structure whose elements are terms from an infix expression, where a
 term is an operator, operand, or a parenthesis. We created a stack to
-solve the nesting expression problem in Section <xref linkend="solution:Nested
-expressions"/>, but we explore stacks in this chapter as one of many
+solve the nesting expression problem in <xref linkend="_problem_nested_expressions"/>, but we explore stacks in this chapter as one of many
 different kinds of dynamic data structure.</simpara>
 </section>
 <section xml:id="_concepts_dynamic_data_structures">
@@ -27775,7 +28187,7 @@ integers into it.</simpara>
 <simpara>In this chapter, we examine <emphasis>dynamic</emphasis> data structures: As more data is
 read or processed, these data structures grow and shrink in memory to
 store what is needed. The stack used to solve the nesting expressions
-problem from Chapter <xref linkend="chapter:Classes"/> is not actually a dynamic data
+problem from <xref linkend="_classes"/> is not actually a dynamic data
 structure since it is defined with a fixed maximum size. In this
 chapter, we implement a true stack as well as many other kinds of
 dynamic data structures.</simpara>
@@ -27804,7 +28216,7 @@ after it must be moved forward one position. Thus, insertions and
 deletions at the end of a dynamic array are usually efficient, but
 insertions and deletions in the middle are very time consuming.</simpara>
 </section>
-<section xml:id="subsection:Linked_lists">
+<section xml:id="_linked_lists">
 <title>Linked lists</title>
 <simpara>The second kind of dynamic data structure is based on objects that link
 to (or reference) other objects. The simplest form of such a data type
@@ -27856,7 +28268,7 @@ value, pop a value, and tell us what value is on top. The internal
 workings of the stack are irrelevant (as long as they are efficient). It
 is possible to use either a dynamic array or a linked list to implement
 a stack ADT. A queue is another ADT we discuss in
-Section <xref linkend="syntax:Abstract_data_types_(ADT)"/>, but there are many other
+<xref linkend="_syntax_abstract_data_types_adt"/>, but there are many other
 useful ADTs.</simpara>
 </section>
 </section>
@@ -27884,7 +28296,7 @@ necessary during processing. (It is also possible to contract an array
 once you determine that the array has more space than needed.)</simpara>
 <section xml:id="_a_simple_solution">
 <title>A simple solution</title>
-<simpara>Program <xref linkend="program:ReadIntoFixedArray"/> allocates an array of 10 strings
+<simpara><xref linkend="ReadIntoFixedArrayProgram"/> allocates an array of 10 strings
 and reads a list of names from standard input until it reaches the end
 of the file, storing each name in successive array locations. If the
 number of names in the input is larger than the size of the array, it
@@ -27895,8 +28307,8 @@ exception or check the index before storing the name in the array. In
 either case, we would then take some action that is more user friendly
 than generating an exception, perhaps simply printing an explanatory
 message before exiting.</simpara>
-<formalpara xml:id="program:ReadIntoFixedArray" xreflabel="ReadIntoFixedArray">
-<title>Program to read names into an array, sort, and print. If there are more than 10 lines in the input, an exception is generated.</title>
+<formalpara xml:id="ReadIntoFixedArrayProgram">
+<title>Reads names into an array, sort, and print. If there are more than 10 lines in the input, an exception is generated.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Arrays;
 import java.util.Scanner;
@@ -27926,22 +28338,20 @@ recompile, and re-run the program), but that option may not be available
 to us if the program has been distributed to users around the world.
 Instead, we fix the problem on the fly by allocating a larger array,
 copying the old array into the new array, and continuing.</simpara>
-<simpara>Program <xref linkend="program:ReadAndGrowArray"/> begins like the previous program by
-allocating a fixed array. However, it now catches the
-<literal>ArrayOutOfBoundsException</literal> at line <xref linkend="exceptionRAGA"/> if it tries to
-store too many names into the array. The <literal>catch</literal> clause allocates a new
-array, twice the size of the original (current) array, copies the
-existing array into it, and replaces the reference to the current array
-with a reference to the new array.</simpara>
-<formalpara xml:id="program:ReadAndGrowArray" xreflabel="ReadAndGrowArray">
-<title>Read names into an array, enlarging the array as necessary.</title>
+<sidebar>
+<simpara><link linkend="exercise18.3">Exercise 18.3</link></simpara>
+</sidebar>
+<simpara><xref linkend="ReadAndGrowArrayProgram"/> begins like the previous program by
+allocating a fixed array.</simpara>
+<formalpara xml:id="ReadAndGrowArrayProgram">
+<title>Reads names into an array, enlarging the array as necessary.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Arrays;
 import java.util.Scanner;
 
 public class ReadAndGrowArray {
 	public static void main(String[] args) {
-		String[] names = new String[10];/*@\label{lineNames}@*/
+		String[] names = new String[10];
 		Scanner in = new Scanner(System.in);
 		int n = 0;
 		String name = null;
@@ -27951,9 +28361,8 @@ public class ReadAndGrowArray {
 			try {
 				names[n] = name;
 			}
-			catch( ArrayIndexOutOfBoundsException e ) {/*@\label{exceptionRAGA}@*/
-				names = Arrays.copyOfRange(names, 0,/*@\label{lineCopy}@*/
-							names.length*2);
+			catch( ArrayIndexOutOfBoundsException e ) { <co xml:id="CO25-1"/>
+				names = Arrays.copyOfRange(names, 0, names.length*2); <co xml:id="CO25-2"/>
 				names[n] = name;
 			}
 			n++;
@@ -27967,22 +28376,33 @@ public class ReadAndGrowArray {
 }</programlisting>
 </para>
 </formalpara>
+<calloutlist>
+<callout arearefs="CO25-1">
+<para>At this point, it now catches the <literal>ArrayOutOfBoundsException</literal> if there isn&#8217;t enough space for another name in the array.</para>
+</callout>
+<callout arearefs="CO25-2">
+<para>The <literal>catch</literal> clause allocates a new array, twice the size of the original (current) array, copies the existing array into it, and replaces the reference to the current array with a reference to the new array.</para>
+</callout>
+</calloutlist>
 <simpara>Note that it was necessary to refactor the code in
-Program <xref linkend="program:ReadIntoFixedArray"/> slightly: Add the <literal>name</literal> variable
+<xref linkend="ReadIntoFixedArrayProgram"/> slightly: Add the <literal>name</literal> variable
 to hold the temporary result of reading the input line, and move the
 counter increment to outside the <literal>try</literal>-<literal>catch</literal> block.</simpara>
 <simpara>Can this new, improved program still fail? Yes, but only for <emphasis role="strong">very
 large</emphasis> input, in the case when the Java virtual machine runs out of
 memory when doubling the size of the array.</simpara>
+<sidebar>
+<simpara><link linkend="exercise18.4">Exercise 18.4</link></simpara>
+</sidebar>
 <simpara>A potentially more serious problem is the way we set <literal>names</literal> to point at
 a new array.</simpara>
 <programlisting language="java" linenumbering="unnumbered">    names = Arrays.copyOfRange(names, 0, names.length*2);</programlisting>
 <simpara>This line works because we know the only variable that references the
 array is <literal>names</literal>. If other variables referenced that array, they would
 continue to reference the old, smaller, and now out-of-date version of
-the <literal>names</literal> array. Figure <xref linkend="figure:dynamicproblems"/> gives an example of
+the <literal>names</literal> array. <xref linkend="figure-dynamicproblems"/> gives an example of
 this problem.</simpara>
-<figure>
+<figure xml:id="figure-dynamicproblems">
 <title>A poorly designed dynamic array implementation. (a) Both <literal>array1</literal> and <literal>array2</literal> begin pointing at the same array. (b) A new array has been allocated, and <literal>42</literal> has been added to it. <literal>array1</literal> has been updated to point at the new array, but <literal>array2</literal> still points at the original.</title>
 <mediaobject>
 <imageobject>
@@ -28002,12 +28422,12 @@ array.</simpara>
 <simpara>A solution to this problem is to create a new class whose objects
 contain the array as a private field. References to the array are then
 mediated, as usual, via accessor methods, which always refers to the
-same version of the array. Program <xref linkend="program:DynamicArray"/> is a simple
+same version of the array. <xref linkend="DynamicArrayProgram"/> is a simple
 implementation of a dynamic array class. This class maintains an
 internal array of <literal>String</literal> objects, which it extends whenever a call to
 <literal>set()</literal> tries to write a new element just past the end of the array.</simpara>
-<formalpara xml:id="program:DynamicArray" xreflabel="DynamicArray">
-<title>A class to manage a dynamic array. This array grows by doubling when more space is needed.</title>
+<formalpara xml:id="DynamicArrayProgram">
+<title>Class to manage a dynamic array. This array grows by doubling when more space is needed.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Arrays;
 
@@ -28033,17 +28453,21 @@ public class DynamicArray {
 </formalpara>
 <simpara>Note that the <literal>set()</literal> and <literal>sort()</literal> methods are both <literal>synchronized</literal> in
 case this class is used by multiple threads simultaneously.
-Exercise <xref linkend="exercise:dynamicArrayTestExercise"/> explores the need to
+<link linkend="exercise18.12">Exercise 18.12</link> explores the need to
 synchronize these methods in the presence of multiple threads.</simpara>
-<simpara>Program <xref linkend="program:UseDynamicArray"/> illustrates how to modify and extend
-Program <xref linkend="program:ReadIntoFixedArray"/> to use this new class. Since the
+<sidebar>
+<simpara><link linkend="exercise18.9">Exercise 18.9</link><?asciidoc-br?>
+<link linkend="exercise18.12">Exercise 18.12</link></simpara>
+</sidebar>
+<simpara><xref linkend="UseDynamicArrayProgram"/> illustrates how to modify and extend
+<xref linkend="ReadIntoFixedArrayProgram"/> to use this new class. Since the
 array grows automatically, there is no need for the original program to
 check for out-of-bounds exceptions. Of course, the array expansion only
 works if the reference occurs exactly at the index corresponding to one
 beyond the end of the array. Other out-of-bound references generate an
 exception.</simpara>
-<formalpara xml:id="program:UseDynamicArray" xreflabel="UseDynamicArray">
-<title>A program that uses the <literal>DynamicArray</literal> class to store input read from a file.</title>
+<formalpara xml:id="UseDynamicArrayProgram">
+<title>Uses the <literal>DynamicArray</literal> class to store input read from a file.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Scanner;
 
@@ -28078,10 +28502,13 @@ potentially serious performance penalties. If the initial array is too
 small, compared to the final size, then it will have been doubled and
 the elements copied multiple times, resulting in slower execution. After
 a resize, the array is only half full, resulting in wasted space. Even
-on average, the array will only be three-quarters full</simpara>
+on average, the array will only be three-quarters full.</simpara>
+<sidebar>
+<simpara><link linkend="exercise18.5">Exercise 18.5</link></simpara>
+</sidebar>
 </section>
 </section>
-<section xml:id="linked-lists">
+<section xml:id="_linked_lists_2">
 <title>Linked lists</title>
 <simpara>As we&#8217;ve seen, while dynamic arrays can grow to accommodate a large
 number of items, the performance penalties of repeated copying and the
@@ -28109,8 +28536,7 @@ modification. The nested class has two fields, one containing the data
 to be stored and the other containing a link or reference to the next
 object, or <emphasis>node</emphasis>, in the list. Since they are only accessed by the
 outer class, it is reasonable to make these fields public. If you need a
-refresher on static nested classes, refer to Section <xref linkend="advanced:Nested
-classes"/>.</simpara>
+refresher on static nested classes, refer to <xref linkend="_advanced_nested_classes"/>.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public class LinkedList {
     private static class Node {
         public String value;
@@ -28135,8 +28561,8 @@ it is useful to know how many nodes are in it. We can create a <literal>size</li
 field that we increment whenever we add a node, as well as an accessor
 to read its value. Finally, we can create a <literal>fillArray()</literal> method that
 fills an array with the values in the list.</simpara>
-<formalpara xml:id="program:LinkedList" xreflabel="LinkedList">
-<title>A basic implementation of a linked list class to hold <literal>String</literal> objects.</title>
+<formalpara xml:id="LinkedListProgram">
+<title>Basic implementation of a linked list class to hold <literal>String</literal> objects.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class LinkedList {
     private static class Node {
@@ -28170,12 +28596,12 @@ fills an array with the values in the list.</simpara>
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Program <xref linkend="program:UseLinkedList"/> is a re-implementation of the
+<simpara><xref linkend="UseLinkedListProgram"/> is a re-implementation of the
 name-reading program using class <literal>LinkedList</literal>. Note that no array needs
 to be pre-allocated. Instead, we capture all the lines of input into a
 linked list called <literal>list</literal>.</simpara>
-<formalpara xml:id="program:UseLinkedList" xreflabel="UseLinkedList">
-<title>A program that uses the <literal>LinkedList</literal> class to store input read from a file.</title>
+<formalpara xml:id="UseLinkedListProgram">
+<title>Uses the <literal>LinkedList</literal> class to store input read from a file.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Arrays;
 import java.util.Scanner;
@@ -28206,11 +28632,10 @@ of the list (which could be empty if <literal>head</literal> is <literal>null</l
 new <literal>Node</literal>. We then update the <literal>head</literal> field to reference the new <literal>Node</literal>.
 Thus, each new line read from the file is stored at the <emphasis role="strong">beginning</emphasis> of
 the linked list. The last node in the list, which contains the first
-<literal>String</literal> read in, has a <literal>next</literal> value of <literal>null</literal>. Figure <xref linkend="figure:linked
-list classes"/> shows a visualization of the contents of this
+<literal>String</literal> read in, has a <literal>next</literal> value of <literal>null</literal>. <xref linkend="figure-linked_list_classes"/> shows a visualization of the contents of this
 implementation of a linked list. An &#8220;X&#8221; is used in place of an arrow
 that points to <literal>null</literal>.</simpara>
-<figure>
+<figure xml:id="figure-linked_list_classes">
 <title>Visualization of linked list implementation with classes.</title>
 <mediaobject>
 <imageobject>
@@ -28239,7 +28664,7 @@ pointing to the first element read from the file and the last element on
 the list (the one with <literal>next</literal> pointing to <literal>null</literal>) containing the
 <literal>String</literal> most recently read, we can maintain a second field that
 references the <emphasis>tail</emphasis> of the list.</simpara>
-<simpara>Program <xref linkend="program:LinkedListWithTail"/> adds a <emphasis>tail pointer</emphasis> called
+<simpara><xref linkend="LinkedListWithTailProgram"/> adds a <emphasis>tail pointer</emphasis> called
 <literal>tail</literal> to the <literal>LinkedList</literal> class. Note that we have changed the <literal>add()</literal>
 method to the <literal>addFirst()</literal> method, and we have also added an <literal>addLast()</literal>
 method to make it easy to append elements to the end of a linked list.
@@ -28251,7 +28676,7 @@ also sets both the <literal>head</literal> and <literal>tail</literal> to point 
 value. Once the list has a node in it, subsequent calls to <literal>addLast()</literal>
 creates a new <literal>Node</literal>, points the <literal>next</literal> field of the old <literal>tail</literal> at it,
 and changes the <literal>tail</literal> field so that it also points at it.</simpara>
-<formalpara xml:id="program:LinkedListWithTail" xreflabel="LinkedListWithTail">
+<formalpara xml:id="LinkedListWithTailProgram">
 <title>We can append to the end of a linked list by using an additional variable, <literal>tail</literal>, to reference the last element (tail) of the list.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class LinkedListWithTail {
@@ -28309,7 +28734,7 @@ captured the lines into a linked list of elements, dumped these elements
 into an array of the right size, and then sorted the array. An
 alternative solution is to insert the elements into the linked list at
 the right point in the first place.</simpara>
-<simpara>Program <xref linkend="program:SortedLinkedList"/> is a version of a linked list that
+<simpara><xref linkend="SortedLinkedListProgram"/> is a version of a linked list that
 inserts elements into the linked list in sorted order. The only
 significant difference between it and the previous implementations of a
 linked list is its <literal>add()</literal> method. This method walks down the linked
@@ -28353,8 +28778,8 @@ new node, and <literal>next</literal> field for the new node is set to <literal>
 </listitem>
 </varlistentry>
 </variablelist>
-<formalpara xml:id="program:SortedLinkedList" xreflabel="SortedLinkedList">
-<title>A linked list class in which calling the <literal>add()</literal> method inserts each value in sorted order.</title>
+<formalpara xml:id="SortedLinkedListProgram">
+<title>Linked list class in which calling the <literal>add()</literal> method inserts each value in sorted order.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class SortedLinkedList {
     private static class Node {
@@ -28449,13 +28874,13 @@ interface that defines that ADT.</simpara>
 <section xml:id="_stacks">
 <title>Stacks</title>
 <simpara>We have already used stacks to solve problems in
-Chapter <xref linkend="chapter:Classes"/>. Recall that a stack data structure behaves
+<xref linkend="_classes"/>. Recall that a stack data structure behaves
 like a stack of books on your desk. When you place a book on the stack
 it covers the books that are already there. When you take a book off the
 stack, you remove the book most recently placed there, exposing the one
 beneath it.</simpara>
 <simpara>You can find a simple implementation of a stack in the solution to the
-infix conversion problem in Section <xref linkend="solution:Infix_conversion"/>, but
+infix conversion problem in <xref linkend="_solution_infix_conversion"/>, but
 we now examine the stack more deeply as an archetypal ADT. A stack&#8217;s
 restricted set of operations (pushing and popping) is adequate for many
 tasks and can be implemented in a number of different ways, some more
@@ -28491,8 +28916,8 @@ off.</simpara>
 concerned with <emphasis role="strong">how</emphasis> these operations are implemented, merely that they
 are. Thus, we can specify an interface called <literal>Stack</literal> that requires
 these four methods.</simpara>
-<formalpara xml:id="program:Stack" xreflabel="Stack">
-<title>An interface specifying the stack ADT.</title>
+<formalpara xml:id="StackProgram">
+<title>Interface specifying the stack ADT.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public interface Stack {
 	void push(String value);
@@ -28506,9 +28931,9 @@ these four methods.</simpara>
 <title>Linked list implementation</title>
 <simpara>All the operations defined by the stack ADT (and interface) are
 implemented as methods in the class <literal>LinkedListStack</literal>, shown in
-Program <xref linkend="program:LinkedListStack"/>.</simpara>
-<formalpara xml:id="program:LinkedListStack" xreflabel="LinkedListStack">
-<title>A class to implement a stack ADT using a linked list.</title>
+<xref linkend="LinkedListStackProgram"/>.</simpara>
+<formalpara xml:id="LinkedListStackProgram">
+<title>Class to implement a stack ADT using a linked list.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class LinkedListStack implements Stack {
 	private static class Node {
@@ -28562,7 +28987,7 @@ setting its <literal>value</literal> field to the incoming <literal>value</liter
 remove that node from the linked list. It does this by replacing the
 <literal>head</literal> node with the node pointed at by the <literal>next</literal> link in <literal>head</literal>. The
 <literal>pop()</literal> method from the simpler stack used in the solution to the nested
-expressions problem in Section <xref linkend="solution:Nested_expressions"/> merely
+expressions problem in <xref linkend="_solution_nested_expressions"/> merely
 removed the top and did not return the value. Most real-world stack
 implementations of <literal>pop()</literal> <emphasis role="strong">do</emphasis> return this value, giving programmers
 more flexibility.</simpara>
@@ -28572,11 +28997,11 @@ by throwing an exception.</simpara>
 </section>
 <section xml:id="_dynamic_array_implementation">
 <title>Dynamic array implementation</title>
-<simpara>Like the dynamic array example of Program <xref linkend="program:UseDynamicArray"/>,
-Program <xref linkend="program:DynamicArrayStack"/> implements a stack of <literal>String</literal>
+<simpara>Like the dynamic array example of <xref linkend="UseDynamicArrayProgram"/>,
+<xref linkend="DynamicArrayStackProgram"/> implements a stack of <literal>String</literal>
 values using a dynamic array data structure.</simpara>
-<formalpara xml:id="program:DynamicArrayStack" xreflabel="DynamicArrayStack">
-<title>Program illustrating a stack ADT partially implemented using a dynamic array.</title>
+<formalpara xml:id="DynamicArrayStackProgram">
+<title>Illustrates a stack ADT partially implemented using a dynamic array.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Arrays;
 
@@ -28607,14 +29032,16 @@ public class DynamicArrayStack implements Stack {
 </formalpara>
 <simpara>This stack implementation using a dynamic array omits the <literal>top()</literal> and
 <literal>isEmpty()</literal> methods (causing a compiler error in
-Program <xref linkend="program:DynamicArrayStack"/> until the <literal>Stack</literal> interface is
-properly implemented). Exercise <xref linkend="exercise:implementDASMethods"/> has you
-provide implementations of these methods.</simpara>
-<example>
+<xref linkend="DynamicArrayStackProgram"/> until the <literal>Stack</literal> interface is
+properly implemented).</simpara>
+<sidebar>
+<simpara><link linkend="exercise18.7">Exercise 18.7</link></simpara>
+</sidebar>
+<example xml:id="postfixComputationExample">
 <title>Postfix computation</title>
 <simpara>At the beginning of the chapter, we introduced the problem of converting
 an expression from infix to postfix notation. In
-Section <xref linkend="solution:Infix_conversion"/>, we give the solution to this
+<xref linkend="_solution_infix_conversion"/>, we give the solution to this
 problem, but without a program that can evaluate a postfix expression,
 the conversion tool is not very useful.</simpara>
 <simpara>Here we give a simple postfix evaluator. Recall the algorithm: Scan the
@@ -28636,7 +29063,7 @@ The first is <literal>Term</literal>.</simpara>
 simple, we update the definition of <literal>Term</literal> later in the solution to the
 infix to postfix conversion problem. By doing so, we can keep exactly
 the same definition for <literal>TermStack</literal> given next.</simpara>
-<formalpara xml:id="program:TermStack" xreflabel="TermStack">
+<formalpara xml:id="TermStackProgram">
 <title>Class to manage a stack of <literal>Term</literal> objects.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class TermStack {
@@ -28681,10 +29108,10 @@ the same definition for <literal>TermStack</literal> given next.</simpara>
 </para>
 </formalpara>
 <simpara>This class gives a linked list implementation of a stack. In fact, it is
-virtually identical to Program <xref linkend="program:LinkedListStack"/> with the
+virtually identical to <xref linkend="LinkedListStackProgram"/> with the
 substitution of <literal>Term</literal> for <literal>String</literal>.</simpara>
-<formalpara xml:id="program:PostfixCalculator" xreflabel="PostfixCalculator">
-<title>Program to evaluate a postfix expression.</title>
+<formalpara xml:id="PostfixCalculatorProgram">
+<title>Evaluates a postfix expression.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -28768,8 +29195,8 @@ queue.</simpara>
 </itemizedlist>
 <simpara>As with stacks, we can specify an interface called <literal>Queue</literal> that requires
 these four methods.</simpara>
-<formalpara xml:id="program:Queue" xreflabel="Queue">
-<title>An interface specifying the queue ADT.</title>
+<formalpara xml:id="QueueProgram">
+<title>Interface specifying the queue ADT.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public interface Queue {
 	void enqueue(String value);
@@ -28781,14 +29208,14 @@ these four methods.</simpara>
 </formalpara>
 <section xml:id="_linked_list_implementation_2">
 <title>Linked list implementation</title>
-<simpara>Program <xref linkend="program:LinkedListQueue"/> shows an implementation of the queue
+<simpara><xref linkend="LinkedListQueueProgram"/> shows an implementation of the queue
 ADT operations using a linked list. Because we need to keep track of
 nodes at both ends of the linked list, we maintain <literal>head</literal> and <literal>tail</literal>
 variables to reference these nodes. The <literal>enqueue()</literal> and <literal>dequeue()</literal>
 methods manipulate these variables to manage the queue as values are put
 onto it and removed from it.</simpara>
-<formalpara xml:id="program:LinkedListQueue" xreflabel="LinkedListQueue">
-<title>Program illustrating a queue ADT implemented using a linked list.</title>
+<formalpara xml:id="LinkedListQueueProgram">
+<title>Illustrates a queue ADT implemented using a linked list.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class LinkedListQueue implements Queue {
 	private static class Node {
@@ -28799,13 +29226,13 @@ onto it and removed from it.</simpara>
     private Node head = null;
     private Node tail = null;
 
-	public void enqueue(String value) {/*@\label{linePutQueue}@*/
+	public void enqueue(String value) {
 		Node temp = new Node();
 		temp.value = value;
 		temp.next = null;
 
 		if( isEmpty() )
-			head = tail = temp; /*@\label{lineNewLLN}@*/
+			head = tail = temp;
 		else {
 			tail.next = temp;
 			tail = temp;
@@ -28852,7 +29279,7 @@ method in the latter.</simpara>
 <simpara>Most of the dynamic data structures we have seen in this chapter store
 values of type <literal>String</literal>. We explore dynamic arrays of <literal>String</literal> values,
 linked lists of <literal>String</literal> objects, queues of <literal>String</literal> objects, and stacks
-of <literal>String</literal> objects. In Example <xref linkend="example:Postfix_computation"/>, we
+of <literal>String</literal> objects. In <xref linkend="postfixComputationExample"/>, we
 create the stack class <literal>TermStack</literal> to hold <literal>Term</literal> objects, but
 <literal>TermStack</literal> is identical to the existing <literal>LinkedListStack</literal> class with
 the substitution of <literal>Term</literal> for <literal>String</literal>.</simpara>
@@ -28860,16 +29287,16 @@ the substitution of <literal>Term</literal> for <literal>String</literal>.</simp
 structures? What if you wanted a stack of <literal>int</literal> values or a queue of
 <literal>Thread</literal> objects? You might think that you need to create a distinct but
 similar implementation of each ADT for each type, as we do in
-Example <xref linkend="example:Postfix_computation"/>.</simpara>
+<xref linkend="postfixComputationExample"/>.</simpara>
 <simpara>One possible solution is to take advantage of the fact that a variable
 of type <literal>Object</literal> can hold a reference to a value of any reference type
 (since all classes are subtypes of <literal>Object</literal>). If we create data
 structures using <literal>Object</literal> as the underlying type, we can store values of
 any type in the data structure. For example,
-Program <xref linkend="program:ObjectStack"/> is an implementation of a stack ADT with
+<xref linkend="ObjectStackProgram"/> is an implementation of a stack ADT with
 an underlying data type of <literal>Object</literal>.</simpara>
-<formalpara xml:id="program:ObjectStack" xreflabel="ObjectStack">
-<title>A class that implements a stack of <literal>Object</literal> references.</title>
+<formalpara xml:id="ObjectStackProgram">
+<title>Class that implements a stack of <literal>Object</literal> references.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class ObjectStack {
 	private static class Node {
@@ -28939,7 +29366,7 @@ preserves the advantages of compile-time type checking and eliminates
 the need for run-time casting. A <emphasis>generic class</emphasis> is a class that gives a
 template for creating classes in which a placeholder for the underlying
 data type can be filled in when a specific instance of that class is
-created. In the case of Example <xref linkend="example:Postfix_computation"/>, we need
+created. In the case of <xref linkend="postfixComputationExample"/>, we need
 a stack that can hold <literal>Term</literal> objects instead of <literal>String</literal> objects, and a
 generic class allows us to create a stack of any reference type.</simpara>
 <simpara>The generics facility in Java only supports underlying data types that
@@ -28992,12 +29419,12 @@ int i = (Integer) genericRaw.transform(27); // cast needed</programlisting>
 <simpara>The next two examples illustrate defining generic classes in Java.</simpara>
 <example>
 <title>Defining a generic linked list</title>
-<simpara>Program <xref linkend="program:GenericLinkedList"/> defines a generic version of the
+<simpara><xref linkend="GenericLinkedListProgram"/> defines a generic version of the
 <literal>LinkedList</literal> class shown earlier. Note that it is necessary to include
 the type parameter <literal>T</literal> on the outer class as well as the nested class
 <literal>Node</literal>.</simpara>
-<formalpara xml:id="program:GenericLinkedList" xreflabel="GenericLinkedList">
-<title>A class that implements a generic linked list.</title>
+<formalpara xml:id="GenericLinkedListProgram">
+<title>Class that implements a generic linked list.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class GenericLinkedList&lt;T&gt; {
     private static class Node&lt;T&gt; {
@@ -29045,11 +29472,11 @@ specify the missing type (or types) used to parameterize the generic
 class. For example, if you want to create an instance of the
 <literal>GenericClass&lt;T&gt;</literal> class, you must specify the type <literal>T</literal>, for example
 <literal>new GenericClass&lt;String&gt;()</literal>.</simpara>
-<simpara>Program <xref linkend="program:UseGenericLinkedList"/> uses the generic class
+<simpara><xref linkend="UseGenericLinkedListProgram"/> uses the generic class
 <literal>GenericLinkedList</literal> parameterized by <literal>String</literal> to re-implement
-Program <xref linkend="program:UseLinkedList"/>.</simpara>
-<formalpara xml:id="program:UseGenericLinkedList" xreflabel="UseGenericLinkedList">
-<title>Program that uses the generic class <literal>GenericLinkedList</literal> to create and use a linked list of Strings.</title>
+<xref linkend="UseLinkedListProgram"/>.</simpara>
+<formalpara xml:id="UseGenericLinkedListProgram">
+<title>Uses the generic class <literal>GenericLinkedList</literal> to create and use a linked list of Strings.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Arrays;
 import java.util.Scanner;
@@ -29086,7 +29513,7 @@ different underlying types. We illustrate three examples here: <literal>Vector</
 class, which is a great deal more powerful than the <literal>LinkedList</literal> class
 defined in this chapter. Any class that implements the <literal>Iterable</literal>
 interface can be used in the for-each loops described in
-Section <xref linkend="subsection:The_for-each_loop"/>. The <literal>ArrayDeque</literal>, <literal>ArrayList</literal>,
+<xref linkend="_the_for_each_loop"/>. The <literal>ArrayDeque</literal>, <literal>ArrayList</literal>,
 <literal>HashSet</literal>, <literal>TreeSet</literal>, and <literal>Vector</literal>, classes all implement <literal>Iterable</literal>. In
 our examples, a <literal>Vector</literal> object and a <literal>Set</literal> (returned by the
 <literal>entrySet()</literal> method of a <literal>HashMap</literal>) are used as targest of for-each
@@ -29102,13 +29529,13 @@ array). Elements can be inserted into the middle of the <literal>Vector</literal
 causing following elements to be pushed back to later indexes. Arbitrary
 elements can also be deleted from the <literal>Vector</literal> using the <literal>remove()</literal>
 method.</simpara>
-<simpara>Program <xref linkend="program:VectorExample"/> illustrates a use of the <literal>Vector</literal>
+<simpara><xref linkend="VectorExampleProgram"/> illustrates a use of the <literal>Vector</literal>
 class. The program creates an empty <literal>Vector</literal> and generates random
 integers between 1 and 10, appending them to the end of the vector,
 until their sum is at least 100. Then, it prints the integers and their
 sum (including how many were generated).</simpara>
-<formalpara xml:id="program:VectorExample" xreflabel="VectorExample">
-<title>A simple program to illustrate the use of the Vector class.</title>
+<formalpara xml:id="VectorExampleProgram">
+<title>Illustrates the use of the Vector class.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Random;
 import java.util.Vector;
@@ -29134,9 +29561,9 @@ public class VectorExample {
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Output from a typical run of Program <xref linkend="program:VectorExample"/> is shown
+<simpara>Output from a typical run of <xref linkend="VectorExampleProgram"/> is shown
 below:</simpara>
-<programlisting language="java" linenumbering="unnumbered">  9
+<literallayout class="monospaced">  9
   9
   8
   7
@@ -29151,24 +29578,24 @@ below:</simpara>
   9
  10
 ---
-104 (14 values)</programlisting>
+104 (14 values)</literallayout>
 </example>
-<example>
+<example xml:id="mapsExample">
 <title>Maps</title>
 <simpara>The <literal>HashMap</literal>(<literal>java.util.HashMap</literal>) is a very useful, general-purpose
 data structure that maintains a dictionary of entries. A dictionary
 associates unique keys with values. You can think of it as <emphasis>mapping</emphasis> a
 <emphasis>key</emphasis> to a <emphasis>value</emphasis>. In the Java <literal>HashMap</literal> class, keys and values can be
 arbitrary Java classes.</simpara>
-<simpara>Program <xref linkend="program:HashMapExample"/> reads a sequence of lines containing
+<simpara><xref linkend="HashMapExampleProgram"/> reads a sequence of lines containing
 names and ages (for simplicity, the name is one word and the age is a
 simple integer). It stores these (name, age) pairs in a
 <literal>HashMap&lt;String,Integer&gt;</literal> data structure. Once all the input is read
 (<literal>in.hasNext()</literal> returns <literal>false</literal>), the program prints all the keys
 (names), then all the values (ages), and finally it prints the names and
 ages of each person in the input file.</simpara>
-<formalpara xml:id="program:HashMapExample" xreflabel="HashMapExample">
-<title>A program that illustrates using a <literal>HashMap</literal> dictionary to store a set of names and ages.</title>
+<formalpara xml:id="HashMapExampleProgram">
+<title>Illustrates using a <literal>HashMap</literal> dictionary to store a set of names and ages.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.HashMap;
 import java.util.Map;
@@ -29203,7 +29630,7 @@ public class HashMapExample {
 </para>
 </formalpara>
 <simpara>Shown below is the output for a simple input file.</simpara>
-<programlisting language="java" linenumbering="unnumbered">Keys
+<literallayout class="monospaced">Keys
     kathy
     martha
     fred
@@ -29237,14 +29664,14 @@ john -&gt; 23
 margarette -&gt; 57
 edward -&gt; 12
 tim -&gt; 57
-hamcost -&gt; 2</programlisting>
+hamcost -&gt; 2</literallayout>
 </example>
 </section>
 </section>
 <section xml:id="_solution_infix_conversion">
 <title>Solution: Infix conversion</title>
 <simpara>Here we give our solution to the infix conversion problem from the
-beginning of the chapter. As in Example <xref linkend="example:Postfix_computation"/>,
+beginning of the chapter. As in <xref linkend="postfixComputationExample"/>,
 we use a stack of <literal>Term</literal> objects to solve the problem. However, we
 expand the <literal>Term</literal> class to hold both operands and operators. We only add
 methods and fields to the earlier definition, taking nothing away. In
@@ -29313,7 +29740,7 @@ parenthesis <literal>(</literal>.</simpara>
 <simpara>With this updated <literal>Term</literal> class, we can create <literal>Term</literal> objects that hold
 either an operator or an operand and allow the precedence of operators
 to be compared. We use exactly the same <literal>TermStack</literal> class from
-Example <xref linkend="example:Postfix_computation"/> for our stack. All that remains
+<xref linkend="postfixComputationExample"/> for our stack. All that remains
 is the client code that parses the input.</simpara>
 <programlisting language="java" linenumbering="numbered">import java.util.*;
 
@@ -29372,7 +29799,7 @@ tucked away inside of the <literal>Term</literal> class.</simpara>
 <simpara>After the input has all been consumed, we pop all the elements off the
 stack and add them to the output. Finally, we print the output. The
 output to this program could be used as the input to the postfix
-evaluator program from Example <xref linkend="example:Postfix_computation"/>. A more
+evaluator program from <xref linkend="postfixComputationExample"/>. A more
 complex program that did both the conversion and the calculation might
 want to store everything in <literal>Term</literal> objects instead of outputting a
 <literal>String</literal> and then recreating <literal>Term</literal> objects.</simpara>
@@ -29385,10 +29812,9 @@ simultaneously, the <literal>head</literal> or <literal>tail</literal> pointers 
 be updated incorrectly, potentially causing the stack or queue to lose
 elements. As you have seen, multiple threads operating on the same data
 can produce unexpected results.</simpara>
-<simpara>Program <xref linkend="program:UseLinkedListQueue"/> is a simple multi-threaded
+<simpara><xref linkend="UseLinkedListQueueProgram"/> is a simple multi-threaded
 program to test (and break!) the thread safety of the queue
-implementation in Program <xref linkend="program:LinkedListQueue"/>. This program
-(<xref linkend="program:UseLinkedListQueue"/>) creates a queue and stores a reference
+implementation in <xref linkend="LinkedListQueueProgram"/>. <xref linkend="UseLinkedListQueueProgram"/>)creates a queue and stores a reference
 to it in a static (class) variable <literal>queue</literal>. It then creates and starts
 10 threads. During the adding phase (indicated by <literal>adding</literal> being
 <literal>true</literal>), each thread adds its thread ID number to the queue and prints
@@ -29397,8 +29823,8 @@ has finished. The program then ends the adding phase (by setting the
 boolean variable <literal>adding</literal> to <literal>false</literal>) and starts 10 more threads. These
 threads each read one value from the queue and print it to standard
 output.</simpara>
-<formalpara xml:id="program:UseLinkedListQueue" xreflabel="UseLinkedListQueue">
-<title>Program to test the queue implementation, including its thread safety.</title>
+<formalpara xml:id="UseLinkedListQueueProgram">
+<title>Tests the queue implementation, including its thread safety.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class UseLinkedListQueue extends Thread {
 	private static final int THREADS = 10;
@@ -29451,7 +29877,7 @@ output.</simpara>
 <simpara>Without appropriate synchronization, the program may not correctly link
 all values into the queue nor remove them at the end. A typical
 error-prone output run is shown here:</simpara>
-<programlisting language="java" linenumbering="unnumbered">Thread ID added to queue: 9
+<literallayout class="monospaced">Thread ID added to queue: 9
 Thread ID added to queue: 14
 Thread ID added to queue: 13
 Thread ID added to queue: 12
@@ -29472,14 +29898,13 @@ Can't dequeue an empty queue!
 Can't dequeue an empty queue!
 Thread ID removed from queue: 15
 Thread ID removed from queue: null
-Thread ID removed from queue: null</programlisting>
+Thread ID removed from queue: null</literallayout>
 <simpara>How does this implementation fail? Consider the situation in which two
-threads are attempting to put a value in the queue simultaneously (see
-line <xref linkend="linePutQueue"/> in Program <xref linkend="program:LinkedListQueue"/>). Suppose
+threads are attempting to put a value in the queue simultaneously by calling the <literal>enqueue()</literal> methode in <xref linkend="LinkedListQueueProgram"/>. Suppose
 the first thread tests the queue and finds it empty (<literal>isEmpty()</literal> returns
 <literal>true</literal>) but is then interrupted. If a second thread gets control it will
 also see that the queue is empty then sets the <literal>head</literal> and <literal>tail</literal>
-variables to the new <literal>Node</literal> object <literal>temp</literal> at line <xref linkend="lineNewLLN"/> and
+variables to the new <literal>Node</literal> object <literal>temp</literal> and
 return. The first thread will eventually wake up, still thinking that
 the queue is empty, and also set the <literal>head</literal> and <literal>tail</literal> variables to its
 own new <literal>Node</literal> <literal>temp</literal>. But these assignments overwrite the assignments
@@ -29488,7 +29913,7 @@ is now lost.</simpara>
 <simpara>This problem can be fixed by ensuring that once one thread starts
 examining and modifying queue variables, no other thread can access the
 same variables until the first one is finished. As shown in
-Chapter <xref linkend="chapter:Synchronization"/>, this mutual exclusion can be
+<xref linkend="_synchronization"/>, this mutual exclusion can be
 achieved by using the <literal>synchronized</literal> keyword on methods that need to
 have exclusive access to object variables. In this queue implementation,
 we need to synchronize access by threads that are using either the
@@ -29502,8 +29927,8 @@ do any harm are already synchronized. Outside code that calls
 contents of the queue, but there is no guarantee that other threads will
 not modify the state of the queue at any point after the <literal>isEmpty()</literal>
 method is called anyway.</simpara>
-<formalpara xml:id="program:LinkedListQueueTS" xreflabel="LinkedListQueueTS">
-<title>A synchronized version of the queue class that allows thread-safe use.</title>
+<formalpara xml:id="LinkedListQueueTSProgram">
+<title>Synchronized version of the queue class that allows thread-safe use.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class LinkedListQueueTS implements Queue {
 	private static class Node {
@@ -29556,9 +29981,9 @@ method is called anyway.</simpara>
 </para>
 </formalpara>
 <simpara>With both <literal>enqueue()</literal> and <literal>dequeue()</literal> methods synchronized as in
-Program <xref linkend="program:LinkedListQueueTS"/>, a typical output generated by the
+<xref linkend="LinkedListQueueTSProgram"/>, a typical output generated by the
 program is shown below.</simpara>
-<programlisting language="java" linenumbering="unnumbered">Thread ID added to queue: 9
+<literallayout class="monospaced">Thread ID added to queue: 9
 Thread ID added to queue: 14
 Thread ID added to queue: 12
 Thread ID added to queue: 13
@@ -29577,11 +30002,11 @@ Thread ID removed from queue: 16
 Thread ID removed from queue: 14
 Thread ID removed from queue: 12
 Thread ID removed from queue: 10
-Thread ID removed from queue: 11</programlisting>
+Thread ID removed from queue: 11</literallayout>
 </section>
 <section xml:id="_concurrency_thread_safe_libraries">
 <title>Concurrency: Thread-safe libraries</title>
-<simpara>As we mentioned in Section <xref linkend="concurrency:Objects"/>, some libraries are
+<simpara>As we mentioned in <xref linkend="_concurrency_objects"/>, some libraries are
 thread-safe and some are not. The Java Collections Framework (JCF) is a
 very useful library, but it is also a library that requires thread
 safety to be at the forefront of your mind.</simpara>
@@ -29591,8 +30016,8 @@ implement, has subinterfaces <literal>Set</literal>, <literal>List</literal>, an
 basic operations in Java that are needed to implement a set, list, or
 queue of items. The <literal>Map</literal> interface gives the basic operations for a
 dictionary, a collection of key-value pairs, one implementation of which
-is the <literal>HashMap</literal> from Example <xref linkend="example:Maps"/>.</simpara>
-<simpara>As we mentioned in Chapter <xref linkend="chapter:Interfaces"/>, an interface cannot
+is the <literal>HashMap</literal> from <xref linkend="mapsExample"/>.</simpara>
+<simpara>As we mentioned in <xref linkend="_interfaces"/>, an interface cannot
 mark a method with the <literal>synchronized</literal> keyword. Consequently, the JCF can
 make no guarantee about the thread safety of a container based on which
 interface it implements. The programmer must read the documentation
@@ -29605,16 +30030,9 @@ but lacks synchronization. That is, if two threads attempt to insert or
 remove an element from the same <literal>ArrayList</literal> at the same time, the
 <literal>ArrayList</literal> internal state may become corrupt or the results may be
 incorrect.</simpara>
-<simpara>Program <xref linkend="program:ArrayListExample"/> is an example of synchronizing
-updates to the <literal>ArrayList</literal> class with multiple threads. The program
-creates an <literal>ArrayList</literal> and places a reference to it in the static class
-variable <literal>list</literal>. It then creates and starts two threads. Each thread
-repeats a loop 10 times, appending a <literal>String</literal> to the <literal>ArrayList</literal> on each
-iteration. To increase the likelihood of concurrent update attempts, the
-thread sleeps for a millisecond on each iteration. To prevent concurrent
-updates from actually happening, each thread synchronizes on the common
-(shared) class variable <literal>list</literal> at line <xref linkend="aleSync"/>.</simpara>
-<formalpara xml:id="program:ArrayListExample" xreflabel="ArrayListExample">
+<simpara><xref linkend="ArrayListExampleProgram"/> is an example of synchronizing
+updates to the <literal>ArrayList</literal> class with multiple threads.</simpara>
+<formalpara xml:id="ArrayListExampleProgram">
 <title>Example of thread-safe use of an <literal>ArrayList</literal>.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.ArrayList;
@@ -29623,11 +30041,10 @@ public class ArrayListExample extends Thread {
 	private static ArrayList&lt;String&gt; list;
 
 	public static void main(String[] args) {
-		Thread t1 = new ArrayListExample();
+		list = new ArrayList&lt;String&gt;(); <co xml:id="CO26-1"/>
+
+		Thread t1 = new ArrayListExample(); <co xml:id="CO26-2"/>
 		Thread t2 = new ArrayListExample();
-
-		list = new ArrayList&lt;String&gt;();
-
 		t1.start();
 		t2.start();
 
@@ -29640,9 +30057,9 @@ public class ArrayListExample extends Thread {
 			System.out.println(s);
 	}
 
-	public void run() {
+	public void run() { <co xml:id="CO26-3"/>
 		for (int i = 0; i &lt; 10; i++) {
-			synchronized (list) {/*@\label{aleSync}@*/
+			synchronized (list) { <co xml:id="CO26-4"/>
 				list.add(this.getName() + ": " + i);
 			}
 			try { Thread.sleep(1);	}
@@ -29654,10 +30071,24 @@ public class ArrayListExample extends Thread {
 }</programlisting>
 </para>
 </formalpara>
+<calloutlist>
+<callout arearefs="CO26-1">
+<para>The program creates an <literal>ArrayList</literal> and places a reference to it in the static class variable <literal>list</literal>.</para>
+</callout>
+<callout arearefs="CO26-2">
+<para>It then creates and starts two threads.</para>
+</callout>
+<callout arearefs="CO26-3">
+<para>Each thread repeats a loop 10 times, appending a <literal>String</literal> to the <literal>ArrayList</literal> on each iteration. To increase the likelihood of concurrent update attempts, the thread sleeps for a millisecond on each iteration.</para>
+</callout>
+<callout arearefs="CO26-4">
+<para>To prevent concurrent updates from actually happening, each thread synchronizes on the shared class variable <literal>list</literal>.</para>
+</callout>
+</calloutlist>
 <simpara><emphasis role="strong">Without</emphasis> the <literal>synchronized</literal> keyword, a typical run, shown below,
 includes a <literal>null</literal> reference in the output, indicating that the internal
 <literal>ArrayList</literal> data structure was not updated correctly.</simpara>
-<programlisting language="java" linenumbering="unnumbered">Thread-1: 0
+<literallayout class="monospaced">Thread-1: 0
 Thread-0: 0
 Thread-1: 1
 Thread-0: 1
@@ -29676,11 +30107,11 @@ Thread-0: 7
 Thread-1: 8
 Thread-0: 8
 Thread-0: 9
-Thread-1: 9</programlisting>
+Thread-1: 9</literallayout>
 <simpara><emphasis role="strong">With</emphasis> the <literal>synchronized</literal> keyword, each run includes exactly the same
 number of entries from each thread, although the threads do not always
 alternate in strict lock-step.</simpara>
-<programlisting language="java" linenumbering="unnumbered">Thread-0: 0
+<literallayout class="monospaced">Thread-0: 0
 Thread-1: 0
 Thread-0: 1
 Thread-1: 1
@@ -29699,38 +30130,39 @@ Thread-0: 7
 Thread-1: 8
 Thread-0: 8
 Thread-1: 9
-Thread-0: 9</programlisting>
+Thread-0: 9</literallayout>
 </example>
 </section>
-<section xml:id="_exercises_17">
+<section xml:id="_exercises_18">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>Explain the difference between static data structures and dynamic
+<simpara><anchor xml:id="exercise18.1" xreflabel="[exercise18.1]"/> Explain the difference between static data structures and dynamic
 data structures.</simpara>
 </listitem>
 <listitem>
-<simpara>In which situations is it better to use a dynamic array? In which
+<simpara><anchor xml:id="exercise18.2" xreflabel="[exercise18.2]"/> In which situations is it better to use a dynamic array? In which
 situations is it better to use a linked list? Explain why in each case.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:exceptionGeneratedExercise"/> On which line in
-Program <xref linkend="program:ReadIntoFixedArray"/> is an exception generated?</simpara>
+<simpara><anchor xml:id="exercise18.3" xreflabel="[exercise18.3]"/> On which line in
+<xref linkend="ReadIntoFixedArrayProgram"/> is an exception generated?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:postIncrementExercise"/> In
-Program <xref linkend="program:ReadAndGrowArray"/>, is it possible to post-increment
+<simpara><anchor xml:id="exercise18.4" xreflabel="[exercise18.4]"/> In
+<xref linkend="ReadAndGrowArrayProgram"/>, is it possible to post-increment
 <literal>n</literal> inside the <literal>try</literal> clause rather than at the bottom of the <literal>while</literal>
 loop?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:proveThreeQuartersFull"/> Explain why the <literal>names</literal> array in
-Program <xref linkend="program:UseDynamicArray"/> is, on average, only three-quarters
+<simpara><anchor xml:id="exercise18.5" xreflabel="[exercise18.5]"/> Explain why the <literal>names</literal> array in
+<xref linkend="UseDynamicArrayProgram"/> is, on average, only three-quarters
 full.</simpara>
 </listitem>
 <listitem>
-<simpara>Based on the stack implementation in
-Program <xref linkend="program:LinkedListStack"/>, draw a picture of the linked list
+<simpara><anchor xml:id="exercise18.6" xreflabel="[exercise18.6]"/> Based on the stack implementation in
+<xref linkend="LinkedListStackProgram"/>, draw a picture of the linked list
 structure after each of the following statements.</simpara>
 <programlisting language="java" linenumbering="unnumbered">    LinkedListStack stack = new LinkedListStack();
     stack.push("hello");
@@ -29742,13 +30174,13 @@ structure after each of the following statements.</simpara>
     stack.push("world");</programlisting>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:implementDASMethods"/> Implement the methods <literal>top()</literal> and
+<simpara><anchor xml:id="exercise18.7" xreflabel="[exercise18.7]"/> Implement the methods <literal>top()</literal> and
 <literal>isEmpty()</literal> for the dynamic array implementation of the stack in
-Program <xref linkend="program:DynamicArrayStack"/>.</simpara>
+<xref linkend="DynamicArrayStackProgram"/>.</simpara>
 </listitem>
 <listitem>
-<simpara>Based on queue implementation in
-Program <xref linkend="program:LinkedListQueue"/>, draw a picture of the linked list
+<simpara><anchor xml:id="exercise18.8" xreflabel="[exercise18.8]"/> Based on queue implementation in
+<xref linkend="LinkedListQueueProgram"/>, draw a picture of the linked list
 structure after each of the following statements.</simpara>
 <programlisting language="java" linenumbering="unnumbered">    LinkedListStack queue = new LinkedListStack();
     stack.enqueue("hello");
@@ -29761,14 +30193,14 @@ structure after each of the following statements.</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:Shrink_dynamic_array"/> Implement a version of
+<simpara><anchor xml:id="exercise18.9" xreflabel="[exercise18.9]"/> Implement a version of
 <literal>DynamicArray</literal> that shrinks the size of its internal storage array to
 half its size when only one quarter of its capacity is being used. This
 design can save significant amounts of space if a large number of items
 are added to the dynamic array at once and then removed.</simpara>
 </listitem>
 <listitem>
-<simpara>Consider Program <xref linkend="program:LinkedListWithTail"/> which defines the
+<simpara><anchor xml:id="exercise18.10" xreflabel="[exercise18.10]"/> Consider <xref linkend="LinkedListWithTailProgram"/> which defines the
 <literal>LinkedListWithTail</literal> class for storing a linked list of <literal>String</literal> values.
 Add a <literal>public reverse()</literal> method to the class which reverses the order of
 the nodes in the linked list. The key idea is make a new linked list
@@ -29779,15 +30211,14 @@ nothing left in the original list. Be sure to reset the <literal>head</literal> 
 <literal>tail</literal> references correctly after the reversal.</simpara>
 </listitem>
 <listitem>
-<simpara>In Section <xref linkend="subsection:Linked_lists"/>, we use two kinds of linked
+<simpara><anchor xml:id="exercise18.11" xreflabel="[exercise18.11]"/> In <xref linkend="_linked_lists"/>, we use two kinds of linked
 lists to store data, but copy all of that data back into an array before
 sorting it. We use third linked list class (<literal>SortedLinkedList</literal>) to
 insert data and maintain a sorted order. However, it is possible to add
 data in non-sorted order to a linked list and then sort it afterwards.
 Add a <literal>sort()</literal> method to the <literal>LinkedListWithTail</literal> class that performs a
 bubble sort on the nodes inside.</simpara>
-<simpara>The algorithm for a bubble sort is described in Section <xref linkend="problem:Sort
-it out"/>. The idea is to make repeated passes through a list, swapping
+<simpara>The algorithm for a bubble sort is described in <xref linkend="_problem_sort_it_out"/>. The idea is to make repeated passes through a list, swapping
 two adjacent items if they are out of order. You keep making passes over
 the list until no adjacent items are out of order. For a this <literal>sort()</literal>
 method, you will need to use the <literal>compareTo()</literal> method to compare the
@@ -29795,13 +30226,12 @@ method, you will need to use the <literal>compareTo()</literal> method to compar
 have special cases that update the <literal>head</literal> and <literal>tail</literal> pointers if those
 nodes are swapped with other nodes. Note that bubble sort is not the
 fastest way to sort a linked list. We introduce a faster approach in
-Chapter <xref linkend="chapter:Recursion"/>.</simpara>
+<xref linkend="_recursion"/>.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:dynamicArrayTestExercise"/> Create JUnit test cases to
+<simpara><anchor xml:id="exercise18.12" xreflabel="[exercise18.12]"/> Create JUnit test cases to
 verify that the <literal>synchronized</literal> keywords are needed on the <literal>set()</literal> and
-<literal>sort()</literal> methods of the <literal>DynamicArray</literal> example
-(Program <xref linkend="program:DynamicArray"/>). To test the <literal>set()</literal> method, you can
+<literal>sort()</literal> methods of the <literal>DynamicArray</literal> example from <xref linkend="DynamicArrayProgram"/>. To test the <literal>set()</literal> method, you can
 create one thread that repeatedly sets, gets, and tests a changing value
 at a fixed location (e.g., 0) and another thread that continuously
 appends to the array (causing it to grow by copy and replace, thus
@@ -29812,7 +30242,7 @@ sorted after the threads have exited. For both tests, you may need to
 repeat the operations a number of times to trigger the race condition.</simpara>
 </listitem>
 <listitem>
-<simpara>To make an infix calculator that can handle floating point values or
+<simpara><anchor xml:id="exercise18.13" xreflabel="[exercise18.13]"/> To make an infix calculator that can handle floating point values or
 even just integers with more than one digit, you need to make a pass
 over the input, parsing the sequence of characters into terms. When an
 expression is in infix notation, the order of terms is an operand
@@ -29823,18 +30253,18 @@ you continue to look for an operand. Whenever you are expecting an
 operator, you might get a right parenthesis, but, after that
 parenthesis, you continue to look for an operator.</simpara>
 <simpara>Using this first pass over input to separate terms as well as the
-<literal>parseDouble()</literal> method from Example <xref linkend="example:Parsing_a_number"/> to
+<literal>parseDouble()</literal> method from <xref linkend="parsingANumberExample"/> to
 compute the equivalent <literal>double</literal> values of operands, rewrite the solution
-from Section <xref linkend="solution:Infix_conversion"/> to convert your terms into
+from <xref linkend="_solution_infix_conversion"/> to convert your terms into
 postfix ordering and then calculate the answer.</simpara>
 </listitem>
 <listitem>
-<simpara>Re-implement the solution to the infix conversion problem given in
-Section <xref linkend="solution:Infix_conversion"/> so that it uses <literal>GenericStack</literal>
+<simpara><anchor xml:id="exercise18.14" xreflabel="[exercise18.14]"/> Re-implement the solution to the infix conversion problem given in
+<xref linkend="_solution_infix_conversion"/> so that it uses <literal>GenericStack</literal>
 with a type parameter of <literal>Term</literal> instead of <literal>TermStack</literal>.</simpara>
 </listitem>
 <listitem>
-<simpara>Interfaces can also be generic. Consider the following generic
+<simpara><anchor xml:id="exercise18.15" xreflabel="[exercise18.15]"/> Interfaces can also be generic. Consider the following generic
 version of <literal>Queue</literal>.</simpara>
 <programlisting language="java" linenumbering="unnumbered">public interface Queue&lt;T&gt; {
     void enqueue(T value);
@@ -29848,7 +30278,7 @@ version of <literal>Queue</literal>.</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Recursion">
+<chapter xml:id="_recursion">
 <title>Recursion</title>
 <blockquote>
 <attribution>
@@ -29858,7 +30288,7 @@ Anonymous
 </blockquote>
 <section xml:id="_problem_maze_of_doom">
 <title>Problem: Maze of doom</title>
-<simpara>The evil mastermind from Chapter <xref linkend="chapter:Concurrent_Programming"/> has
+<simpara>The evil mastermind from <xref linkend="_concurrent_programming"/> has
 returned with a new attempt at world domination. Since he now knows that
 you can use concurrency to crack his security code, this time he has
 hidden his deadly virus in a secret location protected by a complex maze
@@ -29909,7 +30339,7 @@ be useful? Since recursion sounds circular, how can it be applied to
 problem solving in Java? How does the computer keep track of these
 self-references? The following subsections address precisely these
 questions.</simpara>
-<section xml:id="subsection:What_is_recursion">
+<section xml:id="_what_is_recursion">
 <title>What is recursion?</title>
 <simpara>In the context of computer science and mathematics, recursion means
 describing some repetitive process in terms of itself. Many complex
@@ -29950,7 +30380,7 @@ or smaller values. In English, it is equally correct to say that you are
 now a year younger than you&#8217;ll be next year. Unfortunately, the age that
 you&#8217;ll be next year is not any closer to a base case, making that
 recursion useless.</simpara>
-<figure>
+<figure xml:id="recursiveTreeFigure">
 <title>Recursive refinement generating a tree-like image.</title>
 <mediaobject>
 <imageobject>
@@ -29966,7 +30396,7 @@ a trunk of a tree is similar to the branching of its limbs, which is
 similar to the branching of its branches, which in turn is similar to
 the branching of its twigs. In fact, we borrow the idea of the branching
 of a tree to define a recursive data structure in
-Section <xref linkend="syntax:Recursive_data_structures"/>. Figure <xref linkend="recursiveTrees"/>
+<xref linkend="_syntax_recursive_data_structures"/>. <xref linkend="recursiveTreeFigure"/>
 starts with a simple Y-shaped branching. By successively replacing the
 branches with the previous shape, a tree is generated recursively.
 <emphasis>Fractals</emphasis> are images generated by similar recursive techniques.
@@ -29985,7 +30415,7 @@ defined in relation to the same function with a smaller input (such as
 <inlineequation><alt><![CDATA[f(n - 1)]]></alt><mathphrase><![CDATA[f(n - 1)]]></mathphrase></inlineequation>). Sequences (such as <inlineequation><alt><![CDATA[s_n]]></alt><mathphrase><![CDATA[s_n]]></mathphrase></inlineequation>) are
 usually defined in relation to earlier elements in the sequence (such as
 <inlineequation><alt><![CDATA[s_{n - 1}]]></alt><mathphrase><![CDATA[s_{n - 1}]]></mathphrase></inlineequation>).</simpara>
-<example>
+<example xml:id="multiplicationDefinedRecursivelyExample">
 <title>Multiplication defined recursively</title>
 <simpara>Even very common functions can be defined recursively. Consider the
 multiplication <inlineequation><alt><![CDATA[x \times y]]></alt><mathphrase><![CDATA[x \times y]]></mathphrase></inlineequation>. This multiplication means
@@ -30007,14 +30437,17 @@ need to have such a definition. Yet mathematicians often use multiple
 equivalent definitions to prove results. Furthermore, this elementary
 definition provides intuition for creating more complex definitions.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise19.1">Exercise 19.1</link></simpara>
+</sidebar>
 <example>
 <title>Factorial defined recursively</title>
 <simpara>Another mathematical function with a natural recursive definition is the
 factorial function, often written <inlineequation><alt><![CDATA[n!]]></alt><mathphrase><![CDATA[n!]]></mathphrase></inlineequation>. The factorial
 function is used heavily in probability and counting. The value of
 <inlineequation><alt><![CDATA[n! = n
-\cdot(n - 1)\cdot(n - 2) \ldots 3\cdot \cdot 2 \cdot 1]]></alt><mathphrase><![CDATA[n! = n
-\cdot(n - 1)\cdot(n - 2) \ldots 3\cdot \cdot 2 \cdot 1]]></mathphrase></inlineequation>. Mathematicians
+\cdot(n - 1)\cdot(n - 2) \ldots 3 \cdot 2 \cdot 1]]></alt><mathphrase><![CDATA[n! = n
+\cdot(n - 1)\cdot(n - 2) \ldots 3 \cdot 2 \cdot 1]]></mathphrase></inlineequation>. Mathematicians
 like recursive definitions because they are able to describe functions
 and sequences precisely without using ellipses (<inlineequation><alt><![CDATA[\ldots]]></alt><mathphrase><![CDATA[\ldots]]></mathphrase></inlineequation>).</simpara>
 <simpara><inlineequation><alt><![CDATA[n! =
@@ -30129,8 +30562,7 @@ languages are designed to work better with a given approach.</simpara>
 <simpara>Many programmers who are new to recursion feel uncomfortable about the
 syntax. How can a method call itself? What does that even mean?</simpara>
 <simpara>Recursion in Java is grounded in the idea of a call stack. We discuss
-the stack abstract data type in Chapter <xref linkend="chapter:Dynamic Data
-Structures"/>. A similar structure is used to control the flow of control
+the stack abstract data type in <xref linkend="_dynamic_data_structures"/>. A similar structure is used to control the flow of control
 of a program as it calls methods.</simpara>
 <simpara>Recall that a stack is a first in, last out (FILO) data structure. Each
 time a method is called, its local variables are put on the call stack.
@@ -30147,11 +30579,11 @@ copy of its stack frame on the call stack. Each call of the method has
 its own stack frame and operates independently. There is no way to
 access the variables from one call to the next, other than by passing in
 parameters or returning values.</simpara>
-<simpara>Figure <xref linkend="figure:recursive_calls"/> shows the stack frames being pushed
+<simpara><xref linkend="figure-recursive_calls"/> shows the stack frames being pushed
 onto the call stack as the <literal>main()</literal> method calls the <literal>factorial()</literal>
 method, starting with the argument <literal>4</literal>. The <literal>factorial()</literal> method
 recursively calls itself with successively smaller values.</simpara>
-<figure>
+<figure xml:id="figure-recursive_calls">
 <title>Successive recursive method calls getting added to the call stack.</title>
 <mediaobject>
 <imageobject>
@@ -30160,12 +30592,12 @@ recursively calls itself with successively smaller values.</simpara>
 <textobject><phrase>recursivecalls</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara>Figure <xref linkend="figure:recursive_returns"/> shows the stack frames popping off
+<simpara><xref linkend="figure-recursive_returns"/> shows the stack frames popping off
 the call stack as each call to <literal>factorial()</literal> returns. As the answers are
 returned, they are incorporated into the answer that is generated and
 returned to the next caller in the sequence until the final answer <literal>24</literal>
 (<inlineequation><alt><![CDATA[4!]]></alt><mathphrase><![CDATA[4!]]></mathphrase></inlineequation>) is returned to <literal>main()</literal>.</simpara>
-<figure>
+<figure xml:id="figure-recursive_returns">
 <title>Recursive methods returning results to their callers.</title>
 <mediaobject>
 <imageobject>
@@ -30254,7 +30686,7 @@ recursive definition. The return type of the method is <literal>long</literal> b
 factorial grows so quickly that only the first few values are small
 enough to fit inside of an <literal>int</literal>.</simpara>
 </example>
-<example>
+<example xml:id="fibonacciImplementedRecursivelyExample">
 <title>Fibonacci implemented recursively</title>
 <simpara>Let us return to the recursive definition of Fibonacci.</simpara>
 <simpara><inlineequation><alt><![CDATA[F_n=
@@ -30278,6 +30710,9 @@ method in Java.</simpara>
 }</programlisting>
 <simpara>One significant problem with this example is performance. In this case,
 the double recursion performs a great deal of redundant computation.</simpara>
+<sidebar>
+<simpara><link linkend="exercise19.3">Exercise 19.3</link></simpara>
+</sidebar>
 <simpara>One technique for eliminating redundant computation in recursion is
 called <emphasis>memoization</emphasis>. Whenever the value for a subproblem is computed,
 we note down the result (like a memo). When we go to compute a value, we
@@ -30300,6 +30735,10 @@ the recursion and store the result in the array.</simpara>
 number much more efficient; however, even more efficient approaches are
 described in the exercises.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise19.6">Exercise 19.6</link><?asciidoc-br?>
+<link linkend="exercise19.8">Exercise 19.8</link></simpara>
+</sidebar>
 <example>
 <title>Tower of Hanoi</title>
 <simpara>The famous Tower of Hanoi puzzle is another example commonly used to
@@ -30307,7 +30746,7 @@ illustrate recursion. In this puzzle, there are three poles containing a
 number of different sized disks. The puzzle begins with all disks
 arranged in a tower on one pole in decreasing size, with the smallest
 diameter disk on top and the largest on the bottom.
-Figure <xref linkend="figure:hanoi"/> shows an example of the puzzle. The goal is to
+<xref linkend="figure-hanoi"/> shows an example of the puzzle. The goal is to
 move all the disks from the initial pole to the final pole, with two
 restrictions:</simpara>
 <orderedlist numeration="arabic">
@@ -30318,7 +30757,7 @@ restrictions:</simpara>
 <simpara>a larger disk can never be placed on top of a smaller disk</simpara>
 </listitem>
 </orderedlist>
-<figure>
+<figure xml:id="figure-hanoi">
 <title>Tower of Hanoi puzzle with 4 disks on the initial pole.</title>
 <mediaobject>
 <imageobject>
@@ -30349,8 +30788,8 @@ destination pole.</simpara>
 </varlistentry>
 </variablelist>
 <simpara>The Tower of Hanoi solution in Java translates this outline into code.</simpara>
-<formalpara xml:id="program:TowerOfHanoi" xreflabel="TowerOfHanoi">
-<title>A recursive solution to the Tower of Hanoi with four disks and poles named <literal>'A'</literal>, <literal>'B'</literal>, and <literal>'C'</literal>.</title>
+<formalpara xml:id="TowerOfHanoiProgram">
+<title>Recursive solution to the Tower of Hanoi with four disks and poles named <literal>'A'</literal>, <literal>'B'</literal>, and <literal>'C'</literal>.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class TowerOfHanoi {
     public static void main(String[] args) {
@@ -30378,7 +30817,7 @@ Run the implementation above with different numbers of disks to see how
 long the sequence of moves is. Try small numbers of disks, since large
 numbers of disks takes a very long time.</simpara>
 </example>
-<example>
+<example xml:id="exponentiationExample">
 <title>Exponentiation</title>
 <simpara>Both Fibonacci and the Tower of Hanoi have natural recursive structures.
 In the case of Fibonacci, one way to implement its natural recursive
@@ -30481,6 +30920,9 @@ start with a power of 2. There is a way to extend this clever approach
 to all values of <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>, even and odd, but we leave it as an
 exercise.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise19.7">Exercise 19.7</link></simpara>
+</sidebar>
 <simpara>Recursion offers elegant ways to compute mathematical functions like
 those we have explored in this section. Recursion also offers powerful
 ways to manipulate data structures. As we show in the next section,
@@ -30509,12 +30951,15 @@ the last (at index <literal>array.length - 1</literal>). Recursion continues unt
 <literal>position</literal> has reached half the length of <literal>array</literal>. If execution
 continued past the halfway point, it would begin to swap elements that
 had already been swapped.</simpara>
+<sidebar>
+<simpara><link linkend="exercise19.5">Exercise 19.5</link></simpara>
+</sidebar>
 <simpara>Although it is possible to reverse an array recursively, there is
-usually no advantage in doing so. We introduce bubble sort and selection
+usually no advantage in doing so. We introduced bubble sort and selection
 sort in previous chapters, but neither of these algorithms is very fast.
 Many of the best sorting algorithms are recursive, as in the following
 example of merge sort.</simpara>
-<example>
+<example xml:id="mergeSortExample">
 <title>Merge sort</title>
 <simpara>Merge sort is an efficient sorting algorithm that is usually implemented
 recursively. The idea of the sort is to break a list of items in half
@@ -30582,6 +31027,9 @@ pays dividends. For large lists, merge sort performs much faster than
 either of those sorts. In fact, it is comparable in speed to the best
 general sorting algorithms that are possible.</simpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise19.15">Exercise 19.15</link></simpara>
+</sidebar>
 <simpara>Although recursive sorting algorithms are useful for arrays, recursion
 really shines when manipulating <emphasis>recursive data structures</emphasis>. A recursive
 data structure is one that is defined in terms of itself. For example,
@@ -30590,8 +31038,7 @@ class <literal>X</literal> is recursive if there is a field inside <literal>X</l
     private int a, b;
     private X x;
 }</programlisting>
-<simpara>The linked list examples from Chapter <xref linkend="chapter:Dynamic Data
-Structures"/> are recursive data structures, since a linked list node is
+<simpara>The linked list examples from <xref linkend="_dynamic_data_structures"/> are recursive data structures, since a linked list node is
 defined in terms of itself. You may not have thought of the linked list
 <literal>Node</literal> class as being recursive since it simply has a reference to
 another <literal>Node</literal> inside it. However, this self-reference is the essence of
@@ -30606,16 +31053,16 @@ Typically, the end of the recursion is indicated by a link with a <literal>null<
 value. For example, in the last node of a linked list, the link field is
 <literal>null</literal>. Unsurprisingly, recursive methods are frequently used to
 manipulate recursive data structures.</simpara>
-<example>
+<example xml:id="recursiveLinkedListSizeExample">
 <title>Recursive linked list size</title>
 <simpara>How would you get the size of a linked list? The implementation in
-Program <xref linkend="program:LinkedList"/> keeps track of its size as it grows, but
+<xref linkend="LinkedListProgram"/> keeps track of its size as it grows, but
 what if it didn&#8217;t? A standard way to count the elements in the list
 would be to start with a reference to the head of the list and a counter
 with value zero. As long as the reference is not <literal>null</literal>, add one to the
 counter and set the reference to the next element on the list.
-Program <xref linkend="program:IterativeListSize"/> counts the elements in this way.</simpara>
-<formalpara xml:id="program:IterativeListSize" xreflabel="IterativeListSize">
+<xref linkend="IterativeListSizeProgram"/> counts the elements in this way.</simpara>
+<formalpara xml:id="IterativeListSizeProgram">
 <title>Linked list implementation whose <literal>size()</literal> method counts its elements iteratively.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class IterativeListSize {
@@ -30650,7 +31097,7 @@ to use the natural recursion of the linked list itself. We can say that
 the length of a linked list is 0 if the list is empty (the current link
 is <literal>null</literal>), otherwise, it is one more than the size of the rest of the
 list.</simpara>
-<simpara>Program <xref linkend="program:RecursiveListSize"/> counts the elements in a linked
+<simpara><xref linkend="RecursiveListSizeProgram"/> counts the elements in a linked
 list using this recursive procedure. Note that there is a non-recursive
 <literal>size()</literal> method that calls the recursive <literal>size()</literal> method. This
 non-recursive method is called a <emphasis>proxy method</emphasis>. The recursive method
@@ -30658,7 +31105,7 @@ requires access to the internals of the data structure. The proxy method
 calls the recursive method with the appropriate starting point (<literal>head</literal>),
 while providing a public way to get the list&#8217;s size without exposing its
 internals.</simpara>
-<formalpara xml:id="program:RecursiveListSize" xreflabel="RecursiveListSize">
+<formalpara xml:id="RecursiveListSizeProgram">
 <title>Linked list implementation with a recursive <literal>size()</literal> method for counting its elements.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class RecursiveListSize {
@@ -30691,6 +31138,10 @@ internals.</simpara>
 </para>
 </formalpara>
 </example>
+<sidebar>
+<simpara><link linkend="exercise19.9">Exercise 19.9</link><?asciidoc-br?>
+<link linkend="exercise19.10">Exercise 19.10</link></simpara>
+</sidebar>
 <section xml:id="_trees">
 <title>Trees</title>
 <simpara>A linked list models a linear, one-to-one relationship between its
@@ -30722,11 +31173,11 @@ the root nor a leaf.</simpara>
 </listitem>
 </varlistentry>
 </variablelist>
-<simpara>Figure <xref linkend="figure:tree_visualization"/> shows a visualization of a tree. In
+<simpara><xref linkend="figure-tree_visualization"/> shows a visualization of a tree. In
 nature, a tree has its root at the bottom and branches upward. Since the
 root is the starting point for a tree data structure, it is almost
 always drawn at the top.</simpara>
-<figure>
+<figure xml:id="figure-tree_visualization">
 <title>Visualization of a tree. The root is shown in light red. The leaves are shown in blue. The interior nodes are show in light purple.</title>
 <mediaobject>
 <imageobject>
@@ -30742,9 +31193,12 @@ applications include dictionaries, catalogs, ordered lists, and any
 other sorted set of objects. For these purposes, we can define an
 abstract data type that includes operations such as <literal>add()</literal> and
 <literal>find()</literal>.</simpara>
+<sidebar>
+<simpara><link linkend="exercise19.13">Exercise 19.13</link></simpara>
+</sidebar>
 <simpara>A special case of a tree that is used frequently is a <emphasis>binary tree</emphasis>, in
 which each node references at most two other trees.</simpara>
-<example>
+<example xml:id="binarySearchTreeExample">
 <title>Binary search tree</title>
 <simpara>A <emphasis>binary search tree</emphasis> is a binary tree with the following three
 properties.</simpara>
@@ -30768,7 +31222,7 @@ you&#8217;ve found it! If the item you want is smaller than the root, go left.
 If the item you want is larger than the root, go right. If you ever run
 out of tree (hit a <literal>null</literal>), the item is not in the tree.</simpara>
 <simpara>This example is a simple binary tree that can stores a list of strings
-and print them out in alphabetical order. Program <xref linkend="program:Tree"/> shows
+and print them out in alphabetical order. <xref linkend="TreeProgram"/> shows
 the <literal>Tree</literal> class that defines the fields and two public methods, <literal>add()</literal>
 and <literal>print()</literal> that operate on the tree. Each is a proxy method that
 calls its private recursive version, which takes a reference to a <literal>Node</literal>
@@ -30784,8 +31238,8 @@ object. The <literal>Node</literal> static nested class contains three fields.</
 <simpara><literal>right</literal>: a link to the right subtree</simpara>
 </listitem>
 </itemizedlist>
-<formalpara xml:id="program:Tree" xreflabel="Tree">
-<title>A class that implements a simple binary search tree ADT for creating a sorted list of strings.</title>
+<formalpara xml:id="TreeProgram">
+<title>Class that implements a simple binary search tree ADT for creating a sorted list of strings.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class Tree {
 	private static class Node {
@@ -30830,10 +31284,10 @@ object. The <literal>Node</literal> static nested class contains three fields.</
 }</programlisting>
 </para>
 </formalpara>
-<simpara>Figure <xref linkend="figure:tree_classes"/> shows a visualization of the contents of
+<simpara><xref linkend="figure-tree_classes"/> shows a visualization of the contents of
 this implementation of a binary search tree. As with a linked list, an
 &#8220;X&#8221; is used in place of arrows that point to <literal>null</literal>.</simpara>
-<figure role="text-center">
+<figure xml:id="figure-tree_classes" role="text-center">
 <title>Visualization of a tree implementation with classes.</title>
 <mediaobject>
 <imageobject>
@@ -30864,12 +31318,16 @@ node. When it finishes, it prints the current node value. Finally, it
 walks the right subtree to print the values that alphabetically follow
 the value in the current node. This path through the nodes of the tree
 is called an <emphasis>inorder traversal</emphasis>.</simpara>
+<sidebar>
+<simpara><link linkend="exercise19.11">Exercise 19.11</link><?asciidoc-br?>
+<link linkend="exercise19.12">Exercise 19.12</link></simpara>
+</sidebar>
 <simpara>With the power of a binary search tree, it takes virtually no code at
 all to store a list of <literal>String</literal> values and then print them out in sorted
-order. Program <xref linkend="program:ReadAndSortStrings"/> gives an example of this
+order. <xref linkend="ReadAndSortStringsProgram"/> gives an example of this
 process using a <literal>Tree</literal> object for storage.</simpara>
-<formalpara xml:id="program:ReadAndSortStrings" xreflabel="ReadAndSortStrings">
-<title>A program to read <literal>String</literal> values, store them in a binary search tree, and print the results in sorted order.</title>
+<formalpara xml:id="ReadAndSortStringsProgram">
+<title>Reads <literal>String</literal> values, stores them in a binary search tree, and prints the results in sorted order.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Scanner;
 
@@ -30900,12 +31358,12 @@ and recursion from this chapter gives us the full power of generic
 dynamic data structures and recursive methods to process them.</simpara>
 <example>
 <title>Binary search tree to hold integers</title>
-<simpara>Consider Program <xref linkend="program:IntegerTree"/>, which implements a tree that
+<simpara>Consider <xref linkend="IntegerTreeProgram"/>, which implements a tree that
 stores values of type <literal>Integer</literal>. Although it would be more efficient to
 store <literal>int</literal> values, we use the <literal>Integer</literal> wrapper class to ease our
 eventual transition into a parameterized generic type.</simpara>
-<formalpara xml:id="program:IntegerTree" xreflabel="IntegerTree">
-<title>A variant of Program <xref linkend="program:Tree"/> that stores`Integer` values instead of <literal>String</literal> values.</title>
+<formalpara xml:id="IntegerTreeProgram">
+<title>Variant of <xref linkend="TreeProgram"/> that stores`Integer` values instead of <literal>String</literal> values.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class IntegerTree {
 	private static class Node {
@@ -30953,12 +31411,12 @@ eventual transition into a parameterized generic type.</simpara>
 </example>
 <simpara>It is a waste to create class <literal>IntegerTree</literal>, which is identical to
 <literal>Tree</literal> except that the type <literal>String</literal> has been replaced by <literal>Integer</literal>. As
-in Chapter <xref linkend="chapter:Dynamic_Data_Structures"/>, we want our data
+in <xref linkend="_dynamic_data_structures"/>, we want our data
 structures, recursive or otherwise, to hold any type. In this way, we
 can reuse code.</simpara>
 <example>
 <title>Defining a generic binary search tree</title>
-<simpara>Program <xref linkend="program:GenericTree"/> defines a generic version of the <literal>Tree</literal>
+<simpara><xref linkend="GenericTreeProgram"/> defines a generic version of the <literal>Tree</literal>
 class. This example is complicated by the fact that we need to be able
 to compare the value we want to store with the value in each <literal>Node</literal>
 object. We can&#8217;t make a tree with any arbitrary type. Objects of the
@@ -30968,8 +31426,8 @@ stored in each <literal>Tree</literal> must implement the <literal>Comparable</l
 requirement complicates the generic syntax significantly but guarantees
 that any type that cannot be compared with itself is rejected at
 compile-time.</simpara>
-<formalpara xml:id="program:GenericTree" xreflabel="GenericTree">
-<title>A class that implements a generic tree.</title>
+<formalpara xml:id="GenericTreeProgram">
+<title>Class that implements a generic tree.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">public class GenericTree&lt;T extends Comparable&lt;T&gt;&gt; {
 	private static class Node&lt;T extends Comparable&lt;T&gt;&gt;{
@@ -31029,12 +31487,12 @@ come up infrequently for programmers who are only using the libraries.</simpara>
 </example>
 <example>
 <title>Using a generic class</title>
-<simpara>Program <xref linkend="program:ReadAndSortGenerics"/> uses the generic tree class to
+<simpara><xref linkend="ReadAndSortGenericsProgram"/> uses the generic tree class to
 create two kinds of trees, a tree of <literal>String</literal> objects and a tree of
 <literal>Integer</literal> objects. Java library implementations of binary search trees
 are available as the <literal>TreeSet</literal> and <literal>TreeMap</literal> classes.</simpara>
-<formalpara xml:id="program:ReadAndSortGenerics" xreflabel="ReadAndSortGenerics">
-<title>Program to create two trees with different underlying types.</title>
+<formalpara xml:id="ReadAndSortGenericsProgram">
+<title>Creates two trees with different underlying types.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.util.Random;
 import java.util.Scanner;
@@ -31098,11 +31556,11 @@ public class MazeSolver {
 
 	public static void main( String[] args ) {
 		MazeSolver solver = new MazeSolver();
-		if( solver.solve(0, 0) )/*@\label{mazeRCall}@*/
+		if( solver.solve(0, 0) )
 			System.out.println("\nSolved!");
 		else
 			System.out.println("\nNot solvable!");
-		solver.print();/*@\label{mazeRPrint}@*/
+		solver.print();
 	}</programlisting>
 <simpara>The <literal>MazeSolver</literal> class needs a two-dimensional array of <literal>char</literal> values to
 store a representation of the maze. Likewise, it is convenient to store
@@ -31145,20 +31603,20 @@ it reads, it prints out each line to the screen, showing the initial
 <simpara>The <literal>print()</literal> method is a utility method that prints out the maze. It
 iterates through each row, printing out the values for the columns in
 that row.</simpara>
-<programlisting language="java" linenumbering="numbered">	public boolean solve( int row, int column ) {/*@\label{mazeRBegin}@*/
-		if( row &lt; 0 || column &lt; 0 || row &gt;= rows || column &gt;= columns)/*@\label{mazeROutside}@*/
+<programlisting language="java" linenumbering="numbered">	public boolean solve( int row, int column ) {
+		if( row &lt; 0 || column &lt; 0 || row &gt;= rows || column &gt;= columns)
 			return false;
-		else if( maze[row][column] == 'E' )/*@\label{mazeRDone}@*/
+		else if( maze[row][column] == 'E' )
 			return true;
-		else if( maze[row][column] != ' ')/*@\label{mazeRBlocked}@*/
+		else if( maze[row][column] != ' ')
 			return false;
 		else {
 			maze[row][column] = '*';
-			if( solve(row - 1, column) || solve(row + 1, column) ||/*@\label{mazeRRecursive}@*/
+			if( solve(row - 1, column) || solve(row + 1, column) ||
 				solve(row, column - 1) || solve(row, column + 1) )
 				return true;
 			else {
-				maze[row][column] = ' ';/*@\label{mazeRBlank}@*/
+				maze[row][column] = ' ';
 				return false;
 			}
 		}
@@ -31190,11 +31648,8 @@ is not making progress toward the finish. Return <literal>false</literal>.</simp
 <simpara>If none of the base cases applies, then the current location, which must
 contain a <literal>' '</literal> character, <emphasis role="strong">might</emphasis> be on a successful path, so <literal>solve()</literal>
 gives it a try. The method tentatively marks the current position with
-<literal>'*'</literal>. Then, it recursively tries to find a path from the current
-location to each of the four neighboring cells
-(line <xref linkend="mazeRRecursive"/>). If any of those four neighbors returns
-<literal>true</literal>, then <literal>solve()</literal> knows it has found a completed path and returns
-<literal>true</literal> to its caller.</simpara>
+<literal>'*'</literal>. Then, it tries to find a path from the current
+location to each of the four neighboring cells by recursively calling <literal>solve()</literal>. If any of those four neighbors returns <literal>true</literal>, then <literal>solve()</literal> knows it has found a completed path and returns <literal>true</literal> to its caller.</simpara>
 <simpara>If none of the four neighbors was on a path to the destination, then the
 current location is not on a path. The method unmarks the current
 location (by storing a <literal>' '</literal>) and returns <literal>false</literal>. Presumably, its
@@ -31278,7 +31733,7 @@ worker class that implements <literal>Callable</literal>. Since the result of th
 square roots is a <literal>double</literal>, it must implement <literal>Callable&lt;Double&gt;</literal>. Recall
 that primitive types such as <literal>double</literal> cannot be used as generic type
 parameters, requiring us to use wrapper classes in those cases.</simpara>
-<programlisting xml:id="program:RootSummer" xreflabel="RootSummer" language="java" linenumbering="numbered">import java.util.concurrent.*;
+<programlisting xml:id="RootSummerProgram" language="java" linenumbering="numbered">import java.util.concurrent.*;
 
 public class RootSummer implements Callable&lt;Double&gt; {
 	private int min;
@@ -31378,41 +31833,42 @@ additional <literal>Callable</literal> objects to it to run more futures. Finall
 print out the result.</simpara>
 </example>
 </section>
-<section xml:id="_exercises_18">
+<section xml:id="_exercises_19">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara><xref linkend="exercise:recursive_addition"/> Example <xref linkend="example:Multiplication_defined_recursively"/> gave a mathematical recursive definition for
+<simpara><anchor xml:id="exercise19.1" xreflabel="[exercise19.1]"/> <xref linkend="multiplicationDefinedRecursivelyExample"/> gave a mathematical recursive definition for
 <inlineequation><alt><![CDATA[x \times y]]></alt><mathphrase><![CDATA[x \times y]]></mathphrase></inlineequation>. Give a similar recursive definition for
 <inlineequation><alt><![CDATA[x + y]]></alt><mathphrase><![CDATA[x + y]]></mathphrase></inlineequation>. The structure is similar to the recursion to
-determine your current age given in Section <xref linkend="subsection:What_is_recursion"/>.</simpara>
+determine your current age given in <xref linkend="_what_is_recursion"/>.</simpara>
 </listitem>
 <listitem>
-<simpara>In principle, every problem that can be solved with an iterative
+<simpara><anchor xml:id="exercise19.2" xreflabel="[exercise19.2]"/> In principle, every problem that can be solved with an iterative
 solution can be solved with a recursive one (and vice versa). However,
 the limited size of the call stack can present problems for recursive
 solutions with very deep recursion. Why? Conversely, are there any
 recursive solutions that are impossible to turn into iterative ones?</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:inefficient_Fibonacci"/> Consider the first (non-memoized)
+<simpara><anchor xml:id="exercise19.3" xreflabel="[exercise19.3]"/> Consider the first (non-memoized)
 recursive version of the Fibonacci method given in
-Example <xref linkend="example:Fibonacci_implemented_recursively"/>. How many times is
+<xref linkend="fibonacciImplementedRecursivelyExample"/>. How many times is
 <literal>fibonacci()</literal> called with argument <inlineequation><alt><![CDATA[1]]></alt><mathphrase><![CDATA[1]]></mathphrase></inlineequation> to compute
 <literal>fibonacci(n)</literal>? Instrument your program and count the number of calls
 for <inlineequation><alt><![CDATA[n = 2, 3, 4 \ldots 20]]></alt><mathphrase><![CDATA[n = 2, 3, 4 \ldots 20]]></mathphrase></inlineequation>.</simpara>
 </listitem>
 <listitem>
-<simpara>In the recursive <literal>solve()</literal> method in the <literal>MazeSolver</literal> program given
-in Section <xref linkend="solution:Maze_of_doom"/>, the current location in the maze
+<simpara><anchor xml:id="exercise19.4" xreflabel="[exercise19.4]"/> In the recursive <literal>solve()</literal> method in the <literal>MazeSolver</literal> program given
+in <xref linkend="_solution_maze_of_doom"/>, the current location in the maze
 array is is set to a blank character (<literal>' '</literal>) after no solution had been
 found. What value was in that location? How would the program behave if
 the value was not changed?</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:recursive_palindromes"/> Exercise <xref linkend="exercise:palindromes"/>
-from Chapter <xref linkend="chapter:Methods"/> challenges you to write a method to
+<simpara><anchor xml:id="exercise19.5" xreflabel="[exercise19.5]"/> <link linkend="exercise8.11">Exercise 8.11</link>
+from <xref linkend="_methods"/> challenges you to write a method to
 determine whether a <literal>String</literal> contains a palindrome. Recall that a
 palindrome (if punctuation and spaces are ignored) can be described as a
 <literal>String</literal> in which the first and last characters are equal, and all the
@@ -31429,8 +31885,8 @@ initially be called with a <literal>String</literal>, <literal>0</literal>, and 
     isPalindrome( "A man, a plan, a canal: Panama", 0, 30 );</programlisting>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:Fibonacci_without_array"/> The efficient implementation of
-Fibonacci from Example <xref linkend="example:Fibonacci_implemented_recursively"/>
+<simpara><anchor xml:id="exercise19.6" xreflabel="[exercise19.6]"/> The efficient implementation of
+Fibonacci from <xref linkend="fibonacciImplementedRecursivelyExample"/>
 eliminates redundant computation through memoization, storing values in
 an array as they are found. It is possible to carry along the
 computations of the previous two Fibonacci numbers <emphasis role="strong">without</emphasis> the
@@ -31445,10 +31901,10 @@ number you were originally looking for.</simpara>
 <simpara>Complete the implementation of this recursive method.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:efficient_exponentiation"/> Write an implementation of
+<simpara><anchor xml:id="exercise19.7" xreflabel="[exercise19.7]"/> Write an implementation of
 fast exponentiation that works for even and odd <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation>. This
 implementation is exactly the same as the one given at the end of
-Example <xref linkend="example:Exponentiation"/> except when <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> is odd.
+<xref linkend="exponentiationExample"/> except when <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation> is odd.
 Use the following recursive definition of exponentiation to guide your
 implementation.</simpara>
 <simpara><inlineequation><alt><![CDATA[a^n =
@@ -31466,7 +31922,7 @@ a\cdot \left(a^{\frac{n - 1}{2}}\right)^2 & \text{if  $n>1$ and odd} & \text{(Ba
 \end{cases}]]></mathphrase></inlineequation></simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:efficient_Fibonacci"/> Example <xref linkend="example:Fibonacci_implemented_recursively"/> shows two implementations that can be used to
+<simpara><anchor xml:id="exercise19.8" xreflabel="[exercise19.8]"/> <xref linkend="fibonacciImplementedRecursivelyExample"/> shows two implementations that can be used to
 find the <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation><superscript>th</superscript> Fibonacci number. With a little bit of
 math, it is possible to show that there is a closed-form equation that
 gives the <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation><superscript>th</superscript> Fibonacci number <inlineequation><alt><![CDATA[F_n]]></alt><mathphrase><![CDATA[F_n]]></mathphrase></inlineequation> where
@@ -31478,7 +31934,7 @@ gives the <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mat
 equation and discover the value of <inlineequation><alt><![CDATA[F_n]]></alt><mathphrase><![CDATA[F_n]]></mathphrase></inlineequation> quickly, provided
 that you have an efficient way to raise values to the
 <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation><superscript>th</superscript> power. Use the recursive algorithm for fast
-exponentation from Exercise <xref linkend="exercise:efficient_exponentiation"/> to
+exponentation from <link linkend="exercise19.7">Exercise 19.7</link> to
 make an implementation that finds the <inlineequation><alt><![CDATA[n]]></alt><mathphrase><![CDATA[n]]></mathphrase></inlineequation><superscript>th</superscript> Fibonacci
 number <emphasis role="strong">very</emphasis> quickly.</simpara>
 <simpara>Note that this approach uses real numbers (including
@@ -31488,22 +31944,22 @@ to do this computation without doing any floating-point arithmetic, but
 we do not go into those details here.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:print_linked_list"/> Example <xref linkend="example:Recursive_linked_list_size"/> shows a way to calculate the size of a linked list
+<simpara><anchor xml:id="exercise19.9" xreflabel="[exercise19.9]"/> <xref linkend="recursiveLinkedListSizeExample"/> shows a way to calculate the size of a linked list
 recursively. Add a recursive method called <literal>print()</literal> to the
 <literal>RecursiveListSize</literal> class that prints out the values in the linked list
 recursively, on each line.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:reverse_print_linked_list"/> Expand the previous exercise
+<simpara><anchor xml:id="exercise19.10" xreflabel="[exercise19.10]"/> Expand the previous exercise
 to add another method called <literal>reversePrint()</literal> that prints out the values
 in the linked list the <emphasis role="strong">opposite</emphasis> order that they appear. It should take
 only a slight modification of the <literal>print()</literal> method you have already
 written.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:tree_find"/> Create a recursive <literal>find()</literal> method (and a
+<simpara><anchor xml:id="exercise19.11" xreflabel="[exercise19.11]"/> Create a recursive <literal>find()</literal> method (and a
 non-recursive proxy method to call it) for the <literal>Tree</literal> class given in
-Program <xref linkend="program:Tree"/>. Its operation is similar to the <literal>add()</literal>
+<xref linkend="TreeProgram"/>. Its operation is similar to the <literal>add()</literal>
 method. If the subtree it is examining is empty (<literal>null</literal>), it should
 return <literal>false</literal>. If the value it is looking for is at the root of the
 current subtree, it should return <literal>true</literal>. These are the two base cases.
@@ -31514,37 +31970,37 @@ the value at the root of the current subtree, it should look in the
 right subtree. These are the two recursive cases.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:tree_height"/> The height of a binary tree is defined as
+<simpara><anchor xml:id="exercise19.12" xreflabel="[exercise19.12]"/> The height of a binary tree is defined as
 the longest path from the root to any leaf node. Thus, the height of a
 tree with only a root node in it is 0. By convention, the height of an
 empty tree is -1.</simpara>
 <simpara>Create a recursive <literal>getHeight()</literal> method (and a non-recursive proxy
 method to call it) for the <literal>Tree</literal> class given in
-Program <xref linkend="program:Tree"/>. The base case is an empty tree (a <literal>null</literal>
+<xref linkend="TreeProgram"/>. The base case is an empty tree (a <literal>null</literal>
 pointer), which has a height of -1. For the recursive case of a
 non-empty tree, its height is one more than the height of the larger of
 its two subtrees.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:setInterfaceExercise"/> Create an <literal>interface</literal> that
-describes a tree ADT. Modify the programs in Example <xref linkend="example:Binary_search_tree"/> to use this <literal>interface</literal>.</simpara>
+<simpara><anchor xml:id="exercise19.13" xreflabel="[exercise19.13]"/> Create an <literal>interface</literal> that
+describes a tree ADT. Modify the programs in <xref linkend="binarySearchTreeExample"/> to use this <literal>interface</literal>.</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Write an iterative version of the factorial function and compare its
+<simpara><anchor xml:id="exercise19.14" xreflabel="[exercise19.14]"/> Write an iterative version of the factorial function and compare its
 speed to the recursive version given in the text. Use the
 <literal>System.currentTimeMillis()</literal> or<?asciidoc-br?>
 <literal>System.nanoTime()</literal> methods before and after <literal>for</literal> loops that call the
 factorial methods 1,000,000 times each for random values.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:sort_timing"/> Write a program that generates four arrays
+<simpara><anchor xml:id="exercise19.15" xreflabel="[exercise19.15]"/> Write a program that generates four arrays
 of random <literal>int</literal> values with lengths 1,000, 10,000, 100,000, and
 1,000,000. Make two additional copies of each array. Then, sort each of
 three copies of the array with the selection sort algorithm given in
-Example <xref linkend="example:Selection_sort"/>, the bubble sort algorithm given in
-Section <xref linkend="section:Problem:_Sort_it_out"/>, and the merge sort algorithm given in
-Example <xref linkend="example:Merge_sort"/>, respectively. Use the
+<xref linkend="selectionSortExample"/>, the bubble sort algorithm given in
+<xref linkend="_problem_sort_it_out"/>, and the merge sort algorithm given in
+<xref linkend="mergeSortExample"/>, respectively. Use the
 <literal>System.currentTimeMillis()</literal> or <literal>System.nanoTime()</literal> methods to time each
 of the sorts. Note that both selection sort and bubble sort may take
 quite a while to sort an array of 1,000,000 elements.</simpara>
@@ -31559,7 +32015,7 @@ bubble sort, but it should take time proportional to
 large arrays, the difference in time is significant.</simpara>
 </listitem>
 <listitem>
-<simpara>Investigate the performance of using recursion to compute Fibonacci
+<simpara><anchor xml:id="exercise19.16" xreflabel="[exercise19.16]"/> Investigate the performance of using recursion to compute Fibonacci
 numbers. Implement the naive recursive solution, the memoization method,
 and an iterative solution similar to the memoization method. Use the
 <literal>System.currentTimeMillis()</literal> or <literal>System.nanoTime()</literal> methods to time the
@@ -31568,8 +32024,7 @@ long time to compute the <literal>n</literal><superscript>th</superscript> Fibon
 recursive solution.)</simpara>
 </listitem>
 <listitem>
-<simpara>Exercise <xref linkend="exercise:binary_search"/> from Chapter <xref linkend="chapter:Arrays"/>
-explains how binary search can be used to search for a value in a sorted
+<simpara><anchor xml:id="exercise19.17" xreflabel="[exercise19.17]"/> <link linkend="exercise6.9">Exercise 6.9</link> from <xref linkend="_arrays"/> explains how binary search can be used to search for a value in a sorted
 array of values. The idea is to play a &#8220;high-low&#8221; game, first looking
 at the middle value. If the value is the one you&#8217;re looking for, you&#8217;re
 done. If it is too high, look in the lower half of the array. If it is
@@ -31584,7 +32039,7 @@ process. Was the iterative or recursive approach faster? By how much?</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:File_IO">
+<chapter xml:id="_file_i_o">
 <title>File I/O</title>
 <blockquote>
 <attribution>
@@ -31942,7 +32397,7 @@ finally { try{ out.close(); } catch( Exception e ){} }</programlisting>
 too difficult, but it seems cumbersome. The objects provide methods
 which elegantly allow you to read and write a whole object at a time. To
 do so, we need to define a new class.</simpara>
-<formalpara xml:id="program:BaseballPlayer" xreflabel="BaseballPlayer">
+<formalpara xml:id="BaseballPlayerProgram">
 <title>Serializable BaseballPlayer class.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.io.Serializable;
@@ -32054,7 +32509,7 @@ Linux and Unix, the <literal>ls</literal> command is generally used. In a few li
 code, we can write a directory listing tool which lists all the files in
 a directory, the dates each was last modified, and whether or not a file
 is a directory.</simpara>
-<formalpara xml:id="program:Directory" xreflabel="Directory">
+<formalpara xml:id="DirectoryProgram">
 <title>Directory listing tool.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.io.*;
@@ -32092,8 +32547,8 @@ number of circles formatted as text, one on each line of the file. It&#8217;s
 our job to read each radius, compute the area of the circle, and write
 those areas to a file called <literal>areas.txt</literal>, using the formula
 <inlineequation><alt><![CDATA[A = \pi r^2]]></alt><mathphrase><![CDATA[A = \pi r^2]]></mathphrase></inlineequation>.</simpara>
-<formalpara xml:id="program:AreaFromRadiusText" xreflabel="AreaFromRadiusText">
-<title>Program to read a list of radiuses from a text file and output their areas to another file.</title>
+<formalpara xml:id="AreaFromRadiusTextProgram">
+<title>Reads a list of radiuses from a text file and output their areas to another file.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.io.*;
 import java.util.*;
@@ -32127,8 +32582,8 @@ public class AreaFromRadiusText {
 <simpara>The previous class did all of its input and output with text files. We
 will also implement this program to read from a binary file called
 <literal>radiuses.bin</literal> and write to a binary file called <literal>areas.bin</literal>.</simpara>
-<formalpara xml:id="program:AreaFromRadiusBinary" xreflabel="AreaFromRadiusBinary">
-<title>Program to read a list of radiuses from a binary file and output their areas to another file.</title>
+<formalpara xml:id="AreaFromRadiusBinaryProgram">
+<title>Reads a list of radiuses from a binary file and output their areas to another file.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.io.*;
 
@@ -32277,7 +32732,7 @@ file a shared resource as well? What happens when two threads try to
 access a file at the same time? If both threads are reading from the
 file, everything should work fine. If the threads are both writing or
 doing a combination of reading and writing, there can be problems.</simpara>
-<simpara>As we mentioned in Section <xref linkend="syntax:File_operations_in_Java"/>, file
+<simpara>As we mentioned in <xref linkend="_syntax_file_operations_in_java"/>, file
 operations are OS dependent. Although Java tries to give a uniform
 interface, different system calls are happening at a low level.
 Consequently, the results may be different as well.</simpara>
@@ -32285,8 +32740,8 @@ Consequently, the results may be different as well.</simpara>
 series of numbers to a file called <literal>concurrent.out</literal>. The first thread
 prints the even numbers between 0 and 9,999 while the second thread
 prints the odd ones.</simpara>
-<formalpara xml:id="program:ConcurrentFileAccess" xreflabel="ConcurrentFileAccess">
-<title>Program that spawns threads that print odd and even numbers to a file concurrently.</title>
+<formalpara xml:id="ConcurrentFileAccessProgram">
+<title>Spawns threads that print odd and even numbers to a file concurrently.</title>
 <para>
 <programlisting language="java" linenumbering="numbered">import java.io.*;
 
@@ -32294,10 +32749,8 @@ public class ConcurrentFileAccess implements Runnable {
 	private boolean even;
 
 	public static void main(String args[]) {
-		Thread writer1 =
-			new Thread( new ConcurrentFileAccess(true) );
-		Thread writer2 =
-			new Thread( new ConcurrentFileAccess(false) );
+		Thread writer1 = new Thread( new ConcurrentFileAccess(true) );
+		Thread writer2 = new Thread( new ConcurrentFileAccess(false) );
 		writer1.start();
 		writer2.start();
 	}
@@ -32312,13 +32765,12 @@ public class ConcurrentFileAccess implements Runnable {
 		if( !even )
 			start = 1;
 		try {
-			out = new PrintWriter (
-					new FileOutputStream ( "concurrent.out", true ) ); /*@\label{open concurrent file}@*/
+			out = new PrintWriter(
+				new FileOutputStream( "concurrent.out", true ) );
 			for( int i = start; i &lt; 10000; i += 2 ) {
-				out.println ( i ); /*@\label{output data concurrently}@*/
+				out.println( i );
 				out.flush();
 			}
-
 		}
 		catch ( FileNotFoundException e ) {
 			System.out.println("concurrent.out not found!");
@@ -32344,14 +32796,14 @@ possibilities.</simpara>
 by default it erases everything that was already in the file. So, an
 entire sequence of numbers is getting saved and then lost. We can change
 this behavior by changing the line below.</simpara>
-<programlisting language="java" linenumbering="unnumbered">out = new PrintWriter ( new FileOutputStream("concurrent.out") );</programlisting>
+<programlisting language="java" linenumbering="unnumbered">out = new PrintWriter( new FileOutputStream("concurrent.out") );</programlisting>
 <simpara>We replace it with the following.</simpara>
-<programlisting language="java" linenumbering="unnumbered">out = new PrintWriter ( new FileOutputStream("concurrent.out", true) );</programlisting>
+<programlisting language="java" linenumbering="unnumbered">out = new PrintWriter( new FileOutputStream("concurrent.out", true) );</programlisting>
 <simpara>This second <literal>boolean</literal> parameter to the <literal>FileOutputStream</literal> constructor
 specifies that output will <emphasis>append</emphasis> to the file instead of overwriting
 it.</simpara>
 <simpara>After this change, what does the file look like when we run the program?
-Since we are going to append to any preexisting file, make sure that you
+Since we&#8217;re going to append to any preexisting file, make sure that you
 delete <literal>concurrent.out</literal> before running the program again. The file may
 look different on different systems. The file probably contains long
 runs of numbers from each thread. In fact, it is quite possible to have
@@ -32359,8 +32811,7 @@ the complete output from one thread followed by the complete output from
 the other.</simpara>
 <simpara>For performance reasons, file operations are usually done in batches.
 Instead of writing each number to the file as the thread produces it,
-output is usually stored in a buffer which is written as a whole. If we
-call <literal>out.flush()</literal> after line <xref linkend="output_data_concurrently"/>, we can flush
+output is usually stored in a buffer which is written as a whole. By calling <literal>out.flush()</literal> after each the <literal>out.println()</literal> call, we can flush
 the buffer to the file after each number is generated. Doing so will not
 be as efficient, but it may give us some insight into how concurrent
 writes on files work.</simpara>
@@ -32383,43 +32834,43 @@ interact with the same files that your program will use, Java provides a
 with everything file-related, <literal>FileLock</literal> is dependent on the underlying
 OS and may behave differently on different systems.</simpara>
 </section>
-<section xml:id="_exercises_19">
+<section xml:id="_exercises_20">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>What is the difference between volatile and non-volatile memory?
+<simpara><anchor xml:id="exercise20.1" xreflabel="[exercise20.1]"/> What is the difference between volatile and non-volatile memory?
 Which is often associated with files and why?</simpara>
 </listitem>
 <listitem>
-<simpara>What is the difference between text and binary files? What are the
+<simpara><anchor xml:id="exercise20.1" xreflabel="[exercise20.1]"/> What is the difference between text and binary files? What are the
 pros and cons of using each?</simpara>
 </listitem>
 <listitem>
-<simpara>Define compression ratio to be the size of the uncompressed data in
+<simpara><anchor xml:id="exercise20.3" xreflabel="[exercise20.3]"/> Define compression ratio to be the size of the uncompressed data in
 bytes divided by the size of the compressed data in bytes. What is the
 theoretical maximum compression ratio you can get out of the RLE
 encoding we used? What is the theoretical lowest compression ratio you
 can get out of the RLE encoding we used?</simpara>
 </listitem>
 <listitem>
-<simpara>What is serialization in Java? What do you have to do to serialize
+<simpara><anchor xml:id="exercise20.4" xreflabel="[exercise20.4]"/> What is serialization in Java? What do you have to do to serialize
 an object?</simpara>
 </listitem>
 <listitem>
-<simpara>What kinds of objects cannot be serialized?</simpara>
+<simpara><anchor xml:id="exercise20.5" xreflabel="[exercise20.5]"/> What kinds of objects cannot be serialized?</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Implement the RLE bitmap compression program using only
+<simpara><anchor xml:id="exercise20.6" xreflabel="[exercise20.6]"/> Implement the RLE bitmap compression program using only
 <literal>FileInputStream</literal> and <literal>FileOutputStream</literal> for file input and output.</simpara>
 </listitem>
 <listitem>
-<simpara>Re-implement the maze solving program from Section <xref linkend="solution:Maze
-of doom"/> to ask the user for a file instead of reading from standard
+<simpara><anchor xml:id="exercise20.7" xreflabel="[exercise20.7]"/> Re-implement the maze solving program from <xref linkend="_solution_maze_of_doom"/> to ask the user for a file instead of reading from standard
 input.</simpara>
 </listitem>
 <listitem>
-<simpara>An HTML file contains many tags such as <literal>&lt;p&gt;</literal>, which marks the
+<simpara><anchor xml:id="exercise20.8" xreflabel="[exercise20.8]"/> An HTML file contains many tags such as <literal>&lt;p&gt;</literal>, which marks the
 beginning of a paragraph, and <literal>&lt;/p&gt;</literal>, which marks the end of a
 paragraph. A lesser known feature of HTML is that ampersand (<literal>&amp;</literal>) can
 mark special HTML entities used to produce symbols on a web page. For
@@ -32430,12 +32881,12 @@ signs (<literal>&gt;</literal>), or ampersands (<literal>&amp;</literal>).</simp
 <simpara>Write a program that reads in an input text file specified by the user
 and writes to an output text file also specified by the user. The output
 file should be exactly the same as the input file except that every
-occurrence of a less than sign should be replaced by <literal>&lt;</literal>, every
-occurrence of a greater than sign should be replaced by <literal>&gt;</literal>, and
+occurrence of a less than sign should be replaced by <literal>&amp;lt;</literal>, every
+occurrence of a greater than sign should be replaced by <literal>&amp;gt;</literal>, and
 every occurrence of an ampersand should be replaced by <literal>&amp;</literal>.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:word_list"/> Write a program that prompts the user for an
+<simpara><anchor xml:id="exercise20.9" xreflabel="[exercise20.9]"/> Write a program that prompts the user for an
 input text file. Open the file and read each word from the file, where a
 word is defined as any <literal>String</literal> made up only of upper and lower case
 letters. You can use the <literal>next()</literal> method in the <literal>Scanner</literal> class to break
@@ -32443,12 +32894,12 @@ up text by whitespace, but your code will still need to examine the
 input character by character, ending a word when any punctuation or
 other characters are reached. Store each word (with a count of the
 number of times you find it) in a binary search tree such as those
-described in Example <xref linkend="example:Binary_search_tree"/>. Then, traverse the
+described in <xref linkend="binarySearchTreeExample"/>. Then, traverse the
 tree, printing all the words found (and the number of times found) to
 the screen in alphabetical order.</simpara>
 </listitem>
 <listitem>
-<simpara>Expand the program from Exercise <xref linkend="exercise:word_list"/> so that it
+<simpara><anchor xml:id="exercise20.10" xreflabel="[exercise20.10]"/> Expand the program from <link linkend="exercise20.9">Exercise 20.9</link> so that it
 also prompts for a second file containing a dictionary in the form of a
 word list with one word on each line. Store the words from the
 dictionary in another binary search tree. Then, for each word in the
@@ -32461,7 +32912,7 @@ implementation by using a novel from Project Gutenberg
 spell checker or from a Scrabble word list.</simpara>
 </listitem>
 <listitem>
-<simpara>Files can become corrupted when they are transferred over a network.
+<simpara><anchor xml:id="exercise20.11" xreflabel="[exercise20.11]"/> Files can become corrupted when they are transferred over a network.
 It is common to make a <emphasis>checksum</emphasis>, a short code generated using the
 entire contents of a file. The checksum can be generated before and
 after file transmission. If both of the checksums match, there&#8217;s a good
@@ -32502,7 +32953,7 @@ checksum.</simpara>
 </orderedlist>
 </listitem>
 <listitem>
-<simpara>Write the RLE bitmap compression program in parallel so that a file
+<simpara><anchor xml:id="exercise20.12" xreflabel="[exercise20.12]"/> Write the RLE bitmap compression program in parallel so that a file
 is evenly divided into as many pieces as you have threads, compressed,
 and then each compressed portion is output in the correct order. Compare
 the speed for 2, 4, and 8 threads to the sequential implementation. Are
@@ -32514,7 +32965,7 @@ already stored in an array.</simpara>
 </orderedlist>
 </section>
 </chapter>
-<chapter xml:id="chapter:Network_Communication">
+<chapter xml:id="_network_communication">
 <title>Network Communication</title>
 <blockquote>
 <attribution>
@@ -32742,7 +33193,7 @@ you can create the <literal>Socket</literal> object directly.</simpara>
 either as an IP address as shown or as domain like <literal>"google.com"</literal>. The
 second parameter is, of course, the port you want to connect on.</simpara>
 </section>
-<section xml:id="subsection:receiving_and_sending_data">
+<section xml:id="_receiving_and_sending_data">
 <title>Receiving and sending data</title>
 <simpara>From here on out, we no longer have to worry about the differences
 between the client and server. Both programs have a <literal>Socket</literal> object that
@@ -32813,13 +33264,16 @@ two command line prompts and run the client from one and the server from
 the other. Be sure that you start the server first so that the client
 has something to connect to.</simpara>
 </example>
-<example>
+<example xml:id="chatClientAndServerExample">
 <title>Chat client and server</title>
 <simpara>Now we look at a more complicated example of network communication which
 should be familiar: a chat program. If you want to apply the GUI design
-from Chapter <xref linkend="chapter:Constructing_Graphical_User_Interfaces"/>, you can
+from <xref linkend="_constructing_graphical_user_interfaces"/>, you can
 make a windowed version of this chat program which looks more like chat
-programs you are used to. For now, our chat program is be text only. .</simpara>
+programs you are used to. For now, our chat program is be text only.</simpara>
+<sidebar>
+<simpara><link linkend="exercise21.9">Exercise 21.9</link></simpara>
+</sidebar>
 <simpara>The functionality of the program is simple. Once connected to a single
 other chat program, the user will enter his or her name, then enter
 lines of text each followed by a newline. The program will insert the
@@ -33146,7 +33600,11 @@ per second. If each request had to wait for the previous one to come to
 completion, the server would become hopelessly bogged down. By using a
 single thread to listen to requests and then spawn worker threads as
 needed, the server can run more smoothly.</simpara>
-<simpara>Even in Example <xref linkend="example:Chat_client_and_server"/>, it was convenient to
+<sidebar>
+<simpara><link linkend="exercise21.10">Exercise 21.10</link><?asciidoc-br?>
+<link linkend="exercise21.11">Exercise 21.11</link></simpara>
+</sidebar>
+<simpara>Even in <xref linkend="chatClientAndServerExample"/>, it was convenient to
 create two different threads, <literal>Sender</literal> and <literal>Receiver</literal>. We did not create
 them for speedup but simply because they were doing two different jobs.
 Since the <literal>Sender</literal> waits for the user to type a line and the <literal>Receiver</literal>
@@ -33161,64 +33619,65 @@ and manage threads transparently, without the user worrying about the
 details. In other cases, your program must explicitly use multiple
 threads to solve the networking problem effectively.</simpara>
 </section>
-<section xml:id="_exercises_20">
+<section xml:id="_exercises_21">
 <title>Exercises</title>
+<simpara><emphasis role="strong">Conceptual Problems</emphasis></simpara>
 <orderedlist numeration="arabic">
 <listitem>
-<simpara>Why are there so many similarities between the network I/O and the
+<simpara><anchor xml:id="exercise21.1" xreflabel="[exercise21.1]"/> Why are there so many similarities between the network I/O and the
 file I/O APIs in Java?</simpara>
 </listitem>
 <listitem>
-<simpara>Explain the difference between client and server computers in
+<simpara><anchor xml:id="exercise21.2" xreflabel="[exercise21.2]"/> Explain the difference between client and server computers in
 network communication. Is it possible for a single computer to be both a
 client and a server?</simpara>
 </listitem>
 <listitem>
-<simpara>Why is writing a web browser so much more complicated than writing a
+<simpara><anchor xml:id="exercise21.3" xreflabel="[exercise21.3]"/> Why is writing a web browser so much more complicated than writing a
 web server?</simpara>
 </listitem>
 <listitem>
-<simpara>Name and briefly describe the seven layers of the OSI model.</simpara>
+<simpara><anchor xml:id="exercise21.4" xreflabel="[exercise21.4]"/> Name and briefly describe the seven layers of the OSI model.</simpara>
 </listitem>
 <listitem>
-<simpara>Modern computers often have many programs running that are all in
+<simpara><anchor xml:id="exercise21.5" xreflabel="[exercise21.5]"/> Modern computers often have many programs running that are all in
 communication over a network. Since a computer often has only one IP
 address that the outside world can send to, how are messages that arrive
 at the computer connected to the right program?</simpara>
 </listitem>
 <listitem>
-<simpara>What are the most popular choices of protocols at the transport
+<simpara><anchor xml:id="exercise21.6" xreflabel="[exercise21.6]"/> What are the most popular choices of protocols at the transport
 layer of the OSI model? What are the advantages and disadvantages of
 each?</simpara>
 </listitem>
 <listitem>
-<simpara>How many possible IP addresses are there in IPv4? IPv6 addresses are
+<simpara><anchor xml:id="exercise21.7" xreflabel="[exercise21.7]"/> How many possible IP addresses are there in IPv4? IPv6 addresses are
 often written as eight groups of four hexadecimal digits, totaling 32
 hexadecimal digits. How many possible IP addresses are there in IPv6?</simpara>
 <simpara><emphasis role="strong">Programming Practice</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Recall the client and server from Section <xref linkend="subsection:receiving_and_sending_data"/> that, respectively, send 100 <literal>int</literal> values and sum them.
+<simpara><anchor xml:id="exercise21.8" xreflabel="[exercise21.8]"/> Recall the client and server from <xref linkend="_receiving_and_sending_data"/> that, respectively, send 100 <literal>int</literal> values and sum them.
 Rewrite these fragments to send and receive the <literal>int</literal> values in text
 rather than binary format.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:chat_GUI"/> Add a GUI based on <literal>JFrame</literal> for the chat
-program given in Example <xref linkend="example:Chat_client_and_server"/>. Use a
+<simpara><anchor xml:id="exercise21.9" xreflabel="[exercise21.9]"/> Add a GUI based on <literal>JFrame</literal> for the chat
+program given in <xref linkend="chatClientAndServerExample"/>. Use a
 (non-editable) <literal>JTextArea</literal> to display the log of messages, including
 user name. Provide a <literal>JTextField</literal> for entering messages, a <literal>JButton</literal> for
 sending messages, and another <literal>JButton</literal> for closing the network
 connections and ending the program.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:multi-threaded_web_server"/> Study the web server
-implementation from Section <xref linkend="solution:Web_server"/>. Implement a similar
+<simpara><anchor xml:id="exercise21.10" xreflabel="[exercise21.10]"/> Study the web server
+implementation from <xref linkend="_solution_web_server"/>. Implement a similar
 web server which is multi-threaded. Instead of serving each request with
 the same thread that is listening for connections, spawn a new thread to
 handle the request each time a connection is made.</simpara>
 </listitem>
 <listitem>
-<simpara><xref linkend="exercise:thread_pool_web_server"/> One of the weaknesses of the web
+<simpara><anchor xml:id="exercise21.11" xreflabel="[exercise21.11]"/> One of the weaknesses of the web
 server from the previous exercise is that a new thread has to be created
 for each connection. An alternative approach is to create a pool of
 threads to handle requests. Then, when a new request arrives, an idle
@@ -33227,8 +33686,8 @@ exercise to use a fixed pool of 10 worker threads.</simpara>
 <simpara><emphasis role="strong">Experiments</emphasis></simpara>
 </listitem>
 <listitem>
-<simpara>Consider the multi-threaded implementation of a web server from
-Exercise <xref linkend="exercise:multi-threaded_web_server"/>. Can you design an
+<simpara><anchor xml:id="exercise21.12" xreflabel="[exercise21.12]"/> Consider the multi-threaded implementation of a web server from
+<link linkend="exercise21.10">Exercise 21.10</link>. Can you design an
 experiment to measure the average amount of time a client waits to
 receive the requested file? How does this time change from the single
 threaded to the multi-threaded version? If the file size is larger, is


### PR DESCRIPTION
This change should have removed all colons from links (except for explicit HTML URLs).

Hopefully, this step will be useful when converting the book to a PDF or ePub.