### PR TITLE
Added callouts to programs included in several segments

### DIFF
--- a/chunked/chap2.html
+++ b/chunked/chap2.html
@@ -3940,89 +3940,162 @@ assigning values, performing simple arithmetic and more advanced math,
 inputting and outputting data, and using the type system, which includes
 subtle differences between primitive and reference types. Our solution to the
 college cost calculator problem posed at the beginning of the chapter
-uses all of these features at some level.</p>
-</div>
-<div class="paragraph">
-<p>We present this solution below. The first step in our solution is to
-import <code>java.util.*</code> so that we can use the <code>Scanner</code> class. Then, we
-start the enclosing <code>CollegeCosts</code> class, begin the <code>main()</code> method,
-print a welcome message for the user, and create a <code>Scanner</code> object.</p>
+uses all of these features at some level. We present this solution below.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span>
+<pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span> <i class="conum" data-value="1"></i><b>(1)</b>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">CollegeCosts</span> <span class="o">{</span>
-    <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Welcome to the College Cost Calculator!&quot;</span><span class="o">);</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span></code></pre>
+    <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Welcome to the College Cost Calculator!&quot;</span><span class="o">);</span> <i class="conum" data-value="3"></i><b>(3)</b>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span> <i class="conum" data-value="4"></i><b>(4)</b></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The first step in our solution is to
+import <code>java.util.*</code> so that we can use the <code>Scanner</code> class.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>After we start the enclosing <code>CollegeCosts</code> class, we begin the <code>main()</code> method.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>We print a welcome message for the user.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Then, we create a <code>Scanner</code> object.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>Next is a sequence of prompts to the user interspersed with input done
-with the <code>Scanner</code> object. The program reads the user’s first name as a
-<code>String</code>, the user’s last name as a <code>String</code>, the per-semester tuition
-cost as a <code>double</code>, the monthly cost of rent as a <code>double</code>, the monthly
-cost of food as a <code>double</code>, the interest rate for the loan as a
-<code>double</code>, and the number of years needed to pay back the loan as an
-<code>int</code>.</p>
+with the <code>Scanner</code> object.</p>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Enter your first name:\t\t&quot;</span><span class="o">);</span>
-        <span class="n">String</span> <span class="n">firstName</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span>
+        <span class="n">String</span> <span class="n">firstName</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span> <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Enter your last name:\t\t&quot;</span><span class="o">);</span>
-        <span class="n">String</span> <span class="n">lastName</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span>
+        <span class="n">String</span> <span class="n">lastName</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Enter tuition per semester:\t$&quot;</span><span class="o">);</span>
-        <span class="kt">double</span> <span class="n">semesterTuition</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
+        <span class="kt">double</span> <span class="n">semesterTuition</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="3"></i><b>(3)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Enter rent per month:\t\t$&quot;</span><span class="o">);</span>
-        <span class="kt">double</span> <span class="n">monthlyRent</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
+        <span class="kt">double</span> <span class="n">monthlyRent</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="4"></i><b>(4)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Enter food cost per month:\t$&quot;</span><span class="o">);</span>
-        <span class="kt">double</span> <span class="n">monthlyFood</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
+        <span class="kt">double</span> <span class="n">monthlyFood</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="5"></i><b>(5)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Annual interest rate:\t\t&quot;</span><span class="o">);</span>
-        <span class="kt">double</span> <span class="n">annualInterest</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
+        <span class="kt">double</span> <span class="n">annualInterest</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="6"></i><b>(6)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Years to pay back your loan:\t&quot;</span><span class="o">);</span>
-        <span class="kt">int</span> <span class="n">years</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span></code></pre>
+        <span class="kt">int</span> <span class="n">years</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="7"></i><b>(7)</b></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The program reads the user’s first name as a
+<code>String</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>the user’s last name as a <code>String</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>the per-semester tuition cost as a <code>double</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>the monthly cost of rent as a <code>double</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>the monthly cost of food as a <code>double</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="6"></i><b>6</b></td>
+<td>the interest rate for the loan as a <code>double</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="7"></i><b>7</b></td>
+<td>and the number of years needed to pay back the loan as an
+<code>int</code>.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
-<p>The next segment of code completes the computations needed. First, it
-finds the total yearly cost by doubling the semester cost, multiplying
-the monthly rent and food costs by 12, and summing the answers together.
-The four year cost is simply four times the yearly cost. To find the
-monthly payment, we find the monthly interest by dividing the annual
-interest rate by 12 and plugging this value into the formula from the
-beginning of the chapter. Finally, the total cost of the loan is the
-monthly payment times 12 times the number of years.</p>
+<p>The next segment of code completes the computations needed.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="kt">double</span> <span class="n">yearlyCost</span> <span class="o">=</span> <span class="n">semesterTuition</span> <span class="o">*</span> <span class="mf">2.0</span> <span class="o">+</span> <span class="o">(</span><span class="n">monthlyRent</span> <span class="o">+</span> <span class="n">monthlyFood</span><span class="o">)</span> <span class="o">*</span> <span class="mf">12.0</span><span class="o">;</span>
-        <span class="kt">double</span> <span class="n">fourYearCost</span> <span class="o">=</span> <span class="n">yearlyCost</span> <span class="o">*</span> <span class="mf">4.0</span><span class="o">;</span>
-        <span class="kt">double</span> <span class="n">monthlyInterest</span> <span class="o">=</span> <span class="n">annualInterest</span> <span class="o">/</span> <span class="mf">12.0</span><span class="o">;</span>
-        <span class="kt">double</span> <span class="n">monthlyPayment</span> <span class="o">=</span> <span class="n">fourYearCost</span> <span class="o">*</span> <span class="n">monthlyInterest</span> <span class="o">/</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="kt">double</span> <span class="n">yearlyCost</span> <span class="o">=</span> <span class="n">semesterTuition</span> <span class="o">*</span> <span class="mf">2.0</span> <span class="o">+</span> <span class="o">(</span><span class="n">monthlyRent</span> <span class="o">+</span> <span class="n">monthlyFood</span><span class="o">)</span> <span class="o">*</span> <span class="mf">12.0</span><span class="o">;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="kt">double</span> <span class="n">fourYearCost</span> <span class="o">=</span> <span class="n">yearlyCost</span> <span class="o">*</span> <span class="mf">4.0</span><span class="o">;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="kt">double</span> <span class="n">monthlyInterest</span> <span class="o">=</span> <span class="n">annualInterest</span> <span class="o">/</span> <span class="mf">12.0</span><span class="o">;</span> <i class="conum" data-value="3"></i><b>(3)</b>
+        <span class="kt">double</span> <span class="n">monthlyPayment</span> <span class="o">=</span> <span class="n">fourYearCost</span> <span class="o">*</span> <span class="n">monthlyInterest</span> <span class="o">/</span> <i class="conum" data-value="4"></i><b>(4)</b>
             <span class="o">(</span><span class="mf">1.0</span> <span class="o">-</span> <span class="n">Math</span><span class="o">.</span><span class="na">pow</span><span class="o">(</span><span class="mf">1.0</span> <span class="o">+</span> <span class="n">monthlyInterest</span><span class="o">,</span> <span class="o">-</span><span class="n">years</span> <span class="o">*</span> <span class="mf">12.0</span><span class="o">));</span>
-        <span class="kt">double</span> <span class="n">totalLoanCost</span> <span class="o">=</span> <span class="n">monthlyPayment</span> <span class="o">*</span> <span class="mf">12.0</span> <span class="o">*</span> <span class="n">years</span><span class="o">;</span></code></pre>
+        <span class="kt">double</span> <span class="n">totalLoanCost</span> <span class="o">=</span> <span class="n">monthlyPayment</span> <span class="o">*</span> <span class="mf">12.0</span> <span class="o">*</span> <span class="n">years</span><span class="o">;</span> <i class="conum" data-value="5"></i><b>(5)</b></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>It finds the total yearly cost by doubling the semester cost, multiplying
+the monthly rent and food costs by 12, and summing the answers together.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The four year cost is simply four times the yearly cost.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>To find the monthly payment, we find the monthly interest by dividing the annual
+interest rate by 12 and plugging this value into the formula from the
+beginning of the chapter.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Finally, the total cost of the loan is the
+monthly payment times 12 times the number of years.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
-<p>All that remains is to print out the output. First, we output a header
-describing the following output as college costs for the user. Using
-<code>System.out.format()</code> as described in <a href="#_primitive_types">Section 3.3.2</a>, we print out the yearly cost, four year cost, monthly loan
-payment, and total cost, all formatted with dollar signs, two places after
-the decimal point, and tabs so that the output lines up.</p>
+<p>All that remains is to print out the output.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;\nCollege costs for &quot;</span> <span class="o">+</span> <span class="n">firstName</span> <span class="o">+</span> <span class="s">&quot; &quot;</span> <span class="o">+</span> <span class="n">lastName</span> <span class="o">);</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;\nCollege costs for &quot;</span> <span class="o">+</span> <span class="n">firstName</span> <span class="o">+</span> <span class="s">&quot; &quot;</span> <span class="o">+</span> <span class="n">lastName</span> <span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;***************************************&quot;</span><span class="o">);</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">&quot;Yearly cost:\t\t\t$%.2f%n&quot;</span><span class="o">,</span> <span class="n">yearlyCost</span><span class="o">);</span>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">&quot;Yearly cost:\t\t\t$%.2f%n&quot;</span><span class="o">,</span> <span class="n">yearlyCost</span><span class="o">);</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">&quot;Four year cost:\t\t\t$%.2f%n&quot;</span><span class="o">,</span> <span class="n">fourYearCost</span><span class="o">);</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">&quot;Monthly loan payment:\t\t$%.2f%n&quot;</span><span class="o">,</span> <span class="n">monthlyPayment</span><span class="o">);</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">&quot;Total loan cost:\t\t$%.2f%n&quot;</span><span class="o">,</span> <span class="n">totalLoanCost</span> <span class="o">);</span>
     <span class="o">}</span>
 <span class="o">}</span></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>First, we output a header
+describing the following output as college costs for the user.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Using
+<code>System.out.format()</code> as described in <a href="#_primitive_types">Section 3.3.2</a>, we print out the yearly cost, four year cost, monthly loan
+payment, and total cost, all formatted with dollar signs, two places after
+the decimal point, and tabs so that the output lines up.</td>
+</tr>
+</table>
 </div>
 </div>
 <div class="sect2">

--- a/chunked/chap3.html
+++ b/chunked/chap3.html
@@ -2783,43 +2783,63 @@ down the sign.</p>
 the chapter. Recall that objects of the <code>Random</code> class allow us to generate all
 kinds of random values. To implement this simulation successfully, our
 program must make the decisions needed to set up the game for the
-user as well as respond to the user’s input. We begin with the <code>import</code>
-statement needed to use both the <code>Scanner</code> and <code>Random</code> class
-and then define the <code>MontyHall</code> class.</p>
+user as well as respond to the user’s input.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span>
+<pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span> <i class="conum" data-value="1"></i><b>(1)</b>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">MontyHall</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
         <span class="n">Random</span> <span class="n">random</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Random</span><span class="o">();</span>
-        <span class="kt">int</span> <span class="n">winner</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="na">nextInt</span><span class="o">(</span><span class="mi">3</span><span class="o">);</span>
+        <span class="kt">int</span> <span class="n">winner</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="na">nextInt</span><span class="o">(</span><span class="mi">3</span><span class="o">);</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Choose a door (enter 0, 1, or 2): &quot;</span><span class="o">);</span>
-        <span class="kt">int</span> <span class="n">choice</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-        <span class="kt">int</span> <span class="n">alternative</span><span class="o">;</span>
+        <span class="kt">int</span> <span class="n">choice</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="3"></i><b>(3)</b>
+        <span class="kt">int</span> <span class="n">alternative</span><span class="o">;</span> <i class="conum" data-value="4"></i><b>(4)</b>
         <span class="kt">int</span> <span class="n">open</span><span class="o">;</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>In the <code>main()</code> method we first decide which of the three doors is the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>We begin with the <code>import</code>
+statement needed to use both the <code>Scanner</code> and <code>Random</code> class
+and then define the <code>MontyHall</code> class.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>In the <code>main()</code> method we first decide which of the three doors is the
 winner. To do so, we instantiate a <code>Random</code> object and use it to
 generate a random number that is either 0, 1, or 2 by calling the
 <code>nextInt()</code> method with an argument of <code>3</code>. We could have added 1 to
 this value to get a random choice of 1, 2, or 3, but many counting
-systems in computer science start with 0 instead of 1. You might as well
-get used to it. Next, we prompt the user to pick from the three doors
-and read the choice. Finally, we declare two more <code>int</code> values to keep
+systems in computer science start with 0 instead of 1. We might as well
+embrace it.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Next, we prompt the user to pick from the three doors
+and read the choice.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Finally, we declare two more <code>int</code> values to keep
 track of which door to open and which door is the alternative that the
-user can choose to change over to.</p>
+user can choose to change over to.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Now, we have to navigate a complicated series of decisions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="n">winner</span> <span class="o">)</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="n">winner</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="kt">int</span> <span class="n">low</span><span class="o">;</span>
             <span class="kt">int</span> <span class="n">high</span><span class="o">;</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span>  <span class="mi">0</span> <span class="o">)</span> <span class="o">{</span>
+            <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span>  <span class="mi">0</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
                 <span class="n">low</span> <span class="o">=</span> <span class="mi">1</span><span class="o">;</span>
                 <span class="n">high</span> <span class="o">=</span> <span class="mi">2</span><span class="o">;</span>
             <span class="o">}</span>
@@ -2832,34 +2852,54 @@ user can choose to change over to.</p>
                 <span class="n">high</span> <span class="o">=</span> <span class="mi">1</span><span class="o">;</span>
             <span class="o">}</span>
             <span class="c1">//randomly choose between other two doors</span>
-            <span class="kt">double</span> <span class="n">threshold</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">threshold</span> <span class="o">&lt;</span> <span class="mf">0.5</span> <span class="o">)</span> <span class="o">{</span>
+            <span class="kt">double</span> <span class="n">threshold</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="3"></i><b>(3)</b>
+            <span class="k">if</span><span class="o">(</span> <span class="n">threshold</span> <span class="o">&lt;</span> <span class="mf">0.5</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="4"></i><b>(4)</b>
                 <span class="n">alternative</span> <span class="o">=</span> <span class="n">low</span><span class="o">;</span>
                 <span class="n">open</span> <span class="o">=</span> <span class="n">high</span><span class="o">;</span>
             <span class="o">}</span>
-            <span class="k">else</span> <span class="o">{</span>
+            <span class="k">else</span> <span class="o">{</span> <i class="conum" data-value="5"></i><b>(5)</b>
                 <span class="n">alternative</span> <span class="o">=</span> <span class="n">high</span><span class="o">;</span>
                 <span class="n">open</span> <span class="o">=</span> <span class="n">low</span><span class="o">;</span>
             <span class="o">}</span>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>Now, we have to navigate a complicated series of decisions. In this
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>In this
 segment of code, we tackle the possibility that the user happened
 to choose the winning door. To obey the rules of the game, we must
-randomly pick which of the two other doors to open. First, we determine
+randomly pick which of the two other doors to open.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>First, we determine
 which are the other two doors and save them in <code>low</code> and <code>high</code>,
-respectively. Then, we generated a random number. If the random number
+respectively.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Then, we generate a random number.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>If the random number
 is less than 0.5, we keep the lower numbered door as an alternative
-choice for the user and open the higher numbered door. If the random
-number is greater than or equal to 0.5, we do the opposite.</p>
+choice for the user and open the higher numbered door.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>If the random number is greater than or equal to 0.5, we do the opposite.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">else</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">else</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="n">alternative</span> <span class="o">=</span> <span class="n">winner</span><span class="o">;</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="mi">0</span> <span class="o">)</span> <span class="o">{</span>
+            <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="mi">0</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
                 <span class="k">if</span><span class="o">(</span> <span class="n">winner</span> <span class="o">==</span> <span class="mi">1</span> <span class="o">)</span>
                     <span class="n">open</span> <span class="o">=</span> <span class="mi">2</span><span class="o">;</span>
                 <span class="k">else</span>
@@ -2880,28 +2920,40 @@ number is greater than or equal to 0.5, we do the opposite.</p>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>This <code>else</code> block covers the case that the player did <strong>not</strong> pick the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>This <code>else</code> block covers the case that the player did <strong>not</strong> pick the
 winning door the first time. Unlike the previous code segment, we no
-longer have a choice of which door to open. Instead, we must always
+longer have a choice of which door to open.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Instead, we must always
 make the winner the alternative for the user to pick. Then, we simply
-determine which door is left over so that we can open it. Note that the
+determine which door is left over so that we can open it.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Note that the
 braces surrounding the blocks for each of the braces surrounding the
 blocks for each of the three possible values of <code>choice</code> are not
 necessary but are included for readability.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;We have opened Door &quot;</span> <span class="o">+</span> <span class="n">open</span> <span class="o">+</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;We have opened Door &quot;</span> <span class="o">+</span> <span class="n">open</span> <span class="o">+</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="s">&quot;, and there is junk behind it!&quot;</span><span class="o">);</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Do you want to change to Door &quot;</span> <span class="o">+</span>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Do you want to change to Door &quot;</span> <span class="o">+</span> <i class="conum" data-value="2"></i><b>(2)</b>
             <span class="n">alternative</span> <span class="o">+</span> <span class="s">&quot; from Door &quot;</span> <span class="o">+</span> <span class="n">choice</span> <span class="o">+</span>
             <span class="s">&quot;? (Enter 'y' or 'n'): &quot;</span><span class="o">);</span>
         <span class="n">String</span> <span class="n">change</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span>
         <span class="k">if</span><span class="o">(</span> <span class="n">change</span><span class="o">.</span><span class="na">equals</span><span class="o">(</span><span class="s">&quot;y&quot;</span><span class="o">)</span> <span class="o">)</span>
             <span class="n">choice</span> <span class="o">=</span> <span class="n">alternative</span><span class="o">;</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;You chose Door &quot;</span> <span class="o">+</span> <span class="n">choice</span><span class="o">);</span>
-        <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="n">winner</span> <span class="o">)</span>
+        <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="n">winner</span> <span class="o">)</span> <i class="conum" data-value="3"></i><b>(3)</b>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;You win a pile of gold!&quot;</span><span class="o">);</span>
         <span class="k">else</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;You win a pile of junk.&quot;</span><span class="o">);</span>
@@ -2909,11 +2961,23 @@ necessary but are included for readability.</p>
 <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>This final segment of code informs the user which door has been opened
-and prompts the user to change his or her decision. Depending on the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>This final segment of code informs the user which door has been opened.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>It prompts the user to change his or her decision.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Depending on the
 final choice, the program says whether or not the user wins gold or
-junk.</p>
+junk.</td>
+</tr>
+</table>
 </div>
 </div>
 <div class="sect2">

--- a/chunked/chap4.html
+++ b/chunked/chap4.html
@@ -2116,55 +2116,82 @@ definition.</p>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">DNASearch</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="n">String</span> <span class="n">sequence</span><span class="o">,</span> <span class="n">subsequence</span><span class="o">;</span>
-        <span class="kt">boolean</span> <span class="n">valid</span><span class="o">;</span>
+        <span class="kt">boolean</span> <span class="n">valid</span><span class="o">;</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="kt">char</span> <span class="n">c</span><span class="o">;</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The <code>main()</code> method instantiates a <code>Scanner</code> object and declares both of
-the <code>String</code> variables we’ll need to store the DNA sequences. The method
-also declares a <code>boolean</code> and a <code>char</code> we’ll use for input checking.</p>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The <code>main()</code> method instantiates a <code>Scanner</code> object and declares both of
+the <code>String</code> variables we’ll need to store the DNA sequences.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The method
+also declares a <code>boolean</code> and a <code>char</code> we’ll use for input checking.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="k">do</span> <span class="o">{</span>
-            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span>
-                <span class="s">&quot;Enter the DNA sequence you wish to search in: &quot;</span><span class="o">);</span>
-            <span class="n">sequence</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toUpperCase</span><span class="o">();</span>
+            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Enter the DNA sequence you wish to search in: &quot;</span><span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="n">sequence</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toUpperCase</span><span class="o">();</span> <i class="conum" data-value="2"></i><b>(2)</b>
             <span class="n">valid</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span> <span class="n">valid</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span> <span class="n">valid</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="3"></i><b>(3)</b>
                 <span class="n">c</span> <span class="o">=</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span><span class="o">);</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'A'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'C'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'G'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'T'</span><span class="o">)</span> <span class="o">{</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">c</span> <span class="o">!=</span> <span class="sc">'A'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'C'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'G'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'T'</span><span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="4"></i><b>(4)</b>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Invalid DNA sequence!&quot;</span><span class="o">);</span>
                     <span class="n">valid</span> <span class="o">=</span> <span class="kc">false</span><span class="o">;</span>
                 <span class="o">}</span>
             <span class="o">}</span>
-        <span class="o">}</span> <span class="k">while</span><span class="o">(</span> <span class="o">!</span><span class="n">valid</span> <span class="o">);</span></code></pre>
+        <span class="o">}</span> <span class="k">while</span><span class="o">(</span> <span class="o">!</span><span class="n">valid</span> <span class="o">);</span> <i class="conum" data-value="5"></i><b>(5)</b></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>Next, the user is prompted for a DNA sequence to search in. This
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Next, the user is prompted for a DNA sequence to search in.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>This
 <code>String</code> stored in <code>sequence</code> is converted to upper case just in case
-the user is not being consistent. The inner <code>for</code> loop in this code is
-checking each <code>char</code> inside of <code>sequence</code>. If any <code>char</code> is not an
+the user is not being consistent.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>The inner <code>for</code> loop in this code checks each <code>char</code> inside of <code>sequence</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>If any <code>char</code> is not an
 <code>'A'</code>, <code>'C'</code>, <code>'G'</code>, or <code>'T'</code>, then <code>valid</code> is set to <code>false</code>. As a
 result, the <code>for</code> loop terminates. Also, the <code>do-while</code> loop repeats the
-prompt and gets a new <code>String</code> for <code>sequence</code> from the user. This outer
+prompt and gets a new <code>String</code> for <code>sequence</code> from the user.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>This outer
 <code>do-while</code> loop continues as long as the user keeps entering invalid DNA
-sequences.</p>
+sequences.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="k">do</span> <span class="o">{</span>
-            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span>
-                <span class="s">&quot;Enter the subsequence you wish to search for: &quot;</span><span class="o">);</span>
+            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Enter the subsequence you wish to search for: &quot;</span><span class="o">);</span>
             <span class="n">subsequence</span>  <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toUpperCase</span><span class="o">();</span>
             <span class="n">valid</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
             <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span> <span class="n">valid</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span>
                 <span class="n">c</span> <span class="o">=</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span><span class="o">);</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'A'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'C'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'G'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'T'</span><span class="o">)</span> <span class="o">{</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">c</span> <span class="o">!=</span> <span class="sc">'A'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'C'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'G'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'T'</span><span class="o">)</span> <span class="o">{</span>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Invalid DNA sequence!&quot;</span><span class="o">);</span>
                     <span class="n">valid</span> <span class="o">=</span> <span class="kc">false</span><span class="o">;</span>
                 <span class="o">}</span>
@@ -2179,12 +2206,11 @@ virtually identical to the code to input <code>sequence</code>.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="kt">int</span> <span class="n">found</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span>
-            <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">();</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-                <span class="k">if</span><span class="o">(</span><span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">!=</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">))</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">();</span> <span class="n">j</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">if</span><span class="o">(</span><span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">!=</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">))</span> <i class="conum" data-value="3"></i><b>(3)</b>
                     <span class="k">break</span><span class="o">;</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="mi">1</span> <span class="o">)</span> <span class="o">{</span> <span class="c1">//matches</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="mi">1</span><span class="o">)</span> <span class="o">{</span> <span class="c1">//matches </span><i class="conum" data-value="4"></i><b>(4)</b>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Match found at index &quot;</span> <span class="o">+</span> <span class="n">i</span><span class="o">);</span>
                     <span class="n">found</span><span class="o">++;</span>
                 <span class="o">}</span>
@@ -2192,8 +2218,11 @@ virtually identical to the code to input <code>sequence</code>.</p>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The actual workhorse of the search is found in these nested <code>for</code> loops.
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The workhorse of the search is found in these nested <code>for</code> loops.
 The outer loop iterates through every index in <code>sequence</code>, until it
 comes to an index that is too late to be the start of a new subsequence
 (since the subsequence would be too long to fit anymore). This happens
@@ -2205,18 +2234,29 @@ the same length, you need to check starting at index <code>0</code> of <code>seq
 but not any later indexes. Also, if <code>subsequence</code> is one <code>char</code> longer
 than <code>sequence</code>, there can never be a match. In that case, the value of
 <code>sequence.length() - subsequence.length() + 1</code> would be <code>0</code>. Since <code>0</code>
-is not less than <code>0</code>, the outer <code>for</code> loop would never execute.</p>
-</div>
-<div class="paragraph">
-<p>The inner <code>for</code> loop iterates through the length of <code>subsequence</code>,
+is not less than <code>0</code>, the outer <code>for</code> loop would never execute.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The inner <code>for</code> loop iterates through the length of <code>subsequence</code>,
 making sure that every <code>char</code> in <code>sequence</code>, starting at the appropriate
-offset, exactly matches a <code>char</code> in <code>subsequence</code>. If, at any point, the
+offset, exactly matches a <code>char</code> in <code>subsequence</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>If, at any point, the
 two <code>char</code> values do not match, the inner <code>for</code> loop will immediately
-exit, using the <code>break</code> command. However, on the last iteration of the
+exit, using the <code>break</code> command.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>However, on the last iteration of the
 inner <code>for</code> loop, when <code>j</code> is one less than the length of <code>subsequence</code>,
 we know that all of <code>subsequence</code> matched a part of <code>sequence</code>. As a
 result, we print out the index of <code>sequence</code> where <code>subsequence</code> started
-and increment the <code>found</code> counter.</p>
+and increment the <code>found</code> counter.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>If you know the <code>String</code> class well, you can use the <code>indexOf()</code> method
@@ -2229,20 +2269,20 @@ to replace the inner <code>for</code> loop. We leave that approach as an exercis
 </div>
 </div>
 </div>
+<div class="paragraph">
+<p>Finally, we print out the total number of matches found. In order to
+avoid awkward output like <code>1 matches found.</code>, we used an <code>if</code>-<code>else</code> to
+customize the output based on the value of <code>found</code>.</p>
+</div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">if</span><span class="o">(</span> <span class="n">found</span> <span class="o">==</span> <span class="mi">1</span> <span class="o">)</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">if</span><span class="o">(</span><span class="n">found</span> <span class="o">==</span> <span class="mi">1</span><span class="o">)</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;One match found.&quot;</span><span class="o">);</span>
         <span class="k">else</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">found</span> <span class="o">+</span> <span class="s">&quot; matches found.&quot;</span><span class="o">);</span>
     <span class="o">}</span>
 <span class="o">}</span></code></pre>
 </div>
-</div>
-<div class="paragraph">
-<p>Finally, we print out the total number of matches found. In order to
-avoid awkward output like <code>1 matches found.</code>, we used an <code>if</code>-<code>else</code> to
-customize the output based on the value of <code>found</code>.</p>
 </div>
 <div class="paragraph">
 <p>The ideas needed to correctly implement the solution are not difficult,
@@ -2254,11 +2294,10 @@ follows.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java"><span class="kt">int</span> <span class="n">found</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
-<span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span>
-    <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-    <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span>
-        <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">==</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">);</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
-        <span class="k">if</span><span class="o">(</span> <span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="mi">1</span> <span class="o">)</span> <span class="o">{</span> <span class="c1">//matches</span>
+<span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span>
+    <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span>
+        <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">==</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">);</span> <span class="n">j</span><span class="o">++)</span>
+        <span class="k">if</span><span class="o">(</span><span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="mi">1</span><span class="o">)</span> <span class="o">{</span> <span class="c1">//matches</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Match found at index &quot;</span> <span class="o">+</span> <span class="n">i</span><span class="o">);</span>
             <span class="n">found</span><span class="o">++;</span>
         <span class="o">}</span>
@@ -2275,11 +2314,10 @@ matching process is done outside of the inner <code>for</code> loop.</p>
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java"><span class="kt">int</span> <span class="n">found</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
 <span class="kt">int</span> <span class="n">j</span><span class="o">;</span>
-<span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span>
-    <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-    <span class="k">for</span><span class="o">(</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span>
-        <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">==</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">);</span> <span class="n">j</span><span class="o">++</span> <span class="o">);</span>
-    <span class="k">if</span><span class="o">(</span> <span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">)</span> <span class="o">{</span> <span class="c1">//matches</span>
+<span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span>
+    <span class="k">for</span><span class="o">(</span><span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span>
+        <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">==</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">);</span> <span class="n">j</span><span class="o">++);</span>
+    <span class="k">if</span><span class="o">(</span><span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">())</span> <span class="o">{</span> <span class="c1">//matches</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Match found at index &quot;</span> <span class="o">+</span> <span class="n">i</span><span class="o">);</span>
         <span class="n">found</span><span class="o">++;</span>
     <span class="o">}</span>
@@ -2289,8 +2327,8 @@ matching process is done outside of the inner <code>for</code> loop.</p>
 <div class="paragraph">
 <p>In this case, note that we must declare <code>j</code> outside of the inner <code>for</code>
 loop, since it will be used outside. This approach is more efficient
-because we only need to perform the check once. Notice also that the
-condition of the <code>if</code> statement has changed. Now, we know that all of
+because we only need to perform the check once. Notice that the
+condition of the <code>if</code> statement has also changed. Now, we know that all of
 <code>subsequence</code> matches because the loop ran to completion. If the loop
 did not run to completion, then <code>j</code> would be smaller than
 <code>subsequence.length()</code> and the loop must have terminated because the two

--- a/chunked/chap5.html
+++ b/chunked/chap5.html
@@ -1538,7 +1538,7 @@ of the array is \(n\), we’ll need to look for the smallest
 element in the array \(n - 1\) times. By putting the code that
 searches for the smallest value inside of an outer loop, we can write a
 program that does selection sort of <code>int</code> values input by the user as
-follows.</p>
+follows. This program’s not very long, but there’s a lot going on.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -1546,58 +1546,87 @@ follows.</p>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">SelectionSort</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
-        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-        <span class="kt">int</span><span class="o">[]</span> <span class="n">values</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span>
+        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="kt">int</span><span class="o">[]</span> <span class="n">values</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="kt">int</span> <span class="n">smallest</span><span class="o">;</span>
         <span class="kt">int</span> <span class="n">temp</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <i class="conum" data-value="3"></i><b>(3)</b>
             <span class="n">values</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>This program is not very long, but there’s a lot going on. After
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>After
 instantiating a <code>Scanner</code>, we read in the total number of values the
 list will hold. We cannot rely on the <code>hasNextInt()</code> method to tell us
-when to stop reading values. We need to know up front how many values we
+when to stop reading values.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>We need to know up front how many values we
 are going to store so that we can instantiate our array with the
-appropriate length. Then, we read each value into the array using the
-first <code>for</code> loop.</p>
+appropriate length.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Then, we read each value into the array using the
+first <code>for</code> loop.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="n">smallest</span> <span class="o">=</span> <span class="n">i</span><span class="o">;</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">values</span><span class="o">[</span><span class="n">j</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">]</span> <span class="o">)</span>
-                    <span class="n">smallest</span> <span class="o">=</span> <span class="n">j</span><span class="o">;</span>
-            <span class="n">temp</span> <span class="o">=</span> <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">];</span>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">j</span><span class="o">++)</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">if</span><span class="o">(</span><span class="n">values</span><span class="o">[</span><span class="n">j</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">])</span>
+                    <span class="n">smallest</span> <span class="o">=</span> <span class="n">j</span><span class="o">;</span> <i class="conum" data-value="3"></i><b>(3)</b>
+            <span class="n">temp</span> <span class="o">=</span> <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">];</span> <i class="conum" data-value="4"></i><b>(4)</b>
             <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">]</span> <span class="o">=</span> <span class="n">values</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
             <span class="n">values</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">temp</span><span class="o">;</span>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The next <code>for</code> loop is where the actual sort happens. We start at index
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The next <code>for</code> loop is where the actual sort happens. We start at index
 <code>0</code> and then try to find the smallest value to be put in that spot.
 Then, we move on to index <code>1</code>, and so on, just as we described before.
 Note that we only go up to <code>n - 2</code>. We don’t need to find the value to
 put in index <code>n - 1</code>, because the rest of the list has the <code>n - 1</code>
 smallest numbers in it and so the last number <strong>must</strong> already be the
-largest. If you look carefully, you’ll notice that the inner <code>for</code>
+largest.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>If you look carefully, you’ll notice that the inner <code>for</code>
 loop has the same overall shape as the loop used to find the smallest
-value in the previous example; however, there is one key difference:
-Instead of storing the <strong>value</strong> of the smallest number in <code>smallest</code>, we
+value in the previous example; however, there is one key difference:</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Instead of storing the <strong>value</strong> of the smallest number in <code>smallest</code>, we
 now store the <strong>index</strong> of the smallest number. We need to store the index
 of the smallest number so that, in the next step, we can swap the
 corresponding element with the element at <code>i</code>, the spot in the array
-we’re trying to fill. The three lines after the inner <code>for</code> loop are a
-simple swap to do exactly that.</p>
+we’re trying to fill.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>The three lines after the inner <code>for</code> loop are a
+simple swap to do exactly that.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;The sorted list is: &quot;</span><span class="o">);</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="n">values</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot; &quot;</span><span class="o">);</span>
     <span class="o">}</span>
 <span class="o">}</span></code></pre>
@@ -1605,7 +1634,10 @@ simple swap to do exactly that.</p>
 </div>
 <div class="paragraph">
 <p>After all the sorting is done, the final <code>for</code> loop prints out the newly
-sorted list. This program gives no prompts for user input, so it’s well
+sorted list.</p>
+</div>
+<div class="paragraph">
+<p>This program gives no prompts for user input, so it’s well
 designed for input redirection. If you’re going to make a file
 containing numbers you want to sort with this program, make sure that
 the first number is the total count of numbers in the file.</p>
@@ -1647,41 +1679,70 @@ the text we want to search through.</p>
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">WordCount</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
         <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
-        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-        <span class="n">String</span><span class="o">[]</span> <span class="n">words</span> <span class="o">=</span> <span class="k">new</span> <span class="n">String</span><span class="o">[</span><span class="n">n</span><span class="o">];</span>
-        <span class="kt">int</span><span class="o">[]</span> <span class="n">counts</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span>
+        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="n">String</span><span class="o">[]</span> <span class="n">words</span> <span class="o">=</span> <span class="k">new</span> <span class="n">String</span><span class="o">[</span><span class="n">n</span><span class="o">];</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="kt">int</span><span class="o">[]</span> <span class="n">counts</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span> <i class="conum" data-value="3"></i><b>(3)</b>
         <span class="n">String</span> <span class="n">temp</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">words</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">words</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <i class="conum" data-value="4"></i><b>(4)</b>
             <span class="n">words</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toLowerCase</span><span class="o">();</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>As in the last example, this program begins by reading in the length of
-the list of words. Then, it instantiates the <code>String</code> array <code>words</code> to
-hold these words. It also instantiates an array <code>counts</code> of type <code>int</code>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>As in the last example, this program begins by reading in the length of
+the list of words.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Then, it instantiates the <code>String</code> array <code>words</code> to
+hold these words.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>It also instantiates an array <code>counts</code> of type <code>int</code>
 to keep track of the number of times each word is found. By default,
-each element in <code>counts</code> is initialized to <code>0</code>. The first <code>for</code> loop in
-the program reads in each word and stores it into the array <code>words</code>.</p>
+each element in <code>counts</code> is initialized to <code>0</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>The first <code>for</code> loop in
+the program reads in each word and stores it into the array <code>words</code>.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">while</span><span class="o">(</span> <span class="n">in</span><span class="o">.</span><span class="na">hasNext</span><span class="o">()</span> <span class="o">)</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">while</span><span class="o">(</span> <span class="n">in</span><span class="o">.</span><span class="na">hasNext</span><span class="o">()</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="n">temp</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toLowerCase</span><span class="o">();</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <i class="conum" data-value="2"></i><b>(2)</b>
                 <span class="k">if</span><span class="o">(</span> <span class="n">temp</span><span class="o">.</span><span class="na">equals</span><span class="o">(</span> <span class="n">words</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">))</span> <span class="o">{</span>
-                    <span class="n">counts</span><span class="o">[</span><span class="n">i</span><span class="o">]++;</span>
+                    <span class="n">counts</span><span class="o">[</span><span class="n">i</span><span class="o">]++;</span> <i class="conum" data-value="3"></i><b>(3)</b>
                     <span class="k">break</span><span class="o">;</span>
                 <span class="o">}</span>
         <span class="o">}</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;The word counts are: &quot;</span><span class="o">);</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The <code>while</code> loop reads in each word from the text following the list and
-stores it in a variable called <code>temp</code>. Then, it loops through <code>words</code>
-and tests to see if <code>temp</code> matches any of the elements in the list. If
-it does, it increases the value of the element of <code>counts</code> that has the
-same index and breaks out of the inner <code>for</code> loop.</p>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The <code>while</code> loop reads in each word from the text following the list and
+stores it in a variable called <code>temp</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Then, it loops through <code>words</code>
+and tests to see if <code>temp</code> matches any of the elements in the list.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>If it does, it increases the value of the element of <code>counts</code> that has the
+same index and breaks out of the inner <code>for</code> loop.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -1843,40 +1904,65 @@ solve after the previous examples.</p>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">Statistics</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
-        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-        <span class="kt">int</span><span class="o">[]</span> <span class="n">scores</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span>
+        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="kt">int</span><span class="o">[]</span> <span class="n">scores</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <i class="conum" data-value="3"></i><b>(3)</b>
             <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>In our solution, the <code>main()</code> method begins by reading in the total
-number of scores and declaring an <code>int</code> array of that length named
-<code>scores</code>. Then, we read in each of the scores and store them into
-<code>scores</code>.</p>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>In our solution, the <code>main()</code> method begins by reading in the total
+number of scores.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>It declares an <code>int</code> array of that length named
+<code>scores</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Then, we read in each of the scores and store them into
+<code>scores</code>.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="kt">int</span> <span class="n">max</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="kt">int</span> <span class="n">max</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span> <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="kt">int</span> <span class="n">min</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span>
         <span class="kt">int</span> <span class="n">sum</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">&gt;</span> <span class="n">max</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
+            <span class="k">if</span><span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">&gt;</span> <span class="n">max</span><span class="o">)</span>
                 <span class="n">max</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">min</span> <span class="o">)</span>
+            <span class="k">if</span><span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">min</span><span class="o">)</span>
                 <span class="n">min</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
             <span class="n">sum</span> <span class="o">+=</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>Here we declare variables <code>max</code>, <code>min</code>, and <code>sum</code> to hold, respectively,
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Here we declare variables <code>max</code>, <code>min</code>, and <code>sum</code> to hold, respectively,
 the maximum, minimum, and sum of the elements in the array. Then, we set
 all three variables to the value of the first element of the array.
-These initializations make the following code work. In a single <code>for</code>
+These initializations make the following code work.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>In a single <code>for</code>
 loop, we find the maximum, minimum, and sum of all the values in the
-array. We could have done so with three separate loops, but this
+array.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>We could have done so with three separate loops, but this
 approach is more efficient. Setting <code>max</code> and <code>min</code> to <code>scores[0]</code>
 follows the pattern we’ve used before, but setting <code>sum</code> to the same
 value is also necessary in this case. Because the loop iterates from <code>1</code>
@@ -1900,46 +1986,58 @@ statistics we’ve computed.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="kt">double</span> <span class="n">variance</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
-            <span class="n">variance</span> <span class="o">+=</span> <span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">-</span> <span class="n">mean</span><span class="o">)*(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">-</span> <span class="n">mean</span><span class="o">);</span>
-        <span class="n">variance</span> <span class="o">/=</span> <span class="o">(</span><span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">);</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Standard Deviation:\t&quot;</span> <span class="o">+</span> <span class="n">Math</span><span class="o">.</span><span class="na">sqrt</span><span class="o">(</span><span class="n">variance</span><span class="o">));</span></code></pre>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span>
+            <span class="n">variance</span> <span class="o">+=</span> <span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">-</span> <span class="n">mean</span><span class="o">)*(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">-</span> <span class="n">mean</span><span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="n">variance</span> <span class="o">/=</span> <span class="o">(</span><span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">);</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Standard Deviation:\t&quot;</span> <span class="o">+</span> <span class="n">Math</span><span class="o">.</span><span class="na">sqrt</span><span class="o">(</span><span class="n">variance</span><span class="o">));</span> <i class="conum" data-value="3"></i><b>(3)</b></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>At this point, we use the mean we’ve already computed to find the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>At this point, we use the mean we’ve already computed to find the
 sample standard deviation. Following the formula for sample standard
 deviation, we subtract the mean from each score, square the result, and
 add it to a running total. Although the formula for sample standard
 deviation uses the bounds \(1\) to \(n\), we
-translate them to <code>0</code> to <code>n - 1</code> because of zero-based array numbering.
-Dividing the total by <code>n - 1</code> gives the sample variance. Then, the
-square root of the variance is the standard deviation.</p>
+translate them to <code>0</code> to <code>n - 1</code> because of zero-based array numbering.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Dividing the total by <code>n - 1</code> gives the sample variance.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Then, the
+square root of the variance is the standard deviation.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="kt">int</span> <span class="n">temp</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="n">min</span> <span class="o">=</span> <span class="n">i</span><span class="o">;</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">scores</span><span class="o">[</span><span class="n">j</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">scores</span><span class="o">[</span><span class="n">min</span><span class="o">]</span> <span class="o">)</span>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">j</span><span class="o">++)</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">j</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">scores</span><span class="o">[</span><span class="n">min</span><span class="o">])</span>
                     <span class="n">min</span> <span class="o">=</span> <span class="n">j</span><span class="o">;</span>
             <span class="n">temp</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">min</span><span class="o">];</span>
             <span class="n">scores</span><span class="o">[</span><span class="n">min</span><span class="o">]</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
             <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">temp</span><span class="o">;</span>
-        <span class="o">}</span>
-        <span class="kt">double</span> <span class="n">median</span><span class="o">;</span>
-        <span class="k">if</span><span class="o">(</span> <span class="n">n</span> <span class="o">%</span> <span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span> <span class="o">)</span>
-            <span class="n">median</span> <span class="o">=</span> <span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span><span class="o">]</span> <span class="o">+</span> <span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span> <span class="o">+</span> <span class="mi">1</span><span class="o">])/</span><span class="mf">2.0</span><span class="o">;</span>
-        <span class="k">else</span>
-            <span class="n">median</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span><span class="o">];</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Median:\t\t\t&quot;</span> <span class="o">+</span> <span class="n">median</span><span class="o">);</span>
-    <span class="o">}</span>
-<span class="o">}</span></code></pre>
+        <span class="o">}</span></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>To find the median, we use our selection sort code.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
-<p>To find the median, we use our selection sort code. Note that we have
+<p>Note that we have
 reused the variable <code>min</code> to hold the smallest value found so far,
 instead of declaring a new variable such as <code>smallest</code>. Some programmers
 might object to doing so, since we run the risk of interpreting the
@@ -1947,20 +2045,45 @@ variable as the minimum value in the entire array, as it was before.
 Either approach is fine. If you worry about confusing people reading
 your code, add a comment.</p>
 </div>
-<div class="paragraph">
-<p>After the array has been sorted, we need to do a quick check to see if
-its length is odd or even. If its length is even, we need to find the
-average of the two middle elements. If its length is odd, we can report
-the value of the single middle element.</p>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java">        <span class="kt">double</span> <span class="n">median</span><span class="o">;</span>
+        <span class="k">if</span><span class="o">(</span><span class="n">n</span> <span class="o">%</span> <span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span><span class="o">)</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="n">median</span> <span class="o">=</span> <span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span><span class="o">]</span> <span class="o">+</span> <span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span> <span class="o">+</span> <span class="mi">1</span><span class="o">])/</span><span class="mf">2.0</span><span class="o">;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="k">else</span>
+            <span class="n">median</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span><span class="o">];</span> <i class="conum" data-value="3"></i><b>(3)</b>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Median:\t\t\t&quot;</span> <span class="o">+</span> <span class="n">median</span><span class="o">);</span>
+    <span class="o">}</span>
+<span class="o">}</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>After the array has been sorted, we need to do a quick check to see if
+its length is odd or even.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>If its length is even, we need to find the average of the two middle elements.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>If its length is odd, we can report the value of the single middle element.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>Note that some of the statistics we found, such as the maximum, minimum,
-or mean, could be computed using loops without an array for storage.
-However, the last two tasks need to store all of the values at once in
-order to work. The simplest way to find the sample standard deviation of a list of values
-requires its mean. At least two passes over the data are needed to
-compute the sample standard deviation: one to find the mean and another
-to apply the equation for sample standard deviation.</p>
+or mean, could be computed with a single pass over the data
+without the need for an array for storage.
+However, the last two tasks need to store all the values to work.
+The simplest way to find the sample standard deviation of a list of values
+requires its mean, requiring one pass to find the mean and a second
+to sum the squares of the difference of the mean and each value.
+Likewise, it’s impossible to find the median of a list of values without
+storing the list.</p>
 </div>
 <div class="sidebarblock">
 <div class="content">
@@ -3026,60 +3149,58 @@ checkers, chess, or Go. Our program will catch any attempt to play on a
 location that has already been played and will determine the winner, if
 there is one.</p>
 </div>
+<div class="paragraph">
+<p>Games often give rise to complex programs, since rules that are
+intuitively obvious to humans may be difficult to state explicitly in
+Java. Our program begins by setting up quite a few variables and
+objects.</p>
+</div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">TicTacToe</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
-        <span class="kt">char</span><span class="o">[][]</span> <span class="n">board</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">char</span><span class="o">[</span><span class="mi">3</span><span class="o">][</span><span class="mi">3</span><span class="o">];</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">].</span><span class="na">length</span><span class="o">;</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span>  <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="kt">char</span><span class="o">[][]</span> <span class="n">board</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">char</span><span class="o">[</span><span class="mi">3</span><span class="o">][</span><span class="mi">3</span><span class="o">];</span>      <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <i class="conum" data-value="3"></i><b>(3)</b>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">].</span><span class="na">length</span><span class="o">;</span> <span class="n">j</span><span class="o">++)</span>
                 <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="n">j</span><span class="o">]</span> <span class="o">=</span> <span class="sc">' '</span><span class="o">;</span>
-        <span class="kt">boolean</span> <span class="n">turn</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
+        <span class="kt">boolean</span> <span class="n">turn</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>        <i class="conum" data-value="4"></i><b>(4)</b>
         <span class="kt">boolean</span> <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">false</span><span class="o">;</span>
-        <span class="kt">int</span> <span class="n">row</span><span class="o">,</span> <span class="n">column</span><span class="o">,</span> <span class="n">moves</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
+        <span class="kt">int</span> <span class="n">row</span><span class="o">,</span> <span class="n">column</span><span class="o">,</span> <span class="n">moves</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <i class="conum" data-value="5"></i><b>(5)</b>
         <span class="kt">char</span> <span class="n">shape</span><span class="o">;</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>Games often give rise to complex programs, since rules that are
-intuitively obvious to humans may be difficult to state explicitly in
-Java. Our program begins by setting up quite a few variables and
-objects. First, we create a <code>Scanner</code> to read in data. Then, we declare
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>First, we create a <code>Scanner</code> to read in data.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Then, we declare
 and instantiate our 3 × 3 playing board as a
-two-dimensional array of type <code>char</code>. We want any unplayed space on the
-grid to be the <code>char</code> for a space, so we fill the array with <code>' '</code>.
-Next, we declare a <code>boolean</code> value to keep track of whose turn it is and
-another to keep track of whether the game is over. Finally, we
+two-dimensional array of type <code>char</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>We want any unplayed space on the
+grid to be the <code>char</code> for a space, so we fill the array with <code>' '</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Next, we declare a <code>boolean</code> value to keep track of whose turn it is and
+another to keep track of whether the game is over.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>Finally, we
 declare variables to hold the row, the column, the number of moves that
-have been made so far and the current shape (<code>'X'</code> or <code>'O'</code>).</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">while</span><span class="o">(</span> <span class="o">!</span><span class="n">gameOver</span> <span class="o">)</span> <span class="o">{</span>
-            <span class="n">shape</span> <span class="o">=</span> <span class="n">turn</span> <span class="o">?</span> <span class="sc">'X'</span> <span class="o">:</span> <span class="sc">'O'</span><span class="o">;</span>
-            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="n">shape</span> <span class="o">+</span> <span class="s">&quot;'s turn.  Enter row (0-2): &quot;</span><span class="o">);</span>
-            <span class="n">row</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Enter column (0-2): &quot;</span><span class="o">);</span>
-            <span class="n">column</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">!=</span> <span class="sc">' '</span> <span class="o">)</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Illegal move&quot;</span><span class="o">);</span>
-            <span class="k">else</span> <span class="o">{</span>
-                <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="n">shape</span><span class="o">;</span>
-                <span class="n">moves</span><span class="o">++;</span>
-                <span class="n">turn</span> <span class="o">=</span> <span class="o">!</span><span class="n">turn</span><span class="o">;</span>
-                <span class="c1">//print board</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span>
-                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">2</span><span class="o">]);</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;-----&quot;</span><span class="o">);</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span>
-                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">2</span><span class="o">]);</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;-----&quot;</span><span class="o">);</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span>
-                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;\n&quot;</span><span class="o">);</span></code></pre>
-</div>
+have been made so far and the current shape (<code>'X'</code> or <code>'O'</code>).</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>The core of the game is a <code>while</code> loop that runs until <code>gameOver</code>
@@ -3103,40 +3224,88 @@ It’s perfect for situations like this where one value is needed when
 <code>turn</code> is <code>true</code> and another is needed when <code>turn</code> is <code>false</code>. The
 ternary operator is a useful trick, but it shouldn’t be overused.</p>
 </div>
-<div class="paragraph">
-<p>After assigning the appropriate value to <code>shape</code>, our code reads in the
-row and column values for the current player’s next move. If the row and
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">while</span><span class="o">(!</span><span class="n">gameOver</span><span class="o">)</span>
+            <span class="n">shape</span> <span class="o">=</span> <span class="n">turn</span> <span class="o">?</span> <span class="sc">'X'</span> <span class="o">:</span> <span class="sc">'O'</span><span class="o">;</span>
+            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="n">shape</span> <span class="o">+</span> <span class="s">&quot;'s turn.  Enter row (0-2): &quot;</span><span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="n">row</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
+            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;Enter column (0-2): &quot;</span><span class="o">);</span>
+            <span class="n">column</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
+            <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">!=</span> <span class="sc">' '</span><span class="o">)</span>   <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Illegal move&quot;</span><span class="o">);</span>
+            <span class="k">else</span> <span class="o">{</span>
+                <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="n">shape</span><span class="o">;</span> <i class="conum" data-value="3"></i><b>(3)</b>
+                <span class="n">moves</span><span class="o">++;</span>
+                <span class="n">turn</span> <span class="o">=</span> <span class="o">!</span><span class="n">turn</span><span class="o">;</span>
+                <span class="c1">//print board </span><i class="conum" data-value="4"></i><b>(4)</b>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span>
+                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">2</span><span class="o">]);</span>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;-----&quot;</span><span class="o">);</span>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span>
+                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">2</span><span class="o">]);</span>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;-----&quot;</span><span class="o">);</span>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span>
+                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;|&quot;</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">+</span> <span class="s">&quot;\n&quot;</span><span class="o">);</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>After assigning the appropriate value to <code>shape</code>, our code reads in the
+row and column values for the current player’s next move.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>If the row and
 column selected correspond to a spot that’s already been taken, the
-program gives an error message. Otherwise, the program sets
+program gives an error message.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Otherwise, the program sets
 <code>board[row][column]</code> to the appropriate symbol, increments <code>moves</code>, and
-changes the value of <code>turn</code>. Then, it prints out the board. We point out
-that our program does not do any bounds checking on <code>row</code> and <code>column</code>.
+changes the value of <code>turn</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Then, it prints out the board.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Our program doesn’t do any bounds checking on <code>row</code> and <code>column</code>.
 If a user tries to place a move at row 5 column 3, our program will try
-to do so and crash. Four additional clauses in the <code>if</code> statement could
+to do so and crash. Additional clauses in the <code>if</code> statement could
 be used to add bounds checking.</p>
+</div>
+<div class="paragraph">
+<p>Perhaps the trickiest part of our tic-tac-toe program is checking for a
+win.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">                <span class="c1">//check rows</span>
-                <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+<pre class="rouge highlight"><code data-lang="java">                <span class="c1">//check rows      </span><i class="conum" data-value="1"></i><b>(1)</b>
+                <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span>
                     <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
                         <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">)</span>
                         <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-                <span class="c1">//check columns</span>
-                <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">].</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+                <span class="c1">//check columns   </span><i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">].</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span>
                     <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="n">i</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="n">i</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
-                        <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="n">i</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">)</span>
+                        <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="n">i</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span><span class="o">)</span>
                         <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-                <span class="c1">//check diagonals</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
-                    <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">)</span>
+                <span class="c1">//check diagonals </span><i class="conum" data-value="3"></i><b>(3)</b>
+                <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
+                    <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span><span class="o">)</span>
                     <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
-                    <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">)</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
+                    <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span><span class="o">)</span>
                     <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">gameOver</span> <span class="o">)</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">gameOver</span><span class="o">)</span>         <i class="conum" data-value="4"></i><b>(4)</b>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">shape</span> <span class="o">+</span> <span class="s">&quot; wins!&quot;</span><span class="o">);</span>
-                <span class="k">else</span> <span class="nf">if</span><span class="o">(</span> <span class="n">moves</span> <span class="o">==</span> <span class="mi">9</span> <span class="o">){</span>
+                <span class="k">else</span> <span class="nf">if</span><span class="o">(</span><span class="n">moves</span> <span class="o">==</span> <span class="mi">9</span><span class="o">){</span> <i class="conum" data-value="5"></i><b>(5)</b>
                     <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Tie game!&quot;</span><span class="o">);</span>
                 <span class="o">}</span>
@@ -3146,16 +3315,38 @@ be used to add bounds checking.</p>
 <span class="o">}</span></code></pre>
 </div>
 </div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>First we check each row to see if it contains three in a row.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Then, we check each column.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Finally, we check the two diagonals.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>If any of
+those checks ended the game, we announce a winner.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>Otherwise, if the
+number of moves has reached 9 with no winner, it must be a tie game.</td>
+</tr>
+</table>
+</div>
 <div class="paragraph">
-<p>Perhaps the trickiest part of our tic-tac-toe program is checking for a
-win. First we check each row to see if it contains three in a row. Then,
-we check each column. Finally, we check the two diagonals. If any of
-those checks ended the game, we announce a winner. Otherwise, if the
-number of moves has reached 9 with no winner, it must be a tie game. In
+<p>In
 a larger game (such as Connect Four), we would want to find better ways
 to automate checking rows, columns, and diagonals. For example, we wouldn’t
 want to check the entirety of a larger board each move.
-Instead, we could focus only on rows, columns, and diagonals
+Instead, we could focus only on the rows, columns, and diagonals
 affected by the last move.</p>
 </div>
 </div>
@@ -3358,54 +3549,78 @@ columns, although it would be easy to change those dimensions.</p>
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java"><span class="kd">public</span> <span class="kd">class</span> <span class="nc">Life</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="kd">final</span> <span class="kt">int</span> <span class="n">ROWS</span> <span class="o">=</span> <span class="mi">24</span><span class="o">;</span>
+        <span class="kd">final</span> <span class="kt">int</span> <span class="n">ROWS</span> <span class="o">=</span> <span class="mi">24</span><span class="o">;</span>        <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="kd">final</span> <span class="kt">int</span> <span class="n">COLUMNS</span> <span class="o">=</span> <span class="mi">80</span><span class="o">;</span>
         <span class="kd">final</span> <span class="kt">int</span> <span class="n">GENERATIONS</span> <span class="o">=</span> <span class="mi">500</span><span class="o">;</span>
-        <span class="kt">boolean</span><span class="o">[][]</span> <span class="n">board</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">boolean</span><span class="o">[</span><span class="n">ROWS</span><span class="o">][</span><span class="n">COLUMNS</span><span class="o">];</span>
+        <span class="kt">boolean</span><span class="o">[][]</span> <span class="n">board</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">boolean</span><span class="o">[</span><span class="n">ROWS</span><span class="o">][</span><span class="n">COLUMNS</span><span class="o">];</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="kt">boolean</span><span class="o">[][]</span> <span class="n">temp</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">boolean</span><span class="o">[</span><span class="n">ROWS</span><span class="o">][</span><span class="n">COLUMNS</span><span class="o">];</span>
         <span class="kt">boolean</span><span class="o">[][]</span> <span class="n">swap</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++</span> <span class="o">)</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++)</span> <i class="conum" data-value="3"></i><b>(3)</b>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++)</span>
                 <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">Math</span><span class="o">.</span><span class="na">random</span><span class="o">()</span> <span class="o">&lt;</span> <span class="mf">0.1</span><span class="o">);</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The <code>main()</code> method of our program starts by defining <code>ROWS</code>, <code>COLUMNS</code>,
-and <code>GENERATIONS</code> as named constants using the <code>final</code> keyword. Next, we
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The <code>main()</code> method of our program starts by defining <code>ROWS</code>, <code>COLUMNS</code>,
+and <code>GENERATIONS</code> as named constants using the <code>final</code> keyword.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Next, we
 create <strong>two</strong> arrays with <code>ROWS</code> rows and <code>COLUMNS</code> columns. The <code>board</code>
 array will hold the current generation. The <code>temp</code> array will be used to
 fill in the next generation. Then, <code>temp</code> will be copied into <code>board</code>,
 and the process will repeat. The <code>swap</code> variable is just a reference we’ll
-use to swap <code>board</code> and <code>temp</code>. We randomly fill the board, making
+use to swap <code>board</code> and <code>temp</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>We randomly fill the board, making
 10% of the cells living. Again, you may wish to play with this number to
-see how the patterns in the simulation are affected.</p>
+see how the patterns in the simulation are affected.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">generation</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">generation</span> <span class="o">&lt;</span> <span class="n">GENERATIONS</span><span class="o">;</span> <span class="n">generation</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++</span> <span class="o">)</span>
-                <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">generation</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">generation</span> <span class="o">&lt;</span> <span class="n">GENERATIONS</span><span class="o">;</span> <span class="n">generation</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++</span> <span class="o">)</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++)</span> <span class="o">{</span>
                     <span class="kt">int</span> <span class="n">total</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
-                    <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="n">Math</span><span class="o">.</span><span class="na">max</span><span class="o">(</span><span class="n">row</span> <span class="o">-</span> <span class="mi">1</span><span class="o">,</span> <span class="mi">0</span><span class="o">);</span>
-						<span class="n">i</span> <span class="o">&lt;</span> <span class="n">Math</span><span class="o">.</span><span class="na">min</span><span class="o">(</span><span class="n">row</span> <span class="o">+</span> <span class="mi">2</span><span class="o">,</span> <span class="n">ROWS</span><span class="o">);</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
-                        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">Math</span><span class="o">.</span><span class="na">max</span><span class="o">(</span><span class="n">column</span> <span class="o">-</span> <span class="mi">1</span><span class="o">,</span> <span class="mi">0</span><span class="o">);</span>
-							<span class="n">j</span> <span class="o">&lt;</span> <span class="n">Math</span><span class="o">.</span><span class="na">min</span><span class="o">(</span><span class="n">column</span> <span class="o">+</span> <span class="mi">2</span><span class="o">,</span> <span class="n">COLUMNS</span><span class="o">);</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
+                    <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="n">Math</span><span class="o">.</span><span class="na">max</span><span class="o">(</span><span class="n">row</span> <span class="o">-</span> <span class="mi">1</span><span class="o">,</span> <span class="mi">0</span><span class="o">);</span> <i class="conum" data-value="3"></i><b>(3)</b>
+						<span class="n">i</span> <span class="o">&lt;</span> <span class="n">Math</span><span class="o">.</span><span class="na">min</span><span class="o">(</span><span class="n">row</span> <span class="o">+</span> <span class="mi">2</span><span class="o">,</span> <span class="n">ROWS</span><span class="o">);</span> <span class="n">i</span><span class="o">++)</span>
+                        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">Math</span><span class="o">.</span><span class="na">max</span><span class="o">(</span><span class="n">column</span> <span class="o">-</span> <span class="mi">1</span><span class="o">,</span> <span class="mi">0</span><span class="o">);</span>
+							<span class="n">j</span> <span class="o">&lt;</span> <span class="n">Math</span><span class="o">.</span><span class="na">min</span><span class="o">(</span><span class="n">column</span> <span class="o">+</span> <span class="mi">2</span><span class="o">,</span> <span class="n">COLUMNS</span><span class="o">);</span> <span class="n">j</span><span class="o">++)</span>
                             <span class="k">if</span><span class="o">((</span><span class="n">i</span> <span class="o">!=</span> <span class="n">row</span> <span class="o">||</span> <span class="n">j</span> <span class="o">!=</span> <span class="n">column</span> <span class="o">)</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="n">j</span><span class="o">]</span> <span class="o">)</span>
                                 <span class="n">total</span><span class="o">++;</span>
-                    <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">)</span>
-                        <span class="n">temp</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">total</span> <span class="o">==</span> <span class="mi">2</span> <span class="o">||</span> <span class="n">total</span> <span class="o">==</span> <span class="mi">3</span><span class="o">);</span>
+                    <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">])</span>
+                        <span class="n">temp</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">total</span> <span class="o">==</span> <span class="mi">2</span> <span class="o">||</span> <span class="n">total</span> <span class="o">==</span> <span class="mi">3</span><span class="o">);</span> <i class="conum" data-value="4"></i><b>(4)</b>
                     <span class="k">else</span>
-                        <span class="n">temp</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">total</span> <span class="o">==</span> <span class="mi">3</span><span class="o">);</span>
+                        <span class="n">temp</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">total</span> <span class="o">==</span> <span class="mi">3</span><span class="o">);</span> <i class="conum" data-value="5"></i><b>(5)</b>
                 <span class="o">}</span>
-            <span class="n">swap</span> <span class="o">=</span> <span class="n">board</span><span class="o">;</span>
+            <span class="n">swap</span> <span class="o">=</span> <span class="n">board</span><span class="o">;</span> <i class="conum" data-value="6"></i><b>(6)</b>
             <span class="n">board</span> <span class="o">=</span> <span class="n">temp</span><span class="o">;</span>
             <span class="n">temp</span> <span class="o">=</span> <span class="n">swap</span><span class="o">;</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The <code>for</code> loop at the beginning of this segment of code runs once for
-each generation we simulate. The two nested <code>for</code> loops examine each
-cell in <code>board</code>. The two <code>for</code> loops nested inside of those loops do the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The <code>for</code> loop at the beginning of this segment of code runs once for
+each generation we simulate.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The two nested <code>for</code> loops examine each
+cell in <code>board</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>The two <code>for</code> loops nested inside of those loops do the
 calculations to determine if a cell will be alive or dead in the next
 generation. These inner loops start one row before the current row and
 finish one row after the current row. They do the same for columns. The
@@ -3414,47 +3629,71 @@ going out of bounds of the array. When backing up a row or a column, the
 <code>Math.max()</code> methods make sure that we do not generate an index smaller
 than 0. When going forward a row or a column, the <code>Math.min()</code> methods
 make sure that we do not generate an index greater than <code>ROWS - 1</code> or
-<code>COLUMNS - 1</code>.</p>
-</div>
-<div class="paragraph">
-<p>After these two innermost <code>for</code> loops have counted the total of living
+<code>COLUMNS - 1</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>After these two innermost <code>for</code> loops have counted the total of living
 cells around the cell in question, we decide the fate of the cell for
 the next generation. If the cell’s alive and has exactly 2 or 3 living
-neighbors, it’ll continue to live. If a cell’s dead, it’ll
-come to life only if it has exactly 3 living neighbors. After we’ve
+neighbors, it’ll continue to live.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>If a cell’s dead, it’ll
+come to life only if it has exactly 3 living neighbors.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="6"></i><b>6</b></td>
+<td>After we’ve
 stored the state of each cell in the next generation into <code>temp</code>, we
 swap <code>board</code> and <code>temp</code>, using the <code>swap</code> variable. We could have thrown
 out the old array stored in <code>board</code> instead of swapping it with <code>temp</code>,
 but then we’d have to create a new array for <code>temp</code> each time, which
-is less efficient.</p>
+is less efficient.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="mi">100</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+<pre class="rouge highlight"><code data-lang="java">            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="mi">100</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <i class="conum" data-value="1"></i><b>(1)</b>
                 <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">();</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-                <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++</span> <span class="o">)</span>
-                    <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">)</span>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++)</span>
+                    <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">])</span>
                         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;*&quot;</span><span class="o">);</span>
                     <span class="k">else</span>
                         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot; &quot;</span><span class="o">);</span>
                 <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">();</span>
             <span class="o">}</span>
-            <span class="k">try</span> <span class="o">{</span> <span class="n">Thread</span><span class="o">.</span><span class="na">sleep</span><span class="o">(</span><span class="mi">500</span><span class="o">);</span> <span class="o">}</span>
+            <span class="k">try</span> <span class="o">{</span> <span class="n">Thread</span><span class="o">.</span><span class="na">sleep</span><span class="o">(</span><span class="mi">500</span><span class="o">);</span> <span class="o">}</span> <i class="conum" data-value="3"></i><b>(3)</b>
             <span class="k">catch</span><span class="o">(</span> <span class="n">InterruptedException</span> <span class="n">e</span> <span class="o">)</span> <span class="o">{}</span>
         <span class="o">}</span>
     <span class="o">}</span>
 <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The first <code>for</code> loop in this segment prints 100 blank lines to clear the
-screen, as we explained earlier. The two nested <code>for</code> loops print out
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The first <code>for</code> loop in this segment prints 100 blank lines to clear the
+screen, as we explained earlier.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The two nested <code>for</code> loops print out
 the state of the current generation, with a <code>*</code> for each living cell and
-a blank space for each dead one. After the output, the code sleeps for
+a blank space for each dead one.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>After the output, the code sleeps for
 500 milliseconds to give the effect of an animation. We’ll discuss
 exceptions in general in <a href="chap11.html#ch12-exceptions">Chapter 12</a> and give more
-information about the <code>Thread.sleep()</code> method in <a href="chap12.html#ch13-concurrency">Chapter 13</a>.</p>
+information about the <code>Thread.sleep()</code> method in <a href="chap12.html#ch13-concurrency">Chapter 13</a>.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>Although 500 milliseconds

--- a/chunked/chap6.html
+++ b/chunked/chap6.html
@@ -714,18 +714,18 @@ truth within the soul.</p>
 <p>Recall from <a href="chap4.html#ch05-repetition">Chapter 5</a> that we can record DNA as a
 sequence of nucleotide bases A, C, G, and T. Using this idea, we can
 represent any sequence of DNA using a <code>String</code> made up of those four
-letters, such as <code>&quot;ATGGAAGTATTTAAATAG&quot;</code>.</p>
+letters such as <code>&quot;ATGGAAGTATTTAAATAG&quot;</code>.</p>
 </div>
 <div class="paragraph">
 <p>This particular sequence contains 18 bases and six <em>codons</em>. A codon is
 a three-base subsequence in DNA. Biologists are interested in dividing
 DNA into codons because a single codon usually maps to the production of
 a specific amino acid. Amino acids, in turn, are the building blocks of
-proteinS. The DNA sequence above contains the six codons ATG, GAA, GTA,
+proteins. The DNA sequence above contains the six codons ATG, GAA, GTA,
 TTT, AAA, and TAG.</p>
 </div>
 <div class="paragraph">
-<p>We want to write a program that extracts codons in order from DNA
+<p>We want to write a program that extracts codons from DNA
 sequences entered by the user. The program must detect and inform the
 user of invalid DNA sequences (those containing letters other than the
 four bases). If the user enters a DNA sequence whose length is not a

--- a/full/ch03-strings-primitive-types.adoc
+++ b/full/ch03-strings-primitive-types.adoc
@@ -2445,55 +2445,65 @@ assigning values, performing simple arithmetic and more advanced math,
 inputting and outputting data, and using the type system, which includes
 subtle differences between primitive and reference types. Our solution to the
 college cost calculator problem posed at the beginning of the chapter
-uses all of these features at some level.
+uses all of these features at some level. We present this solution below.
 
-We present this solution below. The first step in our solution is to
-import `java.util.*` so that we can use the `Scanner` class. Then, we
-start the enclosing `CollegeCosts` class, begin the `main()` method,
-print a welcome message for the user, and create a `Scanner` object.
+
 
 [source, java]
 ----
 include::{programsdir}/CollegeCosts.java[lines=1..7]
 ----
+<.> The first step in our solution is to
+import `java.util.*` so that we can use the `Scanner` class.
+<.> After we start the enclosing `CollegeCosts` class, we begin the `main()` method.
+<.> We print a welcome message for the user.
+<.> Then, we create a `Scanner` object.
 
 Next is a sequence of prompts to the user interspersed with input done
-with the `Scanner` object. The program reads the user's first name as a
-`String`, the user's last name as a `String`, the per-semester tuition
-cost as a `double`, the monthly cost of rent as a `double`, the monthly
-cost of food as a `double`, the interest rate for the loan as a
-`double`, and the number of years needed to pay back the loan as an
-`int`.
+with the `Scanner` object.
 
 [source, java]
 ----
 include::{programsdir}/CollegeCosts.java[lines=8..22]
 ----
+<.> The program reads the user's first name as a
+`String`,
+<.> the user's last name as a `String`,
+<.> the per-semester tuition cost as a `double`,
+<.> the monthly cost of rent as a `double`,
+<.> the monthly cost of food as a `double`,
+<.> the interest rate for the loan as a `double`,
+<.> and the number of years needed to pay back the loan as an
+`int`.
 
-The next segment of code completes the computations needed. First, it
-finds the total yearly cost by doubling the semester cost, multiplying
-the monthly rent and food costs by 12, and summing the answers together.
-The four year cost is simply four times the yearly cost. To find the
-monthly payment, we find the monthly interest by dividing the annual
-interest rate by 12 and plugging this value into the formula from the
-beginning of the chapter. Finally, the total cost of the loan is the
-monthly payment times 12 times the number of years.
+The next segment of code completes the computations needed.
 
 [source, java]
 ----
 include::{programsdir}/CollegeCosts.java[lines=23..29]
 ----
+<.> It finds the total yearly cost by doubling the semester cost, multiplying
+the monthly rent and food costs by 12, and summing the answers together.
+<.> The four year cost is simply four times the yearly cost.
+<.> To find the monthly payment, we find the monthly interest by dividing the annual
+interest rate by 12 and plugging this value into the formula from the
+beginning of the chapter.
+<.> Finally, the total cost of the loan is the
+monthly payment times 12 times the number of years.
 
-All that remains is to print out the output. First, we output a header
-describing the following output as college costs for the user. Using
-`System.out.format()` as described in <<Primitive types>>, we print out the yearly cost, four year cost, monthly loan
-payment, and total cost, all formatted with dollar signs, two places after
-the decimal point, and tabs so that the output lines up.
+All that remains is to print out the output.
+
 
 [source, java]
 ----
 include::{programsdir}/CollegeCosts.java[lines=30..37]
 ----
+<.> First, we output a header
+describing the following output as college costs for the user.
+<.> Using
+`System.out.format()` as described in <<Primitive types>>, we print out the yearly cost, four year cost, monthly loan
+payment, and total cost, all formatted with dollar signs, two places after
+the decimal point, and tabs so that the output lines up.
 
 
 === Concurrency: Expressions

--- a/full/ch04-selection.adoc
+++ b/full/ch04-selection.adoc
@@ -1282,53 +1282,59 @@ We now return to the Monty Hall simulation described at the beginning of
 the chapter. Recall that objects of the `Random` class allow us to generate all
 kinds of random values. To implement this simulation successfully, our
 program must make the decisions needed to set up the game for the
-user as well as respond to the user's input. We begin with the `import`
-statement needed to use both the `Scanner` and `Random` class
-and then define the `MontyHall` class.
+user as well as respond to the user's input. 
 
 [source, java]
 ----
 include::{programsdir}/MontyHall.java[lines=1..11]
 ----
-
-
-In the `main()` method we first decide which of the three doors is the
+<.> We begin with the `import`
+statement needed to use both the `Scanner` and `Random` class
+and then define the `MontyHall` class.
+<.> In the `main()` method we first decide which of the three doors is the
 winner. To do so, we instantiate a `Random` object and use it to
 generate a random number that is either 0, 1, or 2 by calling the
 `nextInt()` method with an argument of `3`. We could have added 1 to
 this value to get a random choice of 1, 2, or 3, but many counting
-systems in computer science start with 0 instead of 1. You might as well
-get used to it. Next, we prompt the user to pick from the three doors
-and read the choice. Finally, we declare two more `int` values to keep
+systems in computer science start with 0 instead of 1. We might as well
+embrace it.
+<.> Next, we prompt the user to pick from the three doors
+and read the choice.
+<.> Finally, we declare two more `int` values to keep
 track of which door to open and which door is the alternative that the
 user can choose to change over to.
+
+Now, we have to navigate a complicated series of decisions. 
 
 [source, java]
 ----
 include::{programsdir}/MontyHall.java[lines=13..38]
 ----
-
-
-Now, we have to navigate a complicated series of decisions. In this
+<.> In this
 segment of code, we tackle the possibility that the user happened
 to choose the winning door. To obey the rules of the game, we must
-randomly pick which of the two other doors to open. First, we determine
+randomly pick which of the two other doors to open.
+<.> First, we determine
 which are the other two doors and save them in `low` and `high`,
-respectively. Then, we generated a random number. If the random number
+respectively.
+<.> Then, we generate a random number.
+<.> If the random number
 is less than 0.5, we keep the lower numbered door as an alternative
-choice for the user and open the higher numbered door. If the random
-number is greater than or equal to 0.5, we do the opposite.
+choice for the user and open the higher numbered door.
+<.> If the random number is greater than or equal to 0.5, we do the opposite.
 
 [source, java]
 ----
 include::{programsdir}/MontyHall.java[lines=39..59]
 ----
-
-This `else` block covers the case that the player did *not* pick the
+<.> This `else` block covers the case that the player did *not* pick the
 winning door the first time. Unlike the previous code segment, we no
-longer have a choice of which door to open. Instead, we must always
+longer have a choice of which door to open.
+<.> Instead, we must always
 make the winner the alternative for the user to pick. Then, we simply
-determine which door is left over so that we can open it. Note that the
+determine which door is left over so that we can open it.
+
+Note that the
 braces surrounding the blocks for each of the braces surrounding the
 blocks for each of the three possible values of `choice` are not
 necessary but are included for readability.
@@ -1337,10 +1343,9 @@ necessary but are included for readability.
 ----
 include::{programsdir}/MontyHall.java[lines=60..74]
 ----
-
-
-This final segment of code informs the user which door has been opened
-and prompts the user to change his or her decision. Depending on the
+<.> This final segment of code informs the user which door has been opened.
+<.> It prompts the user to change his or her decision.
+<.> Depending on the
 final choice, the program says whether or not the user wins gold or
 junk.
 

--- a/full/ch05-repetition.adoc
+++ b/full/ch05-repetition.adoc
@@ -1059,44 +1059,41 @@ definition.
 ----
 include::{programsdir}/DNASearch.java[lines=1..8]
 ----
-
-
-The `main()` method instantiates a `Scanner` object and declares both of
-the `String` variables we'll need to store the DNA sequences. The method
+<.> The `main()` method instantiates a `Scanner` object and declares both of
+the `String` variables we'll need to store the DNA sequences.
+<.> The method
 also declares a `boolean` and a `char` we'll use for input checking.
 
 [source, java]
 ----
-include::{programsdir}/DNASearch.java[lines=10..22]
+include::{programsdir}/DNASearch.java[lines=10..21]
 ----
-
-
-Next, the user is prompted for a DNA sequence to search in. This
+<.> Next, the user is prompted for a DNA sequence to search in.
+<.> This
 `String` stored in `sequence` is converted to upper case just in case
-the user is not being consistent. The inner `for` loop in this code is
-checking each `char` inside of `sequence`. If any `char` is not an
+the user is not being consistent.
+<.> The inner `for` loop in this code checks each `char` inside of `sequence`.
+<.> If any `char` is not an
 `'A'`, `'C'`, `'G'`, or `'T'`, then `valid` is set to `false`. As a
 result, the `for` loop terminates. Also, the `do-while` loop repeats the
-prompt and gets a new `String` for `sequence` from the user. This outer
+prompt and gets a new `String` for `sequence` from the user.
+<.> This outer
 `do-while` loop continues as long as the user keeps entering invalid DNA
 sequences.
 
 [source, java]
 ----
-include::{programsdir}/DNASearch.java[lines=24..36]
+include::{programsdir}/DNASearch.java[lines=23..34]
 ----
-
 
 The code used to input `subsequence` while doing error checking is
 virtually identical to the code to input `sequence`.
 
 [source, java]
 ----
-include::{programsdir}/DNASearch.java[lines=38..49]
+include::{programsdir}/DNASearch.java[lines=36..46]
 ----
-
-
-The actual workhorse of the search is found in these nested `for` loops.
+<.> The workhorse of the search is found in these nested `for` loops.
 The outer loop iterates through every index in `sequence`, until it
 comes to an index that is too late to be the start of a new subsequence
 (since the subsequence would be too long to fit anymore). This happens
@@ -1109,12 +1106,13 @@ but not any later indexes. Also, if `subsequence` is one `char` longer
 than `sequence`, there can never be a match. In that case, the value of
 `sequence.length() - subsequence.length() + 1` would be `0`. Since `0`
 is not less than `0`, the outer `for` loop would never execute.
-
-The inner `for` loop iterates through the length of `subsequence`,
+<.> The inner `for` loop iterates through the length of `subsequence`,
 making sure that every `char` in `sequence`, starting at the appropriate
-offset, exactly matches a `char` in `subsequence`. If, at any point, the
+offset, exactly matches a `char` in `subsequence`.
+<.> If, at any point, the
 two `char` values do not match, the inner `for` loop will immediately
-exit, using the `break` command. However, on the last iteration of the
+exit, using the `break` command.
+<.> However, on the last iteration of the
 inner `for` loop, when `j` is one less than the length of `subsequence`,
 we know that all of `subsequence` matched a part of `sequence`. As a
 result, we print out the index of `sequence` where `subsequence` started
@@ -1127,15 +1125,14 @@ to replace the inner `for` loop. We leave that approach as an exercise.
 <<indexOfSearchExercise>>
 ****
 
-[source, java]
-----
-include::{programsdir}/DNASearch.java[lines=51..56]
-----
-
-
 Finally, we print out the total number of matches found. In order to
 avoid awkward output like `1 matches found.`, we used an `if`-`else` to
 customize the output based on the value of `found`.
+
+[source, java]
+----
+include::{programsdir}/DNASearch.java[lines=48..53]
+----
 
 The ideas needed to correctly implement the solution are not difficult,
 but catching all the off-by-one errors and getting every detail right
@@ -1146,11 +1143,10 @@ follows.
 [source,java]
 ----
 int found = 0;
-for( int i = 0; i < sequence.length() -
-    subsequence.length() + 1; i++ ) {
-    for( int j = 0; j < subsequence.length() &&
-        subsequence.charAt(j) == sequence.charAt(i + j); j++ )
-        if( j == subsequence.length() - 1 ) { //matches
+for(int i = 0; i < sequence.length() - subsequence.length() + 1; i++) {
+    for(int j = 0; j < subsequence.length() &&
+        subsequence.charAt(j) == sequence.charAt(i + j); j++)
+        if(j == subsequence.length() - 1) { //matches
             System.out.println("Match found at index " + i);
             found++;
         }
@@ -1166,11 +1162,10 @@ matching process is done outside of the inner `for` loop.
 ----
 int found = 0;
 int j;
-for( int i = 0; i < sequence.length() -
-    subsequence.length() + 1; i++ ) {
-    for( j = 0; j < subsequence.length() &&
-        subsequence.charAt(j) == sequence.charAt(i + j); j++ );
-    if( j == subsequence.length() ) { //matches
+for(int i = 0; i < sequence.length() - subsequence.length() + 1; i++) {
+    for(j = 0; j < subsequence.length() &&
+        subsequence.charAt(j) == sequence.charAt(i + j); j++);
+    if(j == subsequence.length()) { //matches
         System.out.println("Match found at index " + i);
         found++;
     }
@@ -1179,8 +1174,8 @@ for( int i = 0; i < sequence.length() -
 
 In this case, note that we must declare `j` outside of the inner `for`
 loop, since it will be used outside. This approach is more efficient
-because we only need to perform the check once. Notice also that the
-condition of the `if` statement has changed. Now, we know that all of
+because we only need to perform the check once. Notice that the
+condition of the `if` statement has also changed. Now, we know that all of
 `subsequence` matches because the loop ran to completion. If the loop
 did not run to completion, then `j` would be smaller than
 `subsequence.length()` and the loop must have terminated because the two

--- a/full/ch06-arrays.adoc
+++ b/full/ch06-arrays.adoc
@@ -697,42 +697,42 @@ of the array is stem:[n], we'll need to look for the smallest
 element in the array stem:[n - 1] times. By putting the code that
 searches for the smallest value inside of an outer loop, we can write a
 program that does selection sort of `int` values input by the user as
-follows.
+follows. This program's not very long, but there's a lot going on. 
 
 [source, java]
 ----
 include::{programsdir}/SelectionSort.java[lines=1..11]
 ----
-
-
-This program is not very long, but there's a lot going on. After
+<.> After
 instantiating a `Scanner`, we read in the total number of values the
 list will hold. We cannot rely on the `hasNextInt()` method to tell us
-when to stop reading values. We need to know up front how many values we
+when to stop reading values.
+<.> We need to know up front how many values we
 are going to store so that we can instantiate our array with the
-appropriate length. Then, we read each value into the array using the
+appropriate length.
+<.> Then, we read each value into the array using the
 first `for` loop.
 
 [source, java]
 ----
 include::{programsdir}/SelectionSort.java[lines=12..20]
 ----
-
-
-The next `for` loop is where the actual sort happens. We start at index
+<.> The next `for` loop is where the actual sort happens. We start at index
 `0` and then try to find the smallest value to be put in that spot.
 Then, we move on to index `1`, and so on, just as we described before.
 Note that we only go up to `n - 2`. We don't need to find the value to
 put in index `n - 1`, because the rest of the list has the `n - 1`
 smallest numbers in it and so the last number *must* already be the
-largest. If you look carefully, you'll notice that the inner `for`
+largest.
+<.> If you look carefully, you'll notice that the inner `for`
 loop has the same overall shape as the loop used to find the smallest
 value in the previous example; however, there is one key difference:
-Instead of storing the *value* of the smallest number in `smallest`, we
+<.> Instead of storing the *value* of the smallest number in `smallest`, we
 now store the *index* of the smallest number. We need to store the index
 of the smallest number so that, in the next step, we can swap the
 corresponding element with the element at `i`, the spot in the array
-we're trying to fill. The three lines after the inner `for` loop are a
+we're trying to fill.
+<.> The three lines after the inner `for` loop are a
 simple swap to do exactly that.
 
 [source, java]
@@ -740,9 +740,10 @@ simple swap to do exactly that.
 include::{programsdir}/SelectionSort.java[lines=21..25]
 ----
 
-
 After all the sorting is done, the final `for` loop prints out the newly
-sorted list. This program gives no prompts for user input, so it's well
+sorted list.
+
+This program gives no prompts for user input, so it's well
 designed for input redirection. If you're going to make a file
 containing numbers you want to sort with this program, make sure that
 the first number is the total count of numbers in the file.
@@ -779,32 +780,31 @@ the text we want to search through.
 ----
 include::{programsdir}/WordCount.java[lines=1..11]
 ----
-
-
-As in the last example, this program begins by reading in the length of
-the list of words. Then, it instantiates the `String` array `words` to
-hold these words. It also instantiates an array `counts` of type `int`
+<.> As in the last example, this program begins by reading in the length of
+the list of words.
+<.> Then, it instantiates the `String` array `words` to
+hold these words.
+<.> It also instantiates an array `counts` of type `int`
 to keep track of the number of times each word is found. By default,
-each element in `counts` is initialized to `0`. The first `for` loop in
+each element in `counts` is initialized to `0`.
+<.> The first `for` loop in
 the program reads in each word and stores it into the array `words`.
 
 [source, java]
 ----
 include::{programsdir}/WordCount.java[lines=12..20]
 ----
-
-
-The `while` loop reads in each word from the text following the list and
-stores it in a variable called `temp`. Then, it loops through `words`
-and tests to see if `temp` matches any of the elements in the list. If
-it does, it increases the value of the element of `counts` that has the
+<.> The `while` loop reads in each word from the text following the list and
+stores it in a variable called `temp`.
+<.> Then, it loops through `words`
+and tests to see if `temp` matches any of the elements in the list.
+<.> If it does, it increases the value of the element of `counts` that has the
 same index and breaks out of the inner `for` loop.
 
 [source, java]
 ----
 include::{programsdir}/WordCount.java[lines=21..24]
 ----
-
 
 After all the words in the text have been processed, the final `for`
 loop prints out each word from the list, along with its counts.
@@ -916,25 +916,26 @@ solve after the previous examples.
 ----
 include::{programsdir}/Statistics.java[lines=1..9]
 ----
-
-
-In our solution, the `main()` method begins by reading in the total
-number of scores and declaring an `int` array of that length named
-`scores`. Then, we read in each of the scores and store them into
+<.> In our solution, the `main()` method begins by reading in the total
+number of scores. 
+<.> It declares an `int` array of that length named
+`scores`.
+<.> Then, we read in each of the scores and store them into
 `scores`.
 
 [source, java]
 ----
 include::{programsdir}/Statistics.java[lines=10..19]
 ----
-
-
-Here we declare variables `max`, `min`, and `sum` to hold, respectively,
+<.> Here we declare variables `max`, `min`, and `sum` to hold, respectively,
 the maximum, minimum, and sum of the elements in the array. Then, we set
 all three variables to the value of the first element of the array.
-These initializations make the following code work. In a single `for`
+These initializations make the following code work.
+<.> In a single `for`
 loop, we find the maximum, minimum, and sum of all the values in the
-array. We could have done so with three separate loops, but this
+array.
+
+We could have done so with three separate loops, but this
 approach is more efficient. Setting `max` and `min` to `scores[0]`
 follows the pattern we've used before, but setting `sum` to the same
 value is also necessary in this case. Because the loop iterates from `1`
@@ -947,7 +948,6 @@ up to `scores.length - 1`, we must include the value at index `0` in
 include::{programsdir}/Statistics.java[lines=20..23]
 ----
 
-
 In this short snippet of code, we compute the mean, being careful to
 cast it into type `double` before the division, and then print out the three
 statistics we've computed.
@@ -956,24 +956,23 @@ statistics we've computed.
 ----
 include::{programsdir}/Statistics.java[lines=24..28]
 ----
-
-
-At this point, we use the mean we've already computed to find the
+<.> At this point, we use the mean we've already computed to find the
 sample standard deviation. Following the formula for sample standard
 deviation, we subtract the mean from each score, square the result, and
 add it to a running total. Although the formula for sample standard
 deviation uses the bounds stem:[1] to stem:[n], we
 translate them to `0` to `n - 1` because of zero-based array numbering.
-Dividing the total by `n - 1` gives the sample variance. Then, the
+<.> Dividing the total by `n - 1` gives the sample variance.
+<.> Then, the
 square root of the variance is the standard deviation.
 
 [source, java]
 ----
-include::{programsdir}/Statistics.java[lines=29..46]
+include::{programsdir}/Statistics.java[lines=29..38]
 ----
+<.> To find the median, we use our selection sort code.
 
-
-To find the median, we use our selection sort code. Note that we have
+Note that we have
 reused the variable `min` to hold the smallest value found so far,
 instead of declaring a new variable such as `smallest`. Some programmers
 might object to doing so, since we run the risk of interpreting the
@@ -981,18 +980,24 @@ variable as the minimum value in the entire array, as it was before.
 Either approach is fine. If you worry about confusing people reading
 your code, add a comment.
 
-After the array has been sorted, we need to do a quick check to see if
-its length is odd or even. If its length is even, we need to find the
-average of the two middle elements. If its length is odd, we can report
-the value of the single middle element.
+[source, java]
+----
+include::{programsdir}/Statistics.java[lines=39..46]
+----
+<.> After the array has been sorted, we need to do a quick check to see if
+its length is odd or even.
+<.> If its length is even, we need to find the average of the two middle elements.
+<.> If its length is odd, we can report the value of the single middle element.
 
 Note that some of the statistics we found, such as the maximum, minimum,
-or mean, could be computed using loops without an array for storage.
-However, the last two tasks need to store all of the values at once in
-order to work. The simplest way to find the sample standard deviation of a list of values
-requires its mean. At least two passes over the data are needed to
-compute the sample standard deviation: one to find the mean and another
-to apply the equation for sample standard deviation.
+or mean, could be computed with a single pass over the data 
+without the need for an array for storage.
+However, the last two tasks need to store all the values to work.
+The simplest way to find the sample standard deviation of a list of values
+requires its mean, requiring one pass to find the mean and a second
+to sum the squares of the difference of the mean and each value. 
+Likewise, it's impossible to find the median of a list of values without
+storing the list.
 
 ****
 <<modeExercise>>
@@ -1626,27 +1631,26 @@ checkers, chess, or Go. Our program will catch any attempt to play on a
 location that has already been played and will determine the winner, if
 there is one.
 
+Games often give rise to complex programs, since rules that are
+intuitively obvious to humans may be difficult to state explicitly in
+Java. Our program begins by setting up quite a few variables and
+objects. 
+
 [source, java]
 ----
 include::{programsdir}/TicTacToe.java[lines=1..13]
 ----
-
-Games often give rise to complex programs, since rules that are
-intuitively obvious to humans may be difficult to state explicitly in
-Java. Our program begins by setting up quite a few variables and
-objects. First, we create a `Scanner` to read in data. Then, we declare
+<.> First, we create a `Scanner` to read in data.
+<.> Then, we declare
 and instantiate our 3 × 3 playing board as a
-two-dimensional array of type `char`. We want any unplayed space on the
+two-dimensional array of type `char`.
+<.> We want any unplayed space on the
 grid to be the `char` for a space, so we fill the array with `' '`.
-Next, we declare a `boolean` value to keep track of whose turn it is and
-another to keep track of whether the game is over. Finally, we
+<.> Next, we declare a `boolean` value to keep track of whose turn it is and
+another to keep track of whether the game is over.
+<.> Finally, we
 declare variables to hold the row, the column, the number of moves that
 have been made so far and the current shape (`'X'` or `'O'`).
-
-[source, java]
-----
-include::{programsdir}/TicTacToe.java[lines=15..35]
-----
 
 The core of the game is a `while` loop that runs until `gameOver`
 becomes `true`. The first line of the body of this loop is an obscure
@@ -1668,32 +1672,45 @@ It's perfect for situations like this where one value is needed when
 `turn` is `true` and another is needed when `turn` is `false`. The
 ternary operator is a useful trick, but it shouldn't be overused.
 
-After assigning the appropriate value to `shape`, our code reads in the
-row and column values for the current player's next move. If the row and
+[source, java]
+----
+include::{programsdir}/TicTacToe.java[lines=15..35]
+----
+<.> After assigning the appropriate value to `shape`, our code reads in the
+row and column values for the current player's next move.
+<.> If the row and
 column selected correspond to a spot that's already been taken, the
-program gives an error message. Otherwise, the program sets
+program gives an error message.
+<.> Otherwise, the program sets
 `board[row][column]` to the appropriate symbol, increments `moves`, and
-changes the value of `turn`. Then, it prints out the board. We point out
-that our program does not do any bounds checking on `row` and `column`.
+changes the value of `turn`.
+<.> Then, it prints out the board.
+
+Our program doesn't do any bounds checking on `row` and `column`.
 If a user tries to place a move at row 5 column 3, our program will try
-to do so and crash. Four additional clauses in the `if` statement could
+to do so and crash. Additional clauses in the `if` statement could
 be used to add bounds checking.
+
+Perhaps the trickiest part of our tic-tac-toe program is checking for a
+win.
 
 [source, java]
 ----
 include::{programsdir}/TicTacToe.java[lines=36..62]
 ----
+<.> First we check each row to see if it contains three in a row.
+<.> Then, we check each column.
+<.> Finally, we check the two diagonals.
+<.> If any of
+those checks ended the game, we announce a winner.
+<.> Otherwise, if the
+number of moves has reached 9 with no winner, it must be a tie game.
 
-
-Perhaps the trickiest part of our tic-tac-toe program is checking for a
-win. First we check each row to see if it contains three in a row. Then,
-we check each column. Finally, we check the two diagonals. If any of
-those checks ended the game, we announce a winner. Otherwise, if the
-number of moves has reached 9 with no winner, it must be a tie game. In
+In
 a larger game (such as Connect Four), we would want to find better ways
 to automate checking rows, columns, and diagonals. For example, we wouldn't
 want to check the entirety of a larger board each move.
-Instead, we could focus only on rows, columns, and diagonals
+Instead, we could focus only on the rows, columns, and diagonals
 affected by the last move.
 ====
 
@@ -1853,15 +1870,15 @@ columns, although it would be easy to change those dimensions.
 ----
 include::{programsdir}/Life.java[lines=1..11]
 ----
-
-
-The `main()` method of our program starts by defining `ROWS`, `COLUMNS`,
-and `GENERATIONS` as named constants using the `final` keyword. Next, we
+<.> The `main()` method of our program starts by defining `ROWS`, `COLUMNS`,
+and `GENERATIONS` as named constants using the `final` keyword.
+<.> Next, we
 create *two* arrays with `ROWS` rows and `COLUMNS` columns. The `board`
 array will hold the current generation. The `temp` array will be used to
 fill in the next generation. Then, `temp` will be copied into `board`,
 and the process will repeat. The `swap` variable is just a reference we'll
-use to swap `board` and `temp`. We randomly fill the board, making
+use to swap `board` and `temp`.
+<.> We randomly fill the board, making
 10% of the cells living. Again, you may wish to play with this number to
 see how the patterns in the simulation are affected.
 
@@ -1869,10 +1886,11 @@ see how the patterns in the simulation are affected.
 ----
 include::{programsdir}/Life.java[lines=12..29]
 ----
-
-The `for` loop at the beginning of this segment of code runs once for
-each generation we simulate. The two nested `for` loops examine each
-cell in `board`. The two `for` loops nested inside of those loops do the
+<.> The `for` loop at the beginning of this segment of code runs once for
+each generation we simulate.
+<.> The two nested `for` loops examine each
+cell in `board`.
+<.> The two `for` loops nested inside of those loops do the
 calculations to determine if a cell will be alive or dead in the next
 generation. These inner loops start one row before the current row and
 finish one row after the current row. They do the same for columns. The
@@ -1882,12 +1900,13 @@ going out of bounds of the array. When backing up a row or a column, the
 than 0. When going forward a row or a column, the `Math.min()` methods
 make sure that we do not generate an index greater than `ROWS - 1` or
 `COLUMNS - 1`.
-
-After these two innermost `for` loops have counted the total of living
+<.> After these two innermost `for` loops have counted the total of living
 cells around the cell in question, we decide the fate of the cell for
 the next generation. If the cell's alive and has exactly 2 or 3 living
-neighbors, it'll continue to live. If a cell's dead, it'll
-come to life only if it has exactly 3 living neighbors. After we've
+neighbors, it'll continue to live.
+<.> If a cell's dead, it'll
+come to life only if it has exactly 3 living neighbors.
+<.> After we've
 stored the state of each cell in the next generation into `temp`, we
 swap `board` and `temp`, using the `swap` variable. We could have thrown
 out the old array stored in `board` instead of swapping it with `temp`,
@@ -1898,11 +1917,12 @@ is less efficient.
 ----
 include::{programsdir}/Life.java[lines=30..44]
 ----
-
-The first `for` loop in this segment prints 100 blank lines to clear the
-screen, as we explained earlier. The two nested `for` loops print out
+<.> The first `for` loop in this segment prints 100 blank lines to clear the
+screen, as we explained earlier.
+<.> The two nested `for` loops print out
 the state of the current generation, with a `*` for each living cell and
-a blank space for each dead one. After the output, the code sleeps for
+a blank space for each dead one.
+<.> After the output, the code sleeps for
 500 milliseconds to give the effect of an animation. We'll discuss
 exceptions in general in <<ch12-exceptions#ch12-exceptions>> and give more
 information about the `Thread.sleep()` method in <<ch13-concurrency#ch13-concurrency>>.

--- a/full/ch07-gui-basics.adoc
+++ b/full/ch07-gui-basics.adoc
@@ -14,16 +14,16 @@ ____
 Recall from <<ch05-repetition#ch05-repetition>> that we can record DNA as a
 sequence of nucleotide bases A, C, G, and T. Using this idea, we can
 represent any sequence of DNA using a `String` made up of those four
-letters, such as `"ATGGAAGTATTTAAATAG"`.
+letters such as `"ATGGAAGTATTTAAATAG"`.
 
 This particular sequence contains 18 bases and six _codons_. A codon is
 a three-base subsequence in DNA. Biologists are interested in dividing
 DNA into codons because a single codon usually maps to the production of
 a specific amino acid. Amino acids, in turn, are the building blocks of
-proteinS. The DNA sequence above contains the six codons ATG, GAA, GTA,
+proteins. The DNA sequence above contains the six codons ATG, GAA, GTA,
 TTT, AAA, and TAG.
 
-We want to write a program that extracts codons in order from DNA
+We want to write a program that extracts codons from DNA
 sequences entered by the user. The program must detect and inform the
 user of invalid DNA sequences (those containing letters other than the
 four bases). If the user enters a DNA sequence whose length is not a

--- a/full/chapters/03-strings-primitive-types/programs/CollegeCosts.java
+++ b/full/chapters/03-strings-primitive-types/programs/CollegeCosts.java
@@ -1,35 +1,35 @@
-import java.util.*;
+import java.util.*; //<.>
 
 public class CollegeCosts {
-    public static void main(String[] args) {
-        System.out.println("Welcome to the College Cost Calculator!");
-        Scanner in = new Scanner(System.in);
+    public static void main(String[] args) { //<.>
+        System.out.println("Welcome to the College Cost Calculator!"); //<.>
+        Scanner in = new Scanner(System.in); //<.>
         
         System.out.print("Enter your first name:\t\t");
-        String firstName = in.next();
+        String firstName = in.next(); //<.>
         System.out.print("Enter your last name:\t\t");
-        String lastName = in.next();
+        String lastName = in.next(); //<.>
         System.out.print("Enter tuition per semester:\t$");
-        double semesterTuition = in.nextDouble();
+        double semesterTuition = in.nextDouble(); //<.>
         System.out.print("Enter rent per month:\t\t$");
-        double monthlyRent = in.nextDouble();
+        double monthlyRent = in.nextDouble(); //<.>
         System.out.print("Enter food cost per month:\t$");
-        double monthlyFood = in.nextDouble();
+        double monthlyFood = in.nextDouble(); //<.>
         System.out.print("Annual interest rate:\t\t");
-        double annualInterest = in.nextDouble();        
+        double annualInterest = in.nextDouble(); //<.>       
         System.out.print("Years to pay back your loan:\t");
-        int years = in.nextInt();       
+        int years = in.nextInt(); //<.>
         
-        double yearlyCost = semesterTuition * 2.0 + (monthlyRent + monthlyFood) * 12.0;
-        double fourYearCost = yearlyCost * 4.0;
-        double monthlyInterest = annualInterest / 12.0;
-        double monthlyPayment = fourYearCost * monthlyInterest /
+        double yearlyCost = semesterTuition * 2.0 + (monthlyRent + monthlyFood) * 12.0; //<.>
+        double fourYearCost = yearlyCost * 4.0; //<.>
+        double monthlyInterest = annualInterest / 12.0; //<.>
+        double monthlyPayment = fourYearCost * monthlyInterest / //<.>
             (1.0 - Math.pow(1.0 + monthlyInterest, -years * 12.0));
-        double totalLoanCost = monthlyPayment * 12.0 * years;
+        double totalLoanCost = monthlyPayment * 12.0 * years; //<.>
                 
-        System.out.println("\nCollege costs for " + firstName + " " + lastName );
+        System.out.println("\nCollege costs for " + firstName + " " + lastName ); //<.>
         System.out.println("***************************************");
-        System.out.format("Yearly cost:\t\t\t$%.2f%n", yearlyCost);
+        System.out.format("Yearly cost:\t\t\t$%.2f%n", yearlyCost); //<.>
         System.out.format("Four year cost:\t\t\t$%.2f%n", fourYearCost);
         System.out.format("Monthly loan payment:\t\t$%.2f%n", monthlyPayment);
         System.out.format("Total loan cost:\t\t$%.2f%n", totalLoanCost );

--- a/full/chapters/04-selection/programs/MontyHall.java
+++ b/full/chapters/04-selection/programs/MontyHall.java
@@ -1,19 +1,19 @@
-import java.util.*;
+import java.util.*; //<.>
 
 public class MontyHall {
     public static void main(String[] args) {
         Random random = new Random();
-        int winner = random.nextInt(3);     
+        int winner = random.nextInt(3); //<.>    
         Scanner in = new Scanner( System.in );
         System.out.print("Choose a door (enter 0, 1, or 2): ");
-        int choice = in.nextInt();
-        int alternative;
+        int choice = in.nextInt(); //<.>
+        int alternative; //<.>
         int open;
 
-        if( choice == winner ) {            
+        if( choice == winner ) { //<.>          
             int low;
             int high;
-            if( choice ==  0 ) { 
+            if( choice ==  0 ) { //<.>
                 low = 1;
                 high = 2;
             }
@@ -26,20 +26,20 @@ public class MontyHall {
                 high = 1;
             }   
             //randomly choose between other two doors
-            double threshold = random.nextDouble();
-            if( threshold < 0.5 ) {
+            double threshold = random.nextDouble(); //<.>
+            if( threshold < 0.5 ) { //<.>
                 alternative = low;
                 open = high;
             }
-            else {
+            else { //<.>
                 alternative = high;
                 open = low;
             }           
         }
-        else {
+        else { //<.>
             alternative = winner;
-            if( choice == 0 ) {
-                if( winner == 1 )                   
+            if( choice == 0 ) { //<.>
+                if( winner == 1 )                 
                     open = 2;               
                 else
                     open = 1;               
@@ -57,16 +57,16 @@ public class MontyHall {
                     open = 0;               
             }           
         }
-        System.out.println("We have opened Door " + open + 
+        System.out.println("We have opened Door " + open + //<.>
             ", and there is junk behind it!");
-        System.out.print("Do you want to change to Door " + 
+        System.out.print("Do you want to change to Door " + //<.>
             alternative + " from Door " + choice +
             "? (Enter 'y' or 'n'): ");
         String change = in.next();      
         if( change.equals("y") )
             choice = alternative;
         System.out.println("You chose Door " + choice);
-        if( choice == winner )
+        if( choice == winner ) //<.>
             System.out.println("You win a pile of gold!");
         else
             System.out.println("You win a pile of junk.");

--- a/full/chapters/05-repetition/programs/DNASearch.java
+++ b/full/chapters/05-repetition/programs/DNASearch.java
@@ -2,33 +2,31 @@ import java.util.*;
 
 public class DNASearch {
     public static void main(String[] args) {                
-        Scanner in = new Scanner( System.in );  
+        Scanner in = new Scanner( System.in ); //<.>
         String sequence, subsequence;
-        boolean valid;
+        boolean valid; //<.>
         char c;
         
         do {
-            System.out.print(
-                "Enter the DNA sequence you wish to search in: ");
-            sequence = in.next().toUpperCase();
+            System.out.print("Enter the DNA sequence you wish to search in: "); //<.>
+            sequence = in.next().toUpperCase(); //<.>
             valid = true;
-            for(int i = 0; i < sequence.length() && valid; i++) {               
+            for(int i = 0; i < sequence.length() && valid; i++) { //<.>              
                 c = sequence.charAt(i);
-                if( c != 'A' && c != 'C' && c != 'G' && c != 'T') {
+                if(c != 'A' && c != 'C' && c != 'G' && c != 'T') { //<.>
                     System.out.println("Invalid DNA sequence!");
                     valid = false;
                 }
             }
-        } while( !valid );
+        } while( !valid ); //<.>
         
         do {        
-            System.out.print(
-                "Enter the subsequence you wish to search for: ");
+            System.out.print("Enter the subsequence you wish to search for: ");
             subsequence  = in.next().toUpperCase();
             valid = true;
             for(int i = 0; i < subsequence.length() && valid; i++) {                
                 c = subsequence.charAt(i);
-                if( c != 'A' && c != 'C' && c != 'G' && c != 'T') {
+                if(c != 'A' && c != 'C' && c != 'G' && c != 'T') {
                     System.out.println("Invalid DNA sequence!");
                     valid = false;
                 }
@@ -36,19 +34,18 @@ public class DNASearch {
         } while( !valid );
         
         int found = 0;
-        for( int i = 0; i < sequence.length() -
-            subsequence.length() + 1; i++ ) {           
-            for( int j = 0; j < subsequence.length(); j++ ) {
-                if(subsequence.charAt(j) != sequence.charAt(i + j))
+        for(int i = 0; i < sequence.length() - subsequence.length() + 1; i++) { //<.>
+            for(int j = 0; j < subsequence.length(); j++) { //<.>
+                if(subsequence.charAt(j) != sequence.charAt(i + j)) //<.>
                     break;
-                if( j == subsequence.length() - 1 ) { //matches
+                if(j == subsequence.length() - 1) { //matches <.>
                     System.out.println("Match found at index " + i);
                     found++;
                 }
             }
         }
         
-        if( found == 1 )
+        if(found == 1)
             System.out.println("One match found.");
         else
             System.out.println(found + " matches found.");

--- a/full/chapters/06-arrays/programs/Life.java
+++ b/full/chapters/06-arrays/programs/Life.java
@@ -1,43 +1,43 @@
 public class Life {
     public static void main(String[] args) {
-        final int ROWS = 24;        
+        final int ROWS = 24;        //<.>
         final int COLUMNS = 80;     
         final int GENERATIONS = 500;
-        boolean[][] board = new boolean[ROWS][COLUMNS];
+        boolean[][] board = new boolean[ROWS][COLUMNS]; //<.>
         boolean[][] temp = new boolean[ROWS][COLUMNS];
         boolean[][] swap;
-        for( int row = 0; row < ROWS; row++ )
-            for( int column = 0; column < COLUMNS; column++ )
+        for(int row = 0; row < ROWS; row++) //<.>
+            for(int column = 0; column < COLUMNS; column++)
                 board[row][column] = (Math.random() < 0.1);
-        for( int generation = 0; generation < GENERATIONS; generation++ ) {
-            for( int row = 0; row < ROWS; row++ )
-                for( int column = 0; column < COLUMNS; column++ ) {
+        for(int generation = 0; generation < GENERATIONS; generation++) { //<.>
+            for(int row = 0; row < ROWS; row++ ) //<.>
+                for(int column = 0; column < COLUMNS; column++) {
                     int total = 0;
-                    for( int i = Math.max(row - 1, 0);
-						i < Math.min(row + 2, ROWS); i++ )
-                        for( int j = Math.max(column - 1, 0);
-							j < Math.min(column + 2, COLUMNS); j++ )
+                    for(int i = Math.max(row - 1, 0); //<.>
+						i < Math.min(row + 2, ROWS); i++)
+                        for(int j = Math.max(column - 1, 0);
+							j < Math.min(column + 2, COLUMNS); j++)
                             if((i != row || j != column ) && board[i][j] )
                                 total++;
-                    if( board[row][column] ) 
-                        temp[row][column] = (total == 2 || total == 3);
+                    if(board[row][column])
+                        temp[row][column] = (total == 2 || total == 3); //<.>
                     else
-                        temp[row][column] = (total == 3);
+                        temp[row][column] = (total == 3); //<.>
                 }
-            swap = board;
+            swap = board; //<.>
             board = temp;
             temp = swap;
-            for( int i = 0; i < 100; i++ )
+            for(int i = 0; i < 100; i++) //<.>
                 System.out.println();                   
-            for( int row = 0; row < ROWS; row++ ) {
-                for( int column = 0; column < COLUMNS; column++ )
-                    if( board[row][column] )
+            for(int row = 0; row < ROWS; row++) { //<.>
+                for(int column = 0; column < COLUMNS; column++)
+                    if(board[row][column])
                         System.out.print("*");
                     else
                         System.out.print(" ");
                 System.out.println();
             }           
-            try { Thread.sleep(500); }
+            try { Thread.sleep(500); } //<.>
             catch( InterruptedException e ) {}
         }
     }

--- a/full/chapters/06-arrays/programs/SelectionSort.java
+++ b/full/chapters/06-arrays/programs/SelectionSort.java
@@ -2,24 +2,24 @@ import java.util.*;
 
 public class SelectionSort {
     public static void main(String[] args) {
-        Scanner in = new Scanner( System.in );
-        int n = in.nextInt();
-        int[] values = new int[n];
+        Scanner in = new Scanner(System.in);
+        int n = in.nextInt(); //<.>
+        int[] values = new int[n]; //<.>
         int smallest;
         int temp;
-        for( int i = 0; i < values.length; i++ )
+        for(int i = 0; i < values.length; i++) //<.>
             values[i] = in.nextInt();
-        for( int i = 0; i < n - 1; i++ ) {
+        for(int i = 0; i < n - 1; i++) { //<.>
             smallest = i;
-            for( int j = i + 1; j < n; j++ )
-                if( values[j] < values[smallest] )
-                    smallest = j;
-            temp = values[smallest];
+            for(int j = i + 1; j < n; j++) //<.>
+                if(values[j] < values[smallest])
+                    smallest = j; //<.>
+            temp = values[smallest]; //<.>
             values[smallest] = values[i];
             values[i] = temp;
         }
         System.out.print("The sorted list is: ");
-        for( int i = 0; i < values.length; i++ )
+        for(int i = 0; i < values.length; i++)
             System.out.print(values[i] + " ");
     }
 }

--- a/full/chapters/06-arrays/programs/Statistics.java
+++ b/full/chapters/06-arrays/programs/Statistics.java
@@ -2,18 +2,18 @@ import java.util.*;
 
 public class Statistics {
     public static void main(String[] args) {
-        Scanner in = new Scanner( System.in );
-        int n = in.nextInt();       
-        int[] scores = new int[n];                  
-        for( int i = 0; i < n; i++ )
+        Scanner in = new Scanner(System.in);
+        int n = in.nextInt(); //<.>
+        int[] scores = new int[n]; //<.>                
+        for(int i = 0; i < n; i++) //<.>
             scores[i] = in.nextInt();
-        int max = scores[0];
+        int max = scores[0]; //<.>
         int min = scores[0];
         int sum = scores[0];
-        for( int i = 1; i < n; i++ ) {
-            if( scores[i] > max )
+        for(int i = 1; i < n; i++) { //<.>
+            if(scores[i] > max)
                 max = scores[i];
-            if( scores[i] < min )
+            if(scores[i] < min)
                 min = scores[i];
             sum += scores[i];
         }
@@ -22,25 +22,25 @@ public class Statistics {
         System.out.println("Minimum:\t\t" + min);
         System.out.println("Mean:\t\t\t" + mean);
         double variance = 0;
-        for( int i = 0; i < n; i++ )
-            variance += (scores[i] - mean)*(scores[i] - mean);
-        variance /= (n - 1);        
-        System.out.println("Standard Deviation:\t" + Math.sqrt(variance));
+        for(int i = 0; i < n; i++)
+            variance += (scores[i] - mean)*(scores[i] - mean); //<.>
+        variance /= (n - 1); //<.>        
+        System.out.println("Standard Deviation:\t" + Math.sqrt(variance)); //<.>
         int temp;
-        for( int i = 0; i < n - 1; i++ ) {
+        for(int i = 0; i < n - 1; i++) { //<.>
             min = i;
-            for( int j = i + 1; j < n; j++ )
-                if( scores[j] < scores[min] )
+            for(int j = i + 1; j < n; j++)
+                if(scores[j] < scores[min])
                     min = j;
             temp = scores[min];
             scores[min] = scores[i];
             scores[i] = temp;
         }
         double median;
-        if( n % 2 == 0 )
-            median = (scores[n/2] + scores[n/2 + 1])/2.0;
+        if(n % 2 == 0) //<.>
+            median = (scores[n/2] + scores[n/2 + 1])/2.0; //<.>
         else
-            median = scores[n/2];
+            median = scores[n/2]; //<.>
         System.out.println("Median:\t\t\t" + median);
     }
 }

--- a/full/chapters/06-arrays/programs/TicTacToe.java
+++ b/full/chapters/06-arrays/programs/TicTacToe.java
@@ -2,29 +2,29 @@ import java.util.*;
 
 public class TicTacToe {
     public static void main(String[] args) {
-        Scanner in = new Scanner( System.in );
-        char[][] board = new char[3][3];
-        for( int i = 0; i < board.length; i++ )
-            for( int j = 0; j < board[0].length; j++ )
+        Scanner in = new Scanner(System.in);  //<.>
+        char[][] board = new char[3][3];      //<.>
+        for(int i = 0; i < board.length; i++) //<.>
+            for(int j = 0; j < board[0].length; j++)
                 board[i][j] = ' ';
-        boolean turn = true;
+        boolean turn = true;        //<.>
         boolean gameOver = false;
-        int row, column, moves = 0;
+        int row, column, moves = 0; //<.>
         char shape;
 
-        while( !gameOver ) {
+        while(!gameOver)
             shape = turn ? 'X' : 'O';
-            System.out.print(shape + "'s turn.  Enter row (0-2): ");
+            System.out.print(shape + "'s turn.  Enter row (0-2): "); //<.>
             row = in.nextInt();
             System.out.print("Enter column (0-2): ");
             column = in.nextInt();
-            if( board[row][column] != ' ' )
+            if(board[row][column] != ' ')   //<.>
                 System.out.println("Illegal move");
             else {  
-                board[row][column] = shape; 
+                board[row][column] = shape; //<.>
                 moves++;            
                 turn = !turn;
-                //print board
+                //print board <.>
                 System.out.println(board[0][0] + "|" 
                          + board[0][1] + "|" + board[0][2]);
                 System.out.println("-----");
@@ -33,26 +33,26 @@ public class TicTacToe {
                 System.out.println("-----");
                 System.out.println(board[2][0] + "|" 
                          + board[2][1] + "|" + board[2][2] + "\n");             
-                //check rows
-                for( int i = 0; i < board.length; i++ )
+                //check rows      <.>
+                for(int i = 0; i < board.length; i++)
                     if( board[i][0] == shape && board[i][1] == shape
                         && board[i][2] == shape )
                         gameOver = true;
-                //check columns
-                for( int i = 0; i < board[0].length; i++ )
+                //check columns   <.>
+                for(int i = 0; i < board[0].length; i++)
                     if( board[0][i] == shape && board[1][i] == shape
-                        && board[2][i] == shape )
+                        && board[2][i] == shape)
                         gameOver = true;
-                //check diagonals
-                if( board[0][0] == shape && board[1][1] == shape
-                    && board[2][2] == shape )
+                //check diagonals <.>
+                if(board[0][0] == shape && board[1][1] == shape
+                    && board[2][2] == shape)
                     gameOver = true;
-                if( board[0][2] == shape && board[1][1] == shape
-                    && board[2][0] == shape )
+                if(board[0][2] == shape && board[1][1] == shape
+                    && board[2][0] == shape)
                     gameOver = true;            
-                if( gameOver )
+                if(gameOver)         //<.>
                     System.out.println(shape + " wins!");
-                else if( moves == 9 ){
+                else if(moves == 9){ //<.>
                     gameOver = true;            
                     System.out.println("Tie game!");        
                 }               

--- a/full/chapters/06-arrays/programs/WordCount.java
+++ b/full/chapters/06-arrays/programs/WordCount.java
@@ -3,17 +3,17 @@ import java.util.*;
 public class WordCount {
     public static void main(String[] args) {
         Scanner in = new Scanner( System.in );
-        int n = in.nextInt();
-        String[] words = new String[n];
-        int[] counts = new int[n];  
+        int n = in.nextInt(); //<.>
+        String[] words = new String[n]; //<.>
+        int[] counts = new int[n]; //<.>
         String temp;    
-        for( int i = 0; i < words.length; i++ )
+        for( int i = 0; i < words.length; i++ ) //<.>
             words[i] = in.next().toLowerCase();
-        while( in.hasNext() ) {
+        while( in.hasNext() ) { //<.>
             temp = in.next().toLowerCase();         
-            for( int i = 0; i < n; i++ )
+            for( int i = 0; i < n; i++ ) //<.>
                 if( temp.equals( words[i] )) {
-                    counts[i]++;
+                    counts[i]++; //<.>
                     break;  
                 }           
         }

--- a/full/index.html
+++ b/full/index.html
@@ -9425,89 +9425,162 @@ assigning values, performing simple arithmetic and more advanced math,
 inputting and outputting data, and using the type system, which includes
 subtle differences between primitive and reference types. Our solution to the
 college cost calculator problem posed at the beginning of the chapter
-uses all of these features at some level.</p>
-</div>
-<div class="paragraph">
-<p>We present this solution below. The first step in our solution is to
-import <code>java.util.*</code> so that we can use the <code>Scanner</code> class. Then, we
-start the enclosing <code>CollegeCosts</code> class, begin the <code>main()</code> method,
-print a welcome message for the user, and create a <code>Scanner</code> object.</p>
+uses all of these features at some level. We present this solution below.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span>
+<pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span> <i class="conum" data-value="1"></i><b>(1)</b>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">CollegeCosts</span> <span class="o">{</span>
-    <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Welcome to the College Cost Calculator!"</span><span class="o">);</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span></code></pre>
+    <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Welcome to the College Cost Calculator!"</span><span class="o">);</span> <i class="conum" data-value="3"></i><b>(3)</b>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span> <i class="conum" data-value="4"></i><b>(4)</b></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The first step in our solution is to
+import <code>java.util.*</code> so that we can use the <code>Scanner</code> class.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>After we start the enclosing <code>CollegeCosts</code> class, we begin the <code>main()</code> method.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>We print a welcome message for the user.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Then, we create a <code>Scanner</code> object.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>Next is a sequence of prompts to the user interspersed with input done
-with the <code>Scanner</code> object. The program reads the user&#8217;s first name as a
-<code>String</code>, the user&#8217;s last name as a <code>String</code>, the per-semester tuition
-cost as a <code>double</code>, the monthly cost of rent as a <code>double</code>, the monthly
-cost of food as a <code>double</code>, the interest rate for the loan as a
-<code>double</code>, and the number of years needed to pay back the loan as an
-<code>int</code>.</p>
+with the <code>Scanner</code> object.</p>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Enter your first name:\t\t"</span><span class="o">);</span>
-        <span class="n">String</span> <span class="n">firstName</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span>
+        <span class="n">String</span> <span class="n">firstName</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span> <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Enter your last name:\t\t"</span><span class="o">);</span>
-        <span class="n">String</span> <span class="n">lastName</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span>
+        <span class="n">String</span> <span class="n">lastName</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Enter tuition per semester:\t$"</span><span class="o">);</span>
-        <span class="kt">double</span> <span class="n">semesterTuition</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
+        <span class="kt">double</span> <span class="n">semesterTuition</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="3"></i><b>(3)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Enter rent per month:\t\t$"</span><span class="o">);</span>
-        <span class="kt">double</span> <span class="n">monthlyRent</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
+        <span class="kt">double</span> <span class="n">monthlyRent</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="4"></i><b>(4)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Enter food cost per month:\t$"</span><span class="o">);</span>
-        <span class="kt">double</span> <span class="n">monthlyFood</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
+        <span class="kt">double</span> <span class="n">monthlyFood</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="5"></i><b>(5)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Annual interest rate:\t\t"</span><span class="o">);</span>
-        <span class="kt">double</span> <span class="n">annualInterest</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
+        <span class="kt">double</span> <span class="n">annualInterest</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="6"></i><b>(6)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Years to pay back your loan:\t"</span><span class="o">);</span>
-        <span class="kt">int</span> <span class="n">years</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span></code></pre>
+        <span class="kt">int</span> <span class="n">years</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="7"></i><b>(7)</b></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The program reads the user&#8217;s first name as a
+<code>String</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>the user&#8217;s last name as a <code>String</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>the per-semester tuition cost as a <code>double</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>the monthly cost of rent as a <code>double</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>the monthly cost of food as a <code>double</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="6"></i><b>6</b></td>
+<td>the interest rate for the loan as a <code>double</code>,</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="7"></i><b>7</b></td>
+<td>and the number of years needed to pay back the loan as an
+<code>int</code>.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
-<p>The next segment of code completes the computations needed. First, it
-finds the total yearly cost by doubling the semester cost, multiplying
-the monthly rent and food costs by 12, and summing the answers together.
-The four year cost is simply four times the yearly cost. To find the
-monthly payment, we find the monthly interest by dividing the annual
-interest rate by 12 and plugging this value into the formula from the
-beginning of the chapter. Finally, the total cost of the loan is the
-monthly payment times 12 times the number of years.</p>
+<p>The next segment of code completes the computations needed.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="kt">double</span> <span class="n">yearlyCost</span> <span class="o">=</span> <span class="n">semesterTuition</span> <span class="o">*</span> <span class="mf">2.0</span> <span class="o">+</span> <span class="o">(</span><span class="n">monthlyRent</span> <span class="o">+</span> <span class="n">monthlyFood</span><span class="o">)</span> <span class="o">*</span> <span class="mf">12.0</span><span class="o">;</span>
-        <span class="kt">double</span> <span class="n">fourYearCost</span> <span class="o">=</span> <span class="n">yearlyCost</span> <span class="o">*</span> <span class="mf">4.0</span><span class="o">;</span>
-        <span class="kt">double</span> <span class="n">monthlyInterest</span> <span class="o">=</span> <span class="n">annualInterest</span> <span class="o">/</span> <span class="mf">12.0</span><span class="o">;</span>
-        <span class="kt">double</span> <span class="n">monthlyPayment</span> <span class="o">=</span> <span class="n">fourYearCost</span> <span class="o">*</span> <span class="n">monthlyInterest</span> <span class="o">/</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="kt">double</span> <span class="n">yearlyCost</span> <span class="o">=</span> <span class="n">semesterTuition</span> <span class="o">*</span> <span class="mf">2.0</span> <span class="o">+</span> <span class="o">(</span><span class="n">monthlyRent</span> <span class="o">+</span> <span class="n">monthlyFood</span><span class="o">)</span> <span class="o">*</span> <span class="mf">12.0</span><span class="o">;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="kt">double</span> <span class="n">fourYearCost</span> <span class="o">=</span> <span class="n">yearlyCost</span> <span class="o">*</span> <span class="mf">4.0</span><span class="o">;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="kt">double</span> <span class="n">monthlyInterest</span> <span class="o">=</span> <span class="n">annualInterest</span> <span class="o">/</span> <span class="mf">12.0</span><span class="o">;</span> <i class="conum" data-value="3"></i><b>(3)</b>
+        <span class="kt">double</span> <span class="n">monthlyPayment</span> <span class="o">=</span> <span class="n">fourYearCost</span> <span class="o">*</span> <span class="n">monthlyInterest</span> <span class="o">/</span> <i class="conum" data-value="4"></i><b>(4)</b>
             <span class="o">(</span><span class="mf">1.0</span> <span class="o">-</span> <span class="n">Math</span><span class="o">.</span><span class="na">pow</span><span class="o">(</span><span class="mf">1.0</span> <span class="o">+</span> <span class="n">monthlyInterest</span><span class="o">,</span> <span class="o">-</span><span class="n">years</span> <span class="o">*</span> <span class="mf">12.0</span><span class="o">));</span>
-        <span class="kt">double</span> <span class="n">totalLoanCost</span> <span class="o">=</span> <span class="n">monthlyPayment</span> <span class="o">*</span> <span class="mf">12.0</span> <span class="o">*</span> <span class="n">years</span><span class="o">;</span></code></pre>
+        <span class="kt">double</span> <span class="n">totalLoanCost</span> <span class="o">=</span> <span class="n">monthlyPayment</span> <span class="o">*</span> <span class="mf">12.0</span> <span class="o">*</span> <span class="n">years</span><span class="o">;</span> <i class="conum" data-value="5"></i><b>(5)</b></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>It finds the total yearly cost by doubling the semester cost, multiplying
+the monthly rent and food costs by 12, and summing the answers together.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The four year cost is simply four times the yearly cost.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>To find the monthly payment, we find the monthly interest by dividing the annual
+interest rate by 12 and plugging this value into the formula from the
+beginning of the chapter.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Finally, the total cost of the loan is the
+monthly payment times 12 times the number of years.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
-<p>All that remains is to print out the output. First, we output a header
-describing the following output as college costs for the user. Using
-<code>System.out.format()</code> as described in <a href="#_primitive_types">Section 3.3.2</a>, we print out the yearly cost, four year cost, monthly loan
-payment, and total cost, all formatted with dollar signs, two places after
-the decimal point, and tabs so that the output lines up.</p>
+<p>All that remains is to print out the output.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"\nCollege costs for "</span> <span class="o">+</span> <span class="n">firstName</span> <span class="o">+</span> <span class="s">" "</span> <span class="o">+</span> <span class="n">lastName</span> <span class="o">);</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"\nCollege costs for "</span> <span class="o">+</span> <span class="n">firstName</span> <span class="o">+</span> <span class="s">" "</span> <span class="o">+</span> <span class="n">lastName</span> <span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"***************************************"</span><span class="o">);</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">"Yearly cost:\t\t\t$%.2f%n"</span><span class="o">,</span> <span class="n">yearlyCost</span><span class="o">);</span>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">"Yearly cost:\t\t\t$%.2f%n"</span><span class="o">,</span> <span class="n">yearlyCost</span><span class="o">);</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">"Four year cost:\t\t\t$%.2f%n"</span><span class="o">,</span> <span class="n">fourYearCost</span><span class="o">);</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">"Monthly loan payment:\t\t$%.2f%n"</span><span class="o">,</span> <span class="n">monthlyPayment</span><span class="o">);</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">format</span><span class="o">(</span><span class="s">"Total loan cost:\t\t$%.2f%n"</span><span class="o">,</span> <span class="n">totalLoanCost</span> <span class="o">);</span>
     <span class="o">}</span>
 <span class="o">}</span></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>First, we output a header
+describing the following output as college costs for the user.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Using
+<code>System.out.format()</code> as described in <a href="#_primitive_types">Section 3.3.2</a>, we print out the yearly cost, four year cost, monthly loan
+payment, and total cost, all formatted with dollar signs, two places after
+the decimal point, and tabs so that the output lines up.</td>
+</tr>
+</table>
 </div>
 </div>
 <div class="sect2">
@@ -12217,43 +12290,63 @@ down the sign.</p>
 the chapter. Recall that objects of the <code>Random</code> class allow us to generate all
 kinds of random values. To implement this simulation successfully, our
 program must make the decisions needed to set up the game for the
-user as well as respond to the user&#8217;s input. We begin with the <code>import</code>
-statement needed to use both the <code>Scanner</code> and <code>Random</code> class
-and then define the <code>MontyHall</code> class.</p>
+user as well as respond to the user&#8217;s input.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span>
+<pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span> <i class="conum" data-value="1"></i><b>(1)</b>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">MontyHall</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
         <span class="n">Random</span> <span class="n">random</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Random</span><span class="o">();</span>
-        <span class="kt">int</span> <span class="n">winner</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="na">nextInt</span><span class="o">(</span><span class="mi">3</span><span class="o">);</span>
+        <span class="kt">int</span> <span class="n">winner</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="na">nextInt</span><span class="o">(</span><span class="mi">3</span><span class="o">);</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Choose a door (enter 0, 1, or 2): "</span><span class="o">);</span>
-        <span class="kt">int</span> <span class="n">choice</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-        <span class="kt">int</span> <span class="n">alternative</span><span class="o">;</span>
+        <span class="kt">int</span> <span class="n">choice</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="3"></i><b>(3)</b>
+        <span class="kt">int</span> <span class="n">alternative</span><span class="o">;</span> <i class="conum" data-value="4"></i><b>(4)</b>
         <span class="kt">int</span> <span class="n">open</span><span class="o">;</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>In the <code>main()</code> method we first decide which of the three doors is the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>We begin with the <code>import</code>
+statement needed to use both the <code>Scanner</code> and <code>Random</code> class
+and then define the <code>MontyHall</code> class.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>In the <code>main()</code> method we first decide which of the three doors is the
 winner. To do so, we instantiate a <code>Random</code> object and use it to
 generate a random number that is either 0, 1, or 2 by calling the
 <code>nextInt()</code> method with an argument of <code>3</code>. We could have added 1 to
 this value to get a random choice of 1, 2, or 3, but many counting
-systems in computer science start with 0 instead of 1. You might as well
-get used to it. Next, we prompt the user to pick from the three doors
-and read the choice. Finally, we declare two more <code>int</code> values to keep
+systems in computer science start with 0 instead of 1. We might as well
+embrace it.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Next, we prompt the user to pick from the three doors
+and read the choice.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Finally, we declare two more <code>int</code> values to keep
 track of which door to open and which door is the alternative that the
-user can choose to change over to.</p>
+user can choose to change over to.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Now, we have to navigate a complicated series of decisions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="n">winner</span> <span class="o">)</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="n">winner</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="kt">int</span> <span class="n">low</span><span class="o">;</span>
             <span class="kt">int</span> <span class="n">high</span><span class="o">;</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span>  <span class="mi">0</span> <span class="o">)</span> <span class="o">{</span>
+            <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span>  <span class="mi">0</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
                 <span class="n">low</span> <span class="o">=</span> <span class="mi">1</span><span class="o">;</span>
                 <span class="n">high</span> <span class="o">=</span> <span class="mi">2</span><span class="o">;</span>
             <span class="o">}</span>
@@ -12266,34 +12359,54 @@ user can choose to change over to.</p>
                 <span class="n">high</span> <span class="o">=</span> <span class="mi">1</span><span class="o">;</span>
             <span class="o">}</span>
             <span class="c1">//randomly choose between other two doors</span>
-            <span class="kt">double</span> <span class="n">threshold</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">threshold</span> <span class="o">&lt;</span> <span class="mf">0.5</span> <span class="o">)</span> <span class="o">{</span>
+            <span class="kt">double</span> <span class="n">threshold</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="na">nextDouble</span><span class="o">();</span> <i class="conum" data-value="3"></i><b>(3)</b>
+            <span class="k">if</span><span class="o">(</span> <span class="n">threshold</span> <span class="o">&lt;</span> <span class="mf">0.5</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="4"></i><b>(4)</b>
                 <span class="n">alternative</span> <span class="o">=</span> <span class="n">low</span><span class="o">;</span>
                 <span class="n">open</span> <span class="o">=</span> <span class="n">high</span><span class="o">;</span>
             <span class="o">}</span>
-            <span class="k">else</span> <span class="o">{</span>
+            <span class="k">else</span> <span class="o">{</span> <i class="conum" data-value="5"></i><b>(5)</b>
                 <span class="n">alternative</span> <span class="o">=</span> <span class="n">high</span><span class="o">;</span>
                 <span class="n">open</span> <span class="o">=</span> <span class="n">low</span><span class="o">;</span>
             <span class="o">}</span>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>Now, we have to navigate a complicated series of decisions. In this
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>In this
 segment of code, we tackle the possibility that the user happened
 to choose the winning door. To obey the rules of the game, we must
-randomly pick which of the two other doors to open. First, we determine
+randomly pick which of the two other doors to open.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>First, we determine
 which are the other two doors and save them in <code>low</code> and <code>high</code>,
-respectively. Then, we generated a random number. If the random number
+respectively.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Then, we generate a random number.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>If the random number
 is less than 0.5, we keep the lower numbered door as an alternative
-choice for the user and open the higher numbered door. If the random
-number is greater than or equal to 0.5, we do the opposite.</p>
+choice for the user and open the higher numbered door.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>If the random number is greater than or equal to 0.5, we do the opposite.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">else</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">else</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="n">alternative</span> <span class="o">=</span> <span class="n">winner</span><span class="o">;</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="mi">0</span> <span class="o">)</span> <span class="o">{</span>
+            <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="mi">0</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
                 <span class="k">if</span><span class="o">(</span> <span class="n">winner</span> <span class="o">==</span> <span class="mi">1</span> <span class="o">)</span>
                     <span class="n">open</span> <span class="o">=</span> <span class="mi">2</span><span class="o">;</span>
                 <span class="k">else</span>
@@ -12314,28 +12427,40 @@ number is greater than or equal to 0.5, we do the opposite.</p>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>This <code>else</code> block covers the case that the player did <strong>not</strong> pick the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>This <code>else</code> block covers the case that the player did <strong>not</strong> pick the
 winning door the first time. Unlike the previous code segment, we no
-longer have a choice of which door to open. Instead, we must always
+longer have a choice of which door to open.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Instead, we must always
 make the winner the alternative for the user to pick. Then, we simply
-determine which door is left over so that we can open it. Note that the
+determine which door is left over so that we can open it.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Note that the
 braces surrounding the blocks for each of the braces surrounding the
 blocks for each of the three possible values of <code>choice</code> are not
 necessary but are included for readability.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"We have opened Door "</span> <span class="o">+</span> <span class="n">open</span> <span class="o">+</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"We have opened Door "</span> <span class="o">+</span> <span class="n">open</span> <span class="o">+</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="s">", and there is junk behind it!"</span><span class="o">);</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Do you want to change to Door "</span> <span class="o">+</span>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Do you want to change to Door "</span> <span class="o">+</span> <i class="conum" data-value="2"></i><b>(2)</b>
             <span class="n">alternative</span> <span class="o">+</span> <span class="s">" from Door "</span> <span class="o">+</span> <span class="n">choice</span> <span class="o">+</span>
             <span class="s">"? (Enter 'y' or 'n'): "</span><span class="o">);</span>
         <span class="n">String</span> <span class="n">change</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">();</span>
         <span class="k">if</span><span class="o">(</span> <span class="n">change</span><span class="o">.</span><span class="na">equals</span><span class="o">(</span><span class="s">"y"</span><span class="o">)</span> <span class="o">)</span>
             <span class="n">choice</span> <span class="o">=</span> <span class="n">alternative</span><span class="o">;</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"You chose Door "</span> <span class="o">+</span> <span class="n">choice</span><span class="o">);</span>
-        <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="n">winner</span> <span class="o">)</span>
+        <span class="k">if</span><span class="o">(</span> <span class="n">choice</span> <span class="o">==</span> <span class="n">winner</span> <span class="o">)</span> <i class="conum" data-value="3"></i><b>(3)</b>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"You win a pile of gold!"</span><span class="o">);</span>
         <span class="k">else</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"You win a pile of junk."</span><span class="o">);</span>
@@ -12343,11 +12468,23 @@ necessary but are included for readability.</p>
 <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>This final segment of code informs the user which door has been opened
-and prompts the user to change his or her decision. Depending on the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>This final segment of code informs the user which door has been opened.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>It prompts the user to change his or her decision.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Depending on the
 final choice, the program says whether or not the user wins gold or
-junk.</p>
+junk.</td>
+</tr>
+</table>
 </div>
 </div>
 <div class="sect2">
@@ -14082,55 +14219,82 @@ definition.</p>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">DNASearch</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="n">String</span> <span class="n">sequence</span><span class="o">,</span> <span class="n">subsequence</span><span class="o">;</span>
-        <span class="kt">boolean</span> <span class="n">valid</span><span class="o">;</span>
+        <span class="kt">boolean</span> <span class="n">valid</span><span class="o">;</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="kt">char</span> <span class="n">c</span><span class="o">;</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The <code>main()</code> method instantiates a <code>Scanner</code> object and declares both of
-the <code>String</code> variables we&#8217;ll need to store the DNA sequences. The method
-also declares a <code>boolean</code> and a <code>char</code> we&#8217;ll use for input checking.</p>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The <code>main()</code> method instantiates a <code>Scanner</code> object and declares both of
+the <code>String</code> variables we&#8217;ll need to store the DNA sequences.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The method
+also declares a <code>boolean</code> and a <code>char</code> we&#8217;ll use for input checking.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="k">do</span> <span class="o">{</span>
-            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span>
-                <span class="s">"Enter the DNA sequence you wish to search in: "</span><span class="o">);</span>
-            <span class="n">sequence</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toUpperCase</span><span class="o">();</span>
+            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Enter the DNA sequence you wish to search in: "</span><span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="n">sequence</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toUpperCase</span><span class="o">();</span> <i class="conum" data-value="2"></i><b>(2)</b>
             <span class="n">valid</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span> <span class="n">valid</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span> <span class="n">valid</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="3"></i><b>(3)</b>
                 <span class="n">c</span> <span class="o">=</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span><span class="o">);</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'A'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'C'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'G'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'T'</span><span class="o">)</span> <span class="o">{</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">c</span> <span class="o">!=</span> <span class="sc">'A'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'C'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'G'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'T'</span><span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="4"></i><b>(4)</b>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Invalid DNA sequence!"</span><span class="o">);</span>
                     <span class="n">valid</span> <span class="o">=</span> <span class="kc">false</span><span class="o">;</span>
                 <span class="o">}</span>
             <span class="o">}</span>
-        <span class="o">}</span> <span class="k">while</span><span class="o">(</span> <span class="o">!</span><span class="n">valid</span> <span class="o">);</span></code></pre>
+        <span class="o">}</span> <span class="k">while</span><span class="o">(</span> <span class="o">!</span><span class="n">valid</span> <span class="o">);</span> <i class="conum" data-value="5"></i><b>(5)</b></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>Next, the user is prompted for a DNA sequence to search in. This
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Next, the user is prompted for a DNA sequence to search in.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>This
 <code>String</code> stored in <code>sequence</code> is converted to upper case just in case
-the user is not being consistent. The inner <code>for</code> loop in this code is
-checking each <code>char</code> inside of <code>sequence</code>. If any <code>char</code> is not an
+the user is not being consistent.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>The inner <code>for</code> loop in this code checks each <code>char</code> inside of <code>sequence</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>If any <code>char</code> is not an
 <code>'A'</code>, <code>'C'</code>, <code>'G'</code>, or <code>'T'</code>, then <code>valid</code> is set to <code>false</code>. As a
 result, the <code>for</code> loop terminates. Also, the <code>do-while</code> loop repeats the
-prompt and gets a new <code>String</code> for <code>sequence</code> from the user. This outer
+prompt and gets a new <code>String</code> for <code>sequence</code> from the user.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>This outer
 <code>do-while</code> loop continues as long as the user keeps entering invalid DNA
-sequences.</p>
+sequences.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="k">do</span> <span class="o">{</span>
-            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span>
-                <span class="s">"Enter the subsequence you wish to search for: "</span><span class="o">);</span>
+            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Enter the subsequence you wish to search for: "</span><span class="o">);</span>
             <span class="n">subsequence</span>  <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toUpperCase</span><span class="o">();</span>
             <span class="n">valid</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
             <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span> <span class="n">valid</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span>
                 <span class="n">c</span> <span class="o">=</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span><span class="o">);</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'A'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'C'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'G'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'T'</span><span class="o">)</span> <span class="o">{</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">c</span> <span class="o">!=</span> <span class="sc">'A'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'C'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'G'</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">!=</span> <span class="sc">'T'</span><span class="o">)</span> <span class="o">{</span>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Invalid DNA sequence!"</span><span class="o">);</span>
                     <span class="n">valid</span> <span class="o">=</span> <span class="kc">false</span><span class="o">;</span>
                 <span class="o">}</span>
@@ -14145,12 +14309,11 @@ virtually identical to the code to input <code>sequence</code>.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="kt">int</span> <span class="n">found</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span>
-            <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">();</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-                <span class="k">if</span><span class="o">(</span><span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">!=</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">))</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">();</span> <span class="n">j</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">if</span><span class="o">(</span><span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">!=</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">))</span> <i class="conum" data-value="3"></i><b>(3)</b>
                     <span class="k">break</span><span class="o">;</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="mi">1</span> <span class="o">)</span> <span class="o">{</span> <span class="c1">//matches</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="mi">1</span><span class="o">)</span> <span class="o">{</span> <span class="c1">//matches </span><i class="conum" data-value="4"></i><b>(4)</b>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Match found at index "</span> <span class="o">+</span> <span class="n">i</span><span class="o">);</span>
                     <span class="n">found</span><span class="o">++;</span>
                 <span class="o">}</span>
@@ -14158,8 +14321,11 @@ virtually identical to the code to input <code>sequence</code>.</p>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The actual workhorse of the search is found in these nested <code>for</code> loops.
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The workhorse of the search is found in these nested <code>for</code> loops.
 The outer loop iterates through every index in <code>sequence</code>, until it
 comes to an index that is too late to be the start of a new subsequence
 (since the subsequence would be too long to fit anymore). This happens
@@ -14171,18 +14337,29 @@ the same length, you need to check starting at index <code>0</code> of <code>seq
 but not any later indexes. Also, if <code>subsequence</code> is one <code>char</code> longer
 than <code>sequence</code>, there can never be a match. In that case, the value of
 <code>sequence.length() - subsequence.length() + 1</code> would be <code>0</code>. Since <code>0</code>
-is not less than <code>0</code>, the outer <code>for</code> loop would never execute.</p>
-</div>
-<div class="paragraph">
-<p>The inner <code>for</code> loop iterates through the length of <code>subsequence</code>,
+is not less than <code>0</code>, the outer <code>for</code> loop would never execute.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The inner <code>for</code> loop iterates through the length of <code>subsequence</code>,
 making sure that every <code>char</code> in <code>sequence</code>, starting at the appropriate
-offset, exactly matches a <code>char</code> in <code>subsequence</code>. If, at any point, the
+offset, exactly matches a <code>char</code> in <code>subsequence</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>If, at any point, the
 two <code>char</code> values do not match, the inner <code>for</code> loop will immediately
-exit, using the <code>break</code> command. However, on the last iteration of the
+exit, using the <code>break</code> command.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>However, on the last iteration of the
 inner <code>for</code> loop, when <code>j</code> is one less than the length of <code>subsequence</code>,
 we know that all of <code>subsequence</code> matched a part of <code>sequence</code>. As a
 result, we print out the index of <code>sequence</code> where <code>subsequence</code> started
-and increment the <code>found</code> counter.</p>
+and increment the <code>found</code> counter.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>If you know the <code>String</code> class well, you can use the <code>indexOf()</code> method
@@ -14195,20 +14372,20 @@ to replace the inner <code>for</code> loop. We leave that approach as an exercis
 </div>
 </div>
 </div>
+<div class="paragraph">
+<p>Finally, we print out the total number of matches found. In order to
+avoid awkward output like <code>1 matches found.</code>, we used an <code>if</code>-<code>else</code> to
+customize the output based on the value of <code>found</code>.</p>
+</div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">if</span><span class="o">(</span> <span class="n">found</span> <span class="o">==</span> <span class="mi">1</span> <span class="o">)</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">if</span><span class="o">(</span><span class="n">found</span> <span class="o">==</span> <span class="mi">1</span><span class="o">)</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"One match found."</span><span class="o">);</span>
         <span class="k">else</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">found</span> <span class="o">+</span> <span class="s">" matches found."</span><span class="o">);</span>
     <span class="o">}</span>
 <span class="o">}</span></code></pre>
 </div>
-</div>
-<div class="paragraph">
-<p>Finally, we print out the total number of matches found. In order to
-avoid awkward output like <code>1 matches found.</code>, we used an <code>if</code>-<code>else</code> to
-customize the output based on the value of <code>found</code>.</p>
 </div>
 <div class="paragraph">
 <p>The ideas needed to correctly implement the solution are not difficult,
@@ -14220,11 +14397,10 @@ follows.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java"><span class="kt">int</span> <span class="n">found</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
-<span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span>
-    <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-    <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span>
-        <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">==</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">);</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
-        <span class="k">if</span><span class="o">(</span> <span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="mi">1</span> <span class="o">)</span> <span class="o">{</span> <span class="c1">//matches</span>
+<span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span>
+    <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span>
+        <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">==</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">);</span> <span class="n">j</span><span class="o">++)</span>
+        <span class="k">if</span><span class="o">(</span><span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="mi">1</span><span class="o">)</span> <span class="o">{</span> <span class="c1">//matches</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Match found at index "</span> <span class="o">+</span> <span class="n">i</span><span class="o">);</span>
             <span class="n">found</span><span class="o">++;</span>
         <span class="o">}</span>
@@ -14241,11 +14417,10 @@ matching process is done outside of the inner <code>for</code> loop.</p>
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java"><span class="kt">int</span> <span class="n">found</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
 <span class="kt">int</span> <span class="n">j</span><span class="o">;</span>
-<span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span>
-    <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-    <span class="k">for</span><span class="o">(</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span>
-        <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">==</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">);</span> <span class="n">j</span><span class="o">++</span> <span class="o">);</span>
-    <span class="k">if</span><span class="o">(</span> <span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">)</span> <span class="o">{</span> <span class="c1">//matches</span>
+<span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">sequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">-</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span>
+    <span class="k">for</span><span class="o">(</span><span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">()</span> <span class="o">&amp;&amp;</span>
+        <span class="n">subsequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">j</span><span class="o">)</span> <span class="o">==</span> <span class="n">sequence</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">i</span> <span class="o">+</span> <span class="n">j</span><span class="o">);</span> <span class="n">j</span><span class="o">++);</span>
+    <span class="k">if</span><span class="o">(</span><span class="n">j</span> <span class="o">==</span> <span class="n">subsequence</span><span class="o">.</span><span class="na">length</span><span class="o">())</span> <span class="o">{</span> <span class="c1">//matches</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Match found at index "</span> <span class="o">+</span> <span class="n">i</span><span class="o">);</span>
         <span class="n">found</span><span class="o">++;</span>
     <span class="o">}</span>
@@ -14255,8 +14430,8 @@ matching process is done outside of the inner <code>for</code> loop.</p>
 <div class="paragraph">
 <p>In this case, note that we must declare <code>j</code> outside of the inner <code>for</code>
 loop, since it will be used outside. This approach is more efficient
-because we only need to perform the check once. Notice also that the
-condition of the <code>if</code> statement has changed. Now, we know that all of
+because we only need to perform the check once. Notice that the
+condition of the <code>if</code> statement has also changed. Now, we know that all of
 <code>subsequence</code> matches because the loop ran to completion. If the loop
 did not run to completion, then <code>j</code> would be smaller than
 <code>subsequence.length()</code> and the loop must have terminated because the two
@@ -15422,7 +15597,7 @@ of the array is \(n\), we&#8217;ll need to look for the smallest
 element in the array \(n - 1\) times. By putting the code that
 searches for the smallest value inside of an outer loop, we can write a
 program that does selection sort of <code>int</code> values input by the user as
-follows.</p>
+follows. This program&#8217;s not very long, but there&#8217;s a lot going on.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -15430,58 +15605,87 @@ follows.</p>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">SelectionSort</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
-        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-        <span class="kt">int</span><span class="o">[]</span> <span class="n">values</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span>
+        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="kt">int</span><span class="o">[]</span> <span class="n">values</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="kt">int</span> <span class="n">smallest</span><span class="o">;</span>
         <span class="kt">int</span> <span class="n">temp</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <i class="conum" data-value="3"></i><b>(3)</b>
             <span class="n">values</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>This program is not very long, but there&#8217;s a lot going on. After
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>After
 instantiating a <code>Scanner</code>, we read in the total number of values the
 list will hold. We cannot rely on the <code>hasNextInt()</code> method to tell us
-when to stop reading values. We need to know up front how many values we
+when to stop reading values.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>We need to know up front how many values we
 are going to store so that we can instantiate our array with the
-appropriate length. Then, we read each value into the array using the
-first <code>for</code> loop.</p>
+appropriate length.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Then, we read each value into the array using the
+first <code>for</code> loop.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="n">smallest</span> <span class="o">=</span> <span class="n">i</span><span class="o">;</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">values</span><span class="o">[</span><span class="n">j</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">]</span> <span class="o">)</span>
-                    <span class="n">smallest</span> <span class="o">=</span> <span class="n">j</span><span class="o">;</span>
-            <span class="n">temp</span> <span class="o">=</span> <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">];</span>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">j</span><span class="o">++)</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">if</span><span class="o">(</span><span class="n">values</span><span class="o">[</span><span class="n">j</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">])</span>
+                    <span class="n">smallest</span> <span class="o">=</span> <span class="n">j</span><span class="o">;</span> <i class="conum" data-value="3"></i><b>(3)</b>
+            <span class="n">temp</span> <span class="o">=</span> <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">];</span> <i class="conum" data-value="4"></i><b>(4)</b>
             <span class="n">values</span><span class="o">[</span><span class="n">smallest</span><span class="o">]</span> <span class="o">=</span> <span class="n">values</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
             <span class="n">values</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">temp</span><span class="o">;</span>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The next <code>for</code> loop is where the actual sort happens. We start at index
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The next <code>for</code> loop is where the actual sort happens. We start at index
 <code>0</code> and then try to find the smallest value to be put in that spot.
 Then, we move on to index <code>1</code>, and so on, just as we described before.
 Note that we only go up to <code>n - 2</code>. We don&#8217;t need to find the value to
 put in index <code>n - 1</code>, because the rest of the list has the <code>n - 1</code>
 smallest numbers in it and so the last number <strong>must</strong> already be the
-largest. If you look carefully, you&#8217;ll notice that the inner <code>for</code>
+largest.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>If you look carefully, you&#8217;ll notice that the inner <code>for</code>
 loop has the same overall shape as the loop used to find the smallest
-value in the previous example; however, there is one key difference:
-Instead of storing the <strong>value</strong> of the smallest number in <code>smallest</code>, we
+value in the previous example; however, there is one key difference:</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Instead of storing the <strong>value</strong> of the smallest number in <code>smallest</code>, we
 now store the <strong>index</strong> of the smallest number. We need to store the index
 of the smallest number so that, in the next step, we can swap the
 corresponding element with the element at <code>i</code>, the spot in the array
-we&#8217;re trying to fill. The three lines after the inner <code>for</code> loop are a
-simple swap to do exactly that.</p>
+we&#8217;re trying to fill.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>The three lines after the inner <code>for</code> loop are a
+simple swap to do exactly that.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"The sorted list is: "</span><span class="o">);</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">values</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span>
             <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="n">values</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">+</span> <span class="s">" "</span><span class="o">);</span>
     <span class="o">}</span>
 <span class="o">}</span></code></pre>
@@ -15489,7 +15693,10 @@ simple swap to do exactly that.</p>
 </div>
 <div class="paragraph">
 <p>After all the sorting is done, the final <code>for</code> loop prints out the newly
-sorted list. This program gives no prompts for user input, so it&#8217;s well
+sorted list.</p>
+</div>
+<div class="paragraph">
+<p>This program gives no prompts for user input, so it&#8217;s well
 designed for input redirection. If you&#8217;re going to make a file
 containing numbers you want to sort with this program, make sure that
 the first number is the total count of numbers in the file.</p>
@@ -15531,41 +15738,70 @@ the text we want to search through.</p>
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">WordCount</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
         <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
-        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-        <span class="n">String</span><span class="o">[]</span> <span class="n">words</span> <span class="o">=</span> <span class="k">new</span> <span class="n">String</span><span class="o">[</span><span class="n">n</span><span class="o">];</span>
-        <span class="kt">int</span><span class="o">[]</span> <span class="n">counts</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span>
+        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="n">String</span><span class="o">[]</span> <span class="n">words</span> <span class="o">=</span> <span class="k">new</span> <span class="n">String</span><span class="o">[</span><span class="n">n</span><span class="o">];</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="kt">int</span><span class="o">[]</span> <span class="n">counts</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span> <i class="conum" data-value="3"></i><b>(3)</b>
         <span class="n">String</span> <span class="n">temp</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">words</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">words</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <i class="conum" data-value="4"></i><b>(4)</b>
             <span class="n">words</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toLowerCase</span><span class="o">();</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>As in the last example, this program begins by reading in the length of
-the list of words. Then, it instantiates the <code>String</code> array <code>words</code> to
-hold these words. It also instantiates an array <code>counts</code> of type <code>int</code>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>As in the last example, this program begins by reading in the length of
+the list of words.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Then, it instantiates the <code>String</code> array <code>words</code> to
+hold these words.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>It also instantiates an array <code>counts</code> of type <code>int</code>
 to keep track of the number of times each word is found. By default,
-each element in <code>counts</code> is initialized to <code>0</code>. The first <code>for</code> loop in
-the program reads in each word and stores it into the array <code>words</code>.</p>
+each element in <code>counts</code> is initialized to <code>0</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>The first <code>for</code> loop in
+the program reads in each word and stores it into the array <code>words</code>.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">while</span><span class="o">(</span> <span class="n">in</span><span class="o">.</span><span class="na">hasNext</span><span class="o">()</span> <span class="o">)</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">while</span><span class="o">(</span> <span class="n">in</span><span class="o">.</span><span class="na">hasNext</span><span class="o">()</span> <span class="o">)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="n">temp</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">next</span><span class="o">().</span><span class="na">toLowerCase</span><span class="o">();</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <i class="conum" data-value="2"></i><b>(2)</b>
                 <span class="k">if</span><span class="o">(</span> <span class="n">temp</span><span class="o">.</span><span class="na">equals</span><span class="o">(</span> <span class="n">words</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">))</span> <span class="o">{</span>
-                    <span class="n">counts</span><span class="o">[</span><span class="n">i</span><span class="o">]++;</span>
+                    <span class="n">counts</span><span class="o">[</span><span class="n">i</span><span class="o">]++;</span> <i class="conum" data-value="3"></i><b>(3)</b>
                     <span class="k">break</span><span class="o">;</span>
                 <span class="o">}</span>
         <span class="o">}</span>
         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"The word counts are: "</span><span class="o">);</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The <code>while</code> loop reads in each word from the text following the list and
-stores it in a variable called <code>temp</code>. Then, it loops through <code>words</code>
-and tests to see if <code>temp</code> matches any of the elements in the list. If
-it does, it increases the value of the element of <code>counts</code> that has the
-same index and breaks out of the inner <code>for</code> loop.</p>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The <code>while</code> loop reads in each word from the text following the list and
+stores it in a variable called <code>temp</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Then, it loops through <code>words</code>
+and tests to see if <code>temp</code> matches any of the elements in the list.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>If it does, it increases the value of the element of <code>counts</code> that has the
+same index and breaks out of the inner <code>for</code> loop.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -15727,40 +15963,65 @@ solve after the previous examples.</p>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">Statistics</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
-        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-        <span class="kt">int</span><span class="o">[]</span> <span class="n">scores</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span>
+        <span class="kt">int</span> <span class="n">n</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="kt">int</span><span class="o">[]</span> <span class="n">scores</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">int</span><span class="o">[</span><span class="n">n</span><span class="o">];</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <i class="conum" data-value="3"></i><b>(3)</b>
             <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>In our solution, the <code>main()</code> method begins by reading in the total
-number of scores and declaring an <code>int</code> array of that length named
-<code>scores</code>. Then, we read in each of the scores and store them into
-<code>scores</code>.</p>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>In our solution, the <code>main()</code> method begins by reading in the total
+number of scores.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>It declares an <code>int</code> array of that length named
+<code>scores</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Then, we read in each of the scores and store them into
+<code>scores</code>.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="kt">int</span> <span class="n">max</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="kt">int</span> <span class="n">max</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span> <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="kt">int</span> <span class="n">min</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span>
         <span class="kt">int</span> <span class="n">sum</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">&gt;</span> <span class="n">max</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
+            <span class="k">if</span><span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">&gt;</span> <span class="n">max</span><span class="o">)</span>
                 <span class="n">max</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">min</span> <span class="o">)</span>
+            <span class="k">if</span><span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">min</span><span class="o">)</span>
                 <span class="n">min</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
             <span class="n">sum</span> <span class="o">+=</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
         <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>Here we declare variables <code>max</code>, <code>min</code>, and <code>sum</code> to hold, respectively,
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Here we declare variables <code>max</code>, <code>min</code>, and <code>sum</code> to hold, respectively,
 the maximum, minimum, and sum of the elements in the array. Then, we set
 all three variables to the value of the first element of the array.
-These initializations make the following code work. In a single <code>for</code>
+These initializations make the following code work.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>In a single <code>for</code>
 loop, we find the maximum, minimum, and sum of all the values in the
-array. We could have done so with three separate loops, but this
+array.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>We could have done so with three separate loops, but this
 approach is more efficient. Setting <code>max</code> and <code>min</code> to <code>scores[0]</code>
 follows the pattern we&#8217;ve used before, but setting <code>sum</code> to the same
 value is also necessary in this case. Because the loop iterates from <code>1</code>
@@ -15784,46 +16045,58 @@ statistics we&#8217;ve computed.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="kt">double</span> <span class="n">variance</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
-            <span class="n">variance</span> <span class="o">+=</span> <span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">-</span> <span class="n">mean</span><span class="o">)*(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">-</span> <span class="n">mean</span><span class="o">);</span>
-        <span class="n">variance</span> <span class="o">/=</span> <span class="o">(</span><span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">);</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Standard Deviation:\t"</span> <span class="o">+</span> <span class="n">Math</span><span class="o">.</span><span class="na">sqrt</span><span class="o">(</span><span class="n">variance</span><span class="o">));</span></code></pre>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span>
+            <span class="n">variance</span> <span class="o">+=</span> <span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">-</span> <span class="n">mean</span><span class="o">)*(</span><span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">-</span> <span class="n">mean</span><span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="n">variance</span> <span class="o">/=</span> <span class="o">(</span><span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">);</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Standard Deviation:\t"</span> <span class="o">+</span> <span class="n">Math</span><span class="o">.</span><span class="na">sqrt</span><span class="o">(</span><span class="n">variance</span><span class="o">));</span> <i class="conum" data-value="3"></i><b>(3)</b></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>At this point, we use the mean we&#8217;ve already computed to find the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>At this point, we use the mean we&#8217;ve already computed to find the
 sample standard deviation. Following the formula for sample standard
 deviation, we subtract the mean from each score, square the result, and
 add it to a running total. Although the formula for sample standard
 deviation uses the bounds \(1\) to \(n\), we
-translate them to <code>0</code> to <code>n - 1</code> because of zero-based array numbering.
-Dividing the total by <code>n - 1</code> gives the sample variance. Then, the
-square root of the variance is the standard deviation.</p>
+translate them to <code>0</code> to <code>n - 1</code> because of zero-based array numbering.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Dividing the total by <code>n - 1</code> gives the sample variance.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Then, the
+square root of the variance is the standard deviation.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java">        <span class="kt">int</span> <span class="n">temp</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">n</span> <span class="o">-</span> <span class="mi">1</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
             <span class="n">min</span> <span class="o">=</span> <span class="n">i</span><span class="o">;</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">scores</span><span class="o">[</span><span class="n">j</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">scores</span><span class="o">[</span><span class="n">min</span><span class="o">]</span> <span class="o">)</span>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">n</span><span class="o">;</span> <span class="n">j</span><span class="o">++)</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">j</span><span class="o">]</span> <span class="o">&lt;</span> <span class="n">scores</span><span class="o">[</span><span class="n">min</span><span class="o">])</span>
                     <span class="n">min</span> <span class="o">=</span> <span class="n">j</span><span class="o">;</span>
             <span class="n">temp</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">min</span><span class="o">];</span>
             <span class="n">scores</span><span class="o">[</span><span class="n">min</span><span class="o">]</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">];</span>
             <span class="n">scores</span><span class="o">[</span><span class="n">i</span><span class="o">]</span> <span class="o">=</span> <span class="n">temp</span><span class="o">;</span>
-        <span class="o">}</span>
-        <span class="kt">double</span> <span class="n">median</span><span class="o">;</span>
-        <span class="k">if</span><span class="o">(</span> <span class="n">n</span> <span class="o">%</span> <span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span> <span class="o">)</span>
-            <span class="n">median</span> <span class="o">=</span> <span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span><span class="o">]</span> <span class="o">+</span> <span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span> <span class="o">+</span> <span class="mi">1</span><span class="o">])/</span><span class="mf">2.0</span><span class="o">;</span>
-        <span class="k">else</span>
-            <span class="n">median</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span><span class="o">];</span>
-        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Median:\t\t\t"</span> <span class="o">+</span> <span class="n">median</span><span class="o">);</span>
-    <span class="o">}</span>
-<span class="o">}</span></code></pre>
+        <span class="o">}</span></code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>To find the median, we use our selection sort code.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
-<p>To find the median, we use our selection sort code. Note that we have
+<p>Note that we have
 reused the variable <code>min</code> to hold the smallest value found so far,
 instead of declaring a new variable such as <code>smallest</code>. Some programmers
 might object to doing so, since we run the risk of interpreting the
@@ -15831,20 +16104,45 @@ variable as the minimum value in the entire array, as it was before.
 Either approach is fine. If you worry about confusing people reading
 your code, add a comment.</p>
 </div>
-<div class="paragraph">
-<p>After the array has been sorted, we need to do a quick check to see if
-its length is odd or even. If its length is even, we need to find the
-average of the two middle elements. If its length is odd, we can report
-the value of the single middle element.</p>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java">        <span class="kt">double</span> <span class="n">median</span><span class="o">;</span>
+        <span class="k">if</span><span class="o">(</span><span class="n">n</span> <span class="o">%</span> <span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span><span class="o">)</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="n">median</span> <span class="o">=</span> <span class="o">(</span><span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span><span class="o">]</span> <span class="o">+</span> <span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span> <span class="o">+</span> <span class="mi">1</span><span class="o">])/</span><span class="mf">2.0</span><span class="o">;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="k">else</span>
+            <span class="n">median</span> <span class="o">=</span> <span class="n">scores</span><span class="o">[</span><span class="n">n</span><span class="o">/</span><span class="mi">2</span><span class="o">];</span> <i class="conum" data-value="3"></i><b>(3)</b>
+        <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Median:\t\t\t"</span> <span class="o">+</span> <span class="n">median</span><span class="o">);</span>
+    <span class="o">}</span>
+<span class="o">}</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>After the array has been sorted, we need to do a quick check to see if
+its length is odd or even.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>If its length is even, we need to find the average of the two middle elements.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>If its length is odd, we can report the value of the single middle element.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>Note that some of the statistics we found, such as the maximum, minimum,
-or mean, could be computed using loops without an array for storage.
-However, the last two tasks need to store all of the values at once in
-order to work. The simplest way to find the sample standard deviation of a list of values
-requires its mean. At least two passes over the data are needed to
-compute the sample standard deviation: one to find the mean and another
-to apply the equation for sample standard deviation.</p>
+or mean, could be computed with a single pass over the data
+without the need for an array for storage.
+However, the last two tasks need to store all the values to work.
+The simplest way to find the sample standard deviation of a list of values
+requires its mean, requiring one pass to find the mean and a second
+to sum the squares of the difference of the mean and each value.
+Likewise, it&#8217;s impossible to find the median of a list of values without
+storing the list.</p>
 </div>
 <div class="sidebarblock">
 <div class="content">
@@ -16910,60 +17208,58 @@ checkers, chess, or Go. Our program will catch any attempt to play on a
 location that has already been played and will determine the winner, if
 there is one.</p>
 </div>
+<div class="paragraph">
+<p>Games often give rise to complex programs, since rules that are
+intuitively obvious to humans may be difficult to state explicitly in
+Java. Our program begins by setting up quite a few variables and
+objects.</p>
+</div>
 <div class="listingblock">
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java"><span class="kn">import</span> <span class="nn">java.util.*</span><span class="o">;</span>
 
 <span class="kd">public</span> <span class="kd">class</span> <span class="nc">TicTacToe</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span> <span class="n">System</span><span class="o">.</span><span class="na">in</span> <span class="o">);</span>
-        <span class="kt">char</span><span class="o">[][]</span> <span class="n">board</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">char</span><span class="o">[</span><span class="mi">3</span><span class="o">][</span><span class="mi">3</span><span class="o">];</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">].</span><span class="na">length</span><span class="o">;</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
+        <span class="n">Scanner</span> <span class="n">in</span> <span class="o">=</span> <span class="k">new</span> <span class="n">Scanner</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span>  <i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="kt">char</span><span class="o">[][]</span> <span class="n">board</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">char</span><span class="o">[</span><span class="mi">3</span><span class="o">][</span><span class="mi">3</span><span class="o">];</span>      <i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <i class="conum" data-value="3"></i><b>(3)</b>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">j</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">].</span><span class="na">length</span><span class="o">;</span> <span class="n">j</span><span class="o">++)</span>
                 <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="n">j</span><span class="o">]</span> <span class="o">=</span> <span class="sc">' '</span><span class="o">;</span>
-        <span class="kt">boolean</span> <span class="n">turn</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
+        <span class="kt">boolean</span> <span class="n">turn</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>        <i class="conum" data-value="4"></i><b>(4)</b>
         <span class="kt">boolean</span> <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">false</span><span class="o">;</span>
-        <span class="kt">int</span> <span class="n">row</span><span class="o">,</span> <span class="n">column</span><span class="o">,</span> <span class="n">moves</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
+        <span class="kt">int</span> <span class="n">row</span><span class="o">,</span> <span class="n">column</span><span class="o">,</span> <span class="n">moves</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <i class="conum" data-value="5"></i><b>(5)</b>
         <span class="kt">char</span> <span class="n">shape</span><span class="o">;</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>Games often give rise to complex programs, since rules that are
-intuitively obvious to humans may be difficult to state explicitly in
-Java. Our program begins by setting up quite a few variables and
-objects. First, we create a <code>Scanner</code> to read in data. Then, we declare
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>First, we create a <code>Scanner</code> to read in data.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Then, we declare
 and instantiate our 3 × 3 playing board as a
-two-dimensional array of type <code>char</code>. We want any unplayed space on the
-grid to be the <code>char</code> for a space, so we fill the array with <code>' '</code>.
-Next, we declare a <code>boolean</code> value to keep track of whose turn it is and
-another to keep track of whether the game is over. Finally, we
+two-dimensional array of type <code>char</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>We want any unplayed space on the
+grid to be the <code>char</code> for a space, so we fill the array with <code>' '</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Next, we declare a <code>boolean</code> value to keep track of whose turn it is and
+another to keep track of whether the game is over.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>Finally, we
 declare variables to hold the row, the column, the number of moves that
-have been made so far and the current shape (<code>'X'</code> or <code>'O'</code>).</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">while</span><span class="o">(</span> <span class="o">!</span><span class="n">gameOver</span> <span class="o">)</span> <span class="o">{</span>
-            <span class="n">shape</span> <span class="o">=</span> <span class="n">turn</span> <span class="o">?</span> <span class="sc">'X'</span> <span class="o">:</span> <span class="sc">'O'</span><span class="o">;</span>
-            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="n">shape</span> <span class="o">+</span> <span class="s">"'s turn.  Enter row (0-2): "</span><span class="o">);</span>
-            <span class="n">row</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Enter column (0-2): "</span><span class="o">);</span>
-            <span class="n">column</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
-            <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">!=</span> <span class="sc">' '</span> <span class="o">)</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Illegal move"</span><span class="o">);</span>
-            <span class="k">else</span> <span class="o">{</span>
-                <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="n">shape</span><span class="o">;</span>
-                <span class="n">moves</span><span class="o">++;</span>
-                <span class="n">turn</span> <span class="o">=</span> <span class="o">!</span><span class="n">turn</span><span class="o">;</span>
-                <span class="c1">//print board</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span>
-                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">2</span><span class="o">]);</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"-----"</span><span class="o">);</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span>
-                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">2</span><span class="o">]);</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"-----"</span><span class="o">);</span>
-                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span>
-                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">+</span> <span class="s">"\n"</span><span class="o">);</span></code></pre>
-</div>
+have been made so far and the current shape (<code>'X'</code> or <code>'O'</code>).</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>The core of the game is a <code>while</code> loop that runs until <code>gameOver</code>
@@ -16987,40 +17283,88 @@ It&#8217;s perfect for situations like this where one value is needed when
 <code>turn</code> is <code>true</code> and another is needed when <code>turn</code> is <code>false</code>. The
 ternary operator is a useful trick, but it shouldn&#8217;t be overused.</p>
 </div>
-<div class="paragraph">
-<p>After assigning the appropriate value to <code>shape</code>, our code reads in the
-row and column values for the current player&#8217;s next move. If the row and
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">while</span><span class="o">(!</span><span class="n">gameOver</span><span class="o">)</span>
+            <span class="n">shape</span> <span class="o">=</span> <span class="n">turn</span> <span class="o">?</span> <span class="sc">'X'</span> <span class="o">:</span> <span class="sc">'O'</span><span class="o">;</span>
+            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="n">shape</span> <span class="o">+</span> <span class="s">"'s turn.  Enter row (0-2): "</span><span class="o">);</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="n">row</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
+            <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"Enter column (0-2): "</span><span class="o">);</span>
+            <span class="n">column</span> <span class="o">=</span> <span class="n">in</span><span class="o">.</span><span class="na">nextInt</span><span class="o">();</span>
+            <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">!=</span> <span class="sc">' '</span><span class="o">)</span>   <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Illegal move"</span><span class="o">);</span>
+            <span class="k">else</span> <span class="o">{</span>
+                <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="n">shape</span><span class="o">;</span> <i class="conum" data-value="3"></i><b>(3)</b>
+                <span class="n">moves</span><span class="o">++;</span>
+                <span class="n">turn</span> <span class="o">=</span> <span class="o">!</span><span class="n">turn</span><span class="o">;</span>
+                <span class="c1">//print board </span><i class="conum" data-value="4"></i><b>(4)</b>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span>
+                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">2</span><span class="o">]);</span>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"-----"</span><span class="o">);</span>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span>
+                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">2</span><span class="o">]);</span>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"-----"</span><span class="o">);</span>
+                <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span>
+                         <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">+</span> <span class="s">"|"</span> <span class="o">+</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">+</span> <span class="s">"\n"</span><span class="o">);</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>After assigning the appropriate value to <code>shape</code>, our code reads in the
+row and column values for the current player&#8217;s next move.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>If the row and
 column selected correspond to a spot that&#8217;s already been taken, the
-program gives an error message. Otherwise, the program sets
+program gives an error message.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Otherwise, the program sets
 <code>board[row][column]</code> to the appropriate symbol, increments <code>moves</code>, and
-changes the value of <code>turn</code>. Then, it prints out the board. We point out
-that our program does not do any bounds checking on <code>row</code> and <code>column</code>.
+changes the value of <code>turn</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Then, it prints out the board.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Our program doesn&#8217;t do any bounds checking on <code>row</code> and <code>column</code>.
 If a user tries to place a move at row 5 column 3, our program will try
-to do so and crash. Four additional clauses in the <code>if</code> statement could
+to do so and crash. Additional clauses in the <code>if</code> statement could
 be used to add bounds checking.</p>
+</div>
+<div class="paragraph">
+<p>Perhaps the trickiest part of our tic-tac-toe program is checking for a
+win.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">                <span class="c1">//check rows</span>
-                <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+<pre class="rouge highlight"><code data-lang="java">                <span class="c1">//check rows      </span><i class="conum" data-value="1"></i><b>(1)</b>
+                <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">.</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span>
                     <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
                         <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">)</span>
                         <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-                <span class="c1">//check columns</span>
-                <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">].</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+                <span class="c1">//check columns   </span><i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">].</span><span class="na">length</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span>
                     <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="n">i</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="n">i</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
-                        <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="n">i</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">)</span>
+                        <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="n">i</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span><span class="o">)</span>
                         <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-                <span class="c1">//check diagonals</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
-                    <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">)</span>
+                <span class="c1">//check diagonals </span><i class="conum" data-value="3"></i><b>(3)</b>
+                <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
+                    <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span><span class="o">)</span>
                     <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
-                    <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">)</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="mi">0</span><span class="o">][</span><span class="mi">2</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">1</span><span class="o">][</span><span class="mi">1</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span>
+                    <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="mi">2</span><span class="o">][</span><span class="mi">0</span><span class="o">]</span> <span class="o">==</span> <span class="n">shape</span><span class="o">)</span>
                     <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
-                <span class="k">if</span><span class="o">(</span> <span class="n">gameOver</span> <span class="o">)</span>
+                <span class="k">if</span><span class="o">(</span><span class="n">gameOver</span><span class="o">)</span>         <i class="conum" data-value="4"></i><b>(4)</b>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="n">shape</span> <span class="o">+</span> <span class="s">" wins!"</span><span class="o">);</span>
-                <span class="k">else</span> <span class="nf">if</span><span class="o">(</span> <span class="n">moves</span> <span class="o">==</span> <span class="mi">9</span> <span class="o">){</span>
+                <span class="k">else</span> <span class="nf">if</span><span class="o">(</span><span class="n">moves</span> <span class="o">==</span> <span class="mi">9</span><span class="o">){</span> <i class="conum" data-value="5"></i><b>(5)</b>
                     <span class="n">gameOver</span> <span class="o">=</span> <span class="kc">true</span><span class="o">;</span>
                     <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">"Tie game!"</span><span class="o">);</span>
                 <span class="o">}</span>
@@ -17030,16 +17374,38 @@ be used to add bounds checking.</p>
 <span class="o">}</span></code></pre>
 </div>
 </div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>First we check each row to see if it contains three in a row.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Then, we check each column.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Finally, we check the two diagonals.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>If any of
+those checks ended the game, we announce a winner.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>Otherwise, if the
+number of moves has reached 9 with no winner, it must be a tie game.</td>
+</tr>
+</table>
+</div>
 <div class="paragraph">
-<p>Perhaps the trickiest part of our tic-tac-toe program is checking for a
-win. First we check each row to see if it contains three in a row. Then,
-we check each column. Finally, we check the two diagonals. If any of
-those checks ended the game, we announce a winner. Otherwise, if the
-number of moves has reached 9 with no winner, it must be a tie game. In
+<p>In
 a larger game (such as Connect Four), we would want to find better ways
 to automate checking rows, columns, and diagonals. For example, we wouldn&#8217;t
 want to check the entirety of a larger board each move.
-Instead, we could focus only on rows, columns, and diagonals
+Instead, we could focus only on the rows, columns, and diagonals
 affected by the last move.</p>
 </div>
 </div>
@@ -17242,54 +17608,78 @@ columns, although it would be easy to change those dimensions.</p>
 <div class="content">
 <pre class="rouge highlight"><code data-lang="java"><span class="kd">public</span> <span class="kd">class</span> <span class="nc">Life</span> <span class="o">{</span>
     <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="o">{</span>
-        <span class="kd">final</span> <span class="kt">int</span> <span class="n">ROWS</span> <span class="o">=</span> <span class="mi">24</span><span class="o">;</span>
+        <span class="kd">final</span> <span class="kt">int</span> <span class="n">ROWS</span> <span class="o">=</span> <span class="mi">24</span><span class="o">;</span>        <i class="conum" data-value="1"></i><b>(1)</b>
         <span class="kd">final</span> <span class="kt">int</span> <span class="n">COLUMNS</span> <span class="o">=</span> <span class="mi">80</span><span class="o">;</span>
         <span class="kd">final</span> <span class="kt">int</span> <span class="n">GENERATIONS</span> <span class="o">=</span> <span class="mi">500</span><span class="o">;</span>
-        <span class="kt">boolean</span><span class="o">[][]</span> <span class="n">board</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">boolean</span><span class="o">[</span><span class="n">ROWS</span><span class="o">][</span><span class="n">COLUMNS</span><span class="o">];</span>
+        <span class="kt">boolean</span><span class="o">[][]</span> <span class="n">board</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">boolean</span><span class="o">[</span><span class="n">ROWS</span><span class="o">][</span><span class="n">COLUMNS</span><span class="o">];</span> <i class="conum" data-value="2"></i><b>(2)</b>
         <span class="kt">boolean</span><span class="o">[][]</span> <span class="n">temp</span> <span class="o">=</span> <span class="k">new</span> <span class="kt">boolean</span><span class="o">[</span><span class="n">ROWS</span><span class="o">][</span><span class="n">COLUMNS</span><span class="o">];</span>
         <span class="kt">boolean</span><span class="o">[][]</span> <span class="n">swap</span><span class="o">;</span>
-        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++</span> <span class="o">)</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++</span> <span class="o">)</span>
+        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++)</span> <i class="conum" data-value="3"></i><b>(3)</b>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++)</span>
                 <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">Math</span><span class="o">.</span><span class="na">random</span><span class="o">()</span> <span class="o">&lt;</span> <span class="mf">0.1</span><span class="o">);</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The <code>main()</code> method of our program starts by defining <code>ROWS</code>, <code>COLUMNS</code>,
-and <code>GENERATIONS</code> as named constants using the <code>final</code> keyword. Next, we
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The <code>main()</code> method of our program starts by defining <code>ROWS</code>, <code>COLUMNS</code>,
+and <code>GENERATIONS</code> as named constants using the <code>final</code> keyword.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Next, we
 create <strong>two</strong> arrays with <code>ROWS</code> rows and <code>COLUMNS</code> columns. The <code>board</code>
 array will hold the current generation. The <code>temp</code> array will be used to
 fill in the next generation. Then, <code>temp</code> will be copied into <code>board</code>,
 and the process will repeat. The <code>swap</code> variable is just a reference we&#8217;ll
-use to swap <code>board</code> and <code>temp</code>. We randomly fill the board, making
+use to swap <code>board</code> and <code>temp</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>We randomly fill the board, making
 10% of the cells living. Again, you may wish to play with this number to
-see how the patterns in the simulation are affected.</p>
+see how the patterns in the simulation are affected.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">generation</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">generation</span> <span class="o">&lt;</span> <span class="n">GENERATIONS</span><span class="o">;</span> <span class="n">generation</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++</span> <span class="o">)</span>
-                <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
+<pre class="rouge highlight"><code data-lang="java">        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">generation</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">generation</span> <span class="o">&lt;</span> <span class="n">GENERATIONS</span><span class="o">;</span> <span class="n">generation</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++</span> <span class="o">)</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++)</span> <span class="o">{</span>
                     <span class="kt">int</span> <span class="n">total</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
-                    <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="n">Math</span><span class="o">.</span><span class="na">max</span><span class="o">(</span><span class="n">row</span> <span class="o">-</span> <span class="mi">1</span><span class="o">,</span> <span class="mi">0</span><span class="o">);</span>
-						<span class="n">i</span> <span class="o">&lt;</span> <span class="n">Math</span><span class="o">.</span><span class="na">min</span><span class="o">(</span><span class="n">row</span> <span class="o">+</span> <span class="mi">2</span><span class="o">,</span> <span class="n">ROWS</span><span class="o">);</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
-                        <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">Math</span><span class="o">.</span><span class="na">max</span><span class="o">(</span><span class="n">column</span> <span class="o">-</span> <span class="mi">1</span><span class="o">,</span> <span class="mi">0</span><span class="o">);</span>
-							<span class="n">j</span> <span class="o">&lt;</span> <span class="n">Math</span><span class="o">.</span><span class="na">min</span><span class="o">(</span><span class="n">column</span> <span class="o">+</span> <span class="mi">2</span><span class="o">,</span> <span class="n">COLUMNS</span><span class="o">);</span> <span class="n">j</span><span class="o">++</span> <span class="o">)</span>
+                    <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="n">Math</span><span class="o">.</span><span class="na">max</span><span class="o">(</span><span class="n">row</span> <span class="o">-</span> <span class="mi">1</span><span class="o">,</span> <span class="mi">0</span><span class="o">);</span> <i class="conum" data-value="3"></i><b>(3)</b>
+						<span class="n">i</span> <span class="o">&lt;</span> <span class="n">Math</span><span class="o">.</span><span class="na">min</span><span class="o">(</span><span class="n">row</span> <span class="o">+</span> <span class="mi">2</span><span class="o">,</span> <span class="n">ROWS</span><span class="o">);</span> <span class="n">i</span><span class="o">++)</span>
+                        <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">j</span> <span class="o">=</span> <span class="n">Math</span><span class="o">.</span><span class="na">max</span><span class="o">(</span><span class="n">column</span> <span class="o">-</span> <span class="mi">1</span><span class="o">,</span> <span class="mi">0</span><span class="o">);</span>
+							<span class="n">j</span> <span class="o">&lt;</span> <span class="n">Math</span><span class="o">.</span><span class="na">min</span><span class="o">(</span><span class="n">column</span> <span class="o">+</span> <span class="mi">2</span><span class="o">,</span> <span class="n">COLUMNS</span><span class="o">);</span> <span class="n">j</span><span class="o">++)</span>
                             <span class="k">if</span><span class="o">((</span><span class="n">i</span> <span class="o">!=</span> <span class="n">row</span> <span class="o">||</span> <span class="n">j</span> <span class="o">!=</span> <span class="n">column</span> <span class="o">)</span> <span class="o">&amp;&amp;</span> <span class="n">board</span><span class="o">[</span><span class="n">i</span><span class="o">][</span><span class="n">j</span><span class="o">]</span> <span class="o">)</span>
                                 <span class="n">total</span><span class="o">++;</span>
-                    <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">)</span>
-                        <span class="n">temp</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">total</span> <span class="o">==</span> <span class="mi">2</span> <span class="o">||</span> <span class="n">total</span> <span class="o">==</span> <span class="mi">3</span><span class="o">);</span>
+                    <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">])</span>
+                        <span class="n">temp</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">total</span> <span class="o">==</span> <span class="mi">2</span> <span class="o">||</span> <span class="n">total</span> <span class="o">==</span> <span class="mi">3</span><span class="o">);</span> <i class="conum" data-value="4"></i><b>(4)</b>
                     <span class="k">else</span>
-                        <span class="n">temp</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">total</span> <span class="o">==</span> <span class="mi">3</span><span class="o">);</span>
+                        <span class="n">temp</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">=</span> <span class="o">(</span><span class="n">total</span> <span class="o">==</span> <span class="mi">3</span><span class="o">);</span> <i class="conum" data-value="5"></i><b>(5)</b>
                 <span class="o">}</span>
-            <span class="n">swap</span> <span class="o">=</span> <span class="n">board</span><span class="o">;</span>
+            <span class="n">swap</span> <span class="o">=</span> <span class="n">board</span><span class="o">;</span> <i class="conum" data-value="6"></i><b>(6)</b>
             <span class="n">board</span> <span class="o">=</span> <span class="n">temp</span><span class="o">;</span>
             <span class="n">temp</span> <span class="o">=</span> <span class="n">swap</span><span class="o">;</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The <code>for</code> loop at the beginning of this segment of code runs once for
-each generation we simulate. The two nested <code>for</code> loops examine each
-cell in <code>board</code>. The two <code>for</code> loops nested inside of those loops do the
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The <code>for</code> loop at the beginning of this segment of code runs once for
+each generation we simulate.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The two nested <code>for</code> loops examine each
+cell in <code>board</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>The two <code>for</code> loops nested inside of those loops do the
 calculations to determine if a cell will be alive or dead in the next
 generation. These inner loops start one row before the current row and
 finish one row after the current row. They do the same for columns. The
@@ -17298,47 +17688,71 @@ going out of bounds of the array. When backing up a row or a column, the
 <code>Math.max()</code> methods make sure that we do not generate an index smaller
 than 0. When going forward a row or a column, the <code>Math.min()</code> methods
 make sure that we do not generate an index greater than <code>ROWS - 1</code> or
-<code>COLUMNS - 1</code>.</p>
-</div>
-<div class="paragraph">
-<p>After these two innermost <code>for</code> loops have counted the total of living
+<code>COLUMNS - 1</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>After these two innermost <code>for</code> loops have counted the total of living
 cells around the cell in question, we decide the fate of the cell for
 the next generation. If the cell&#8217;s alive and has exactly 2 or 3 living
-neighbors, it&#8217;ll continue to live. If a cell&#8217;s dead, it&#8217;ll
-come to life only if it has exactly 3 living neighbors. After we&#8217;ve
+neighbors, it&#8217;ll continue to live.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>If a cell&#8217;s dead, it&#8217;ll
+come to life only if it has exactly 3 living neighbors.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="6"></i><b>6</b></td>
+<td>After we&#8217;ve
 stored the state of each cell in the next generation into <code>temp</code>, we
 swap <code>board</code> and <code>temp</code>, using the <code>swap</code> variable. We could have thrown
 out the old array stored in <code>board</code> instead of swapping it with <code>temp</code>,
 but then we&#8217;d have to create a new array for <code>temp</code> each time, which
-is less efficient.</p>
+is less efficient.</td>
+</tr>
+</table>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="java">            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="mi">100</span><span class="o">;</span> <span class="n">i</span><span class="o">++</span> <span class="o">)</span>
+<pre class="rouge highlight"><code data-lang="java">            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">i</span> <span class="o">&lt;</span> <span class="mi">100</span><span class="o">;</span> <span class="n">i</span><span class="o">++)</span> <i class="conum" data-value="1"></i><b>(1)</b>
                 <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">();</span>
-            <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++</span> <span class="o">)</span> <span class="o">{</span>
-                <span class="k">for</span><span class="o">(</span> <span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++</span> <span class="o">)</span>
-                    <span class="k">if</span><span class="o">(</span> <span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">]</span> <span class="o">)</span>
+            <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">row</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">row</span> <span class="o">&lt;</span> <span class="n">ROWS</span><span class="o">;</span> <span class="n">row</span><span class="o">++)</span> <span class="o">{</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="k">for</span><span class="o">(</span><span class="kt">int</span> <span class="n">column</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span> <span class="n">column</span> <span class="o">&lt;</span> <span class="n">COLUMNS</span><span class="o">;</span> <span class="n">column</span><span class="o">++)</span>
+                    <span class="k">if</span><span class="o">(</span><span class="n">board</span><span class="o">[</span><span class="n">row</span><span class="o">][</span><span class="n">column</span><span class="o">])</span>
                         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">"*"</span><span class="o">);</span>
                     <span class="k">else</span>
                         <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">" "</span><span class="o">);</span>
                 <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">();</span>
             <span class="o">}</span>
-            <span class="k">try</span> <span class="o">{</span> <span class="n">Thread</span><span class="o">.</span><span class="na">sleep</span><span class="o">(</span><span class="mi">500</span><span class="o">);</span> <span class="o">}</span>
+            <span class="k">try</span> <span class="o">{</span> <span class="n">Thread</span><span class="o">.</span><span class="na">sleep</span><span class="o">(</span><span class="mi">500</span><span class="o">);</span> <span class="o">}</span> <i class="conum" data-value="3"></i><b>(3)</b>
             <span class="k">catch</span><span class="o">(</span> <span class="n">InterruptedException</span> <span class="n">e</span> <span class="o">)</span> <span class="o">{}</span>
         <span class="o">}</span>
     <span class="o">}</span>
 <span class="o">}</span></code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p>The first <code>for</code> loop in this segment prints 100 blank lines to clear the
-screen, as we explained earlier. The two nested <code>for</code> loops print out
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>The first <code>for</code> loop in this segment prints 100 blank lines to clear the
+screen, as we explained earlier.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The two nested <code>for</code> loops print out
 the state of the current generation, with a <code>*</code> for each living cell and
-a blank space for each dead one. After the output, the code sleeps for
+a blank space for each dead one.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>After the output, the code sleeps for
 500 milliseconds to give the effect of an animation. We&#8217;ll discuss
 exceptions in general in <a href="#ch12-exceptions">Chapter 12</a> and give more
-information about the <code>Thread.sleep()</code> method in <a href="#ch13-concurrency">Chapter 13</a>.</p>
+information about the <code>Thread.sleep()</code> method in <a href="#ch13-concurrency">Chapter 13</a>.</td>
+</tr>
+</table>
 </div>
 <div class="paragraph">
 <p>Although 500 milliseconds
@@ -17740,18 +18154,18 @@ truth within the soul.</p>
 <p>Recall from <a href="#ch05-repetition">Chapter 5</a> that we can record DNA as a
 sequence of nucleotide bases A, C, G, and T. Using this idea, we can
 represent any sequence of DNA using a <code>String</code> made up of those four
-letters, such as <code>"ATGGAAGTATTTAAATAG"</code>.</p>
+letters such as <code>"ATGGAAGTATTTAAATAG"</code>.</p>
 </div>
 <div class="paragraph">
 <p>This particular sequence contains 18 bases and six <em>codons</em>. A codon is
 a three-base subsequence in DNA. Biologists are interested in dividing
 DNA into codons because a single codon usually maps to the production of
 a specific amino acid. Amino acids, in turn, are the building blocks of
-proteinS. The DNA sequence above contains the six codons ATG, GAA, GTA,
+proteins. The DNA sequence above contains the six codons ATG, GAA, GTA,
 TTT, AAA, and TAG.</p>
 </div>
 <div class="paragraph">
-<p>We want to write a program that extracts codons in order from DNA
+<p>We want to write a program that extracts codons from DNA
 sequences entered by the user. The program must detect and inform the
 user of invalid DNA sequences (those containing letters other than the
 four bases). If the user enters a DNA sequence whose length is not a


### PR DESCRIPTION
Until recently, it was very difficult to add callouts to a program that was included in several segments.

Numbering the callouts inside the program sequentially doesn't work.  If a program has callouts <1> and <2> in its first segment and <3> and <4> in the second, Asciidoctor complains when the <3> and <4> are listed to describe the second section, since each block of callout numbers are supposed to start at <1>.

The solution adopted by this commit is to use callout autonumbering (using <.> for all callouts).  The benefits of callout autonumbering are that they don't require the author to keep track of specific numbers and each segment of code automatically starts at <1>.  This solution works even if included code segments overlap.

In my opinion, however, it would be nice if callout numbering could start at particular points, to show progression through a program.  After a comment thread with Dan Allen, I intend to make an issue request for this feature in Asciidoctor.