### PR TITLE
Fixed three broken image links in Chapter 7

### DIFF
--- a/chunked/chap1.html
+++ b/chunked/chap1.html
@@ -3032,7 +3032,7 @@ error handling be different from an audience of architects?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap10.html
+++ b/chunked/chap10.html
@@ -2330,7 +2330,7 @@ processes. Is there a significant difference in the times you found?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap11.html
+++ b/chunked/chap11.html
@@ -2085,7 +2085,7 @@ implications for code that routinely throws thousands of exceptions?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap12.html
+++ b/chunked/chap12.html
@@ -3034,7 +3034,7 @@ wait and which threads terminate.</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap13.html
+++ b/chunked/chap13.html
@@ -2414,7 +2414,7 @@ you set the priorities of these new threads to <code>MAX_PRIORITY</code> or
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap14.html
+++ b/chunked/chap14.html
@@ -3849,7 +3849,7 @@ but not others, why do you think that might be?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap15.html
+++ b/chunked/chap15.html
@@ -3450,7 +3450,7 @@ execute contentious code in parallel.</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap16.html
+++ b/chunked/chap16.html
@@ -2126,7 +2126,7 @@ the implementation of locks and CAS on your OS and hardware platform.</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap17.html
+++ b/chunked/chap17.html
@@ -3582,7 +3582,7 @@ How much slower are the adds to the <code>Vector&lt;Integer&gt;</code> container
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap18.html
+++ b/chunked/chap18.html
@@ -2927,7 +2927,7 @@ time each process. Was the iterative or recursive approach faster? By how much?<
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap19.html
+++ b/chunked/chap19.html
@@ -2568,7 +2568,7 @@ already stored in an array.</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap2.html
+++ b/chunked/chap2.html
@@ -4716,7 +4716,7 @@ display properly.</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap20.html
+++ b/chunked/chap20.html
@@ -1874,7 +1874,7 @@ multi-threaded versions?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap3.html
+++ b/chunked/chap3.html
@@ -3308,7 +3308,7 @@ input and output.</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap4.html
+++ b/chunked/chap4.html
@@ -2659,7 +2659,7 @@ pieces run significantly faster or slower than the others?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap5.html
+++ b/chunked/chap5.html
@@ -4082,7 +4082,7 @@ mirror the increase in running time?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap6.html
+++ b/chunked/chap6.html
@@ -740,7 +740,7 @@ that looks similar to the following.</p>
 </div>
 <div id="codonInput" class="imageblock text-center">
 <div class="content">
-<img src="chapters/07-gui-basics/images/codonInput.png" alt="codonInput" width="50%">
+<img src="chapters/07-gui-basics/images/codoninput.png" alt="codoninput" width="50%">
 </div>
 </div>
 <div class="paragraph">
@@ -748,7 +748,7 @@ that looks similar to the following.</p>
 </div>
 <div id="codonOutput" class="imageblock text-center">
 <div class="content">
-<img src="chapters/07-gui-basics/images/codonOutput.png" alt="codonOutput" width="50%">
+<img src="chapters/07-gui-basics/images/codonoutput.png" alt="codonoutput" width="50%">
 </div>
 </div>
 </div>
@@ -1026,7 +1026,7 @@ icons displayed toward the top left of the two dialogs.</p>
 </div>
 <div id="iconsInMessageDialogsFigure" class="imageblock text-center">
 <div class="content">
-<img src="chapters/07-gui-basics/images/iconsInMessageDialogsFigure.png" alt="iconsInMessageDialogsFigure" width="100%">
+<img src="chapters/07-gui-basics/images/iconsinMessageDialogsFigure.png" alt="iconsinMessageDialogsFigure" width="100%">
 </div>
 <div class="title">Figure 7.3 The left dialog uses <code>JOptionPane.ERROR_MESSAGE</code>, and the right uses <code>JOptionPane.WARNING_MESSAGE</code>. The only difference is the icon displayed.</div>
 </div>
@@ -1750,7 +1750,7 @@ There is, of course, no guarantee that an answer is correct just because it’s 
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap7.html
+++ b/chunked/chap7.html
@@ -2415,7 +2415,7 @@ method.</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap8.html
+++ b/chunked/chap8.html
@@ -2391,7 +2391,7 @@ it takes to call a constructor and allocate a new object?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/chap9.html
+++ b/chunked/chap9.html
@@ -1976,7 +1976,7 @@ performance increase? Was it as much as you expected?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/chunked/index.html
+++ b/chunked/index.html
@@ -3871,7 +3871,7 @@ use?</p>
 </div></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/full/ch07-gui-basics.adoc
+++ b/full/ch07-gui-basics.adoc
@@ -38,14 +38,14 @@ that looks similar to the following.
 
 [[codonInput]]
 [.text-center]
-image::codonInput.png[scaledwidth=50%,pdfwidth=50%,width=50%]
+image::codoninput.png[scaledwidth=50%,pdfwidth=50%,width=50%]
 
 
 And the corresponding output should look very much like this.
 
 [[codonOutput]]
 [.text-center]
-image::codonOutput.png[scaledwidth=50%,pdfwidth=50%,width=50%]
+image::codonoutput.png[scaledwidth=50%,pdfwidth=50%,width=50%]
 
 [[GUIBasicsIntroductionSection]]
 === Concepts: User interaction
@@ -249,7 +249,7 @@ icons displayed toward the top left of the two dialogs.
 [[iconsInMessageDialogsFigure]]
 [.text-center]
 .The left dialog uses `JOptionPane.ERROR_MESSAGE`, and the right uses `JOptionPane.WARNING_MESSAGE`. The only difference is the icon displayed.
-image::iconsInMessageDialogsFigure.png[width=100%,pdfwidth=100%,scaledwidth=100%]
+image::iconsinMessageDialogsFigure.png[width=100%,pdfwidth=100%,scaledwidth=100%]
 
 ****
 <<dialogMessageTypesExercise>>

--- a/full/index.html
+++ b/full/index.html
@@ -18239,7 +18239,7 @@ that looks similar to the following.</p>
 </div>
 <div id="codonInput" class="imageblock text-center">
 <div class="content">
-<img src="chapters/07-gui-basics/images/codonInput.png" alt="codonInput" width="50%">
+<img src="chapters/07-gui-basics/images/codoninput.png" alt="codoninput" width="50%">
 </div>
 </div>
 <div class="paragraph">
@@ -18247,7 +18247,7 @@ that looks similar to the following.</p>
 </div>
 <div id="codonOutput" class="imageblock text-center">
 <div class="content">
-<img src="chapters/07-gui-basics/images/codonOutput.png" alt="codonOutput" width="50%">
+<img src="chapters/07-gui-basics/images/codonoutput.png" alt="codonoutput" width="50%">
 </div>
 </div>
 </div>
@@ -18525,7 +18525,7 @@ icons displayed toward the top left of the two dialogs.</p>
 </div>
 <div id="iconsInMessageDialogsFigure" class="imageblock text-center">
 <div class="content">
-<img src="chapters/07-gui-basics/images/iconsInMessageDialogsFigure.png" alt="iconsInMessageDialogsFigure" width="100%">
+<img src="chapters/07-gui-basics/images/iconsinMessageDialogsFigure.png" alt="iconsinMessageDialogsFigure" width="100%">
 </div>
 <div class="title">Figure 7.3 The left dialog uses <code>JOptionPane.ERROR_MESSAGE</code>, and the right uses <code>JOptionPane.WARNING_MESSAGE</code>. The only difference is the icon displayed.</div>
 </div>
@@ -46541,7 +46541,7 @@ multi-threaded versions?</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-09 04:16:39 UTC
+Last updated 2019-08-15 14:36:07 UTC
 </div>
 </div>
 <style>

--- a/index.html
+++ b/index.html
@@ -766,7 +766,7 @@ eventually move onto Chapter 15 for more depth in GUIs and Swing. Instructors wh
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-06-03 15:36:48 UTC
+Last updated 2019-07-17 17:13:33 UTC
 </div>
 </div>
 <script type="text/x-mathjax-config">


### PR DESCRIPTION
The case of the image names in the source didn't match the case of the file names.  The problem wasn't spotted in Windows, where file names are case-insensitive.